### PR TITLE
Fix bug to set _rev in Document.save()

### DIFF
--- a/src/cloudant/document.py
+++ b/src/cloudant/document.py
@@ -117,6 +117,8 @@ class Document(dict):
             headers=headers
         )
         put_resp.raise_for_status()
+        data = put_resp.json()
+        super(Document, self).__setitem__('_rev', data['rev'])
         return
 
     # Update Actions

--- a/tests/unit/cloudant_t/document_test.py
+++ b/tests/unit/cloudant_t/document_test.py
@@ -85,12 +85,16 @@ class DocumentTest(unittest.TestCase):
         mock_put_resp = mock.Mock()
         mock_put_resp.status_code = 200
         mock_put_resp.raise_for_status = mock.Mock()
+        mock_put_resp.json = mock.Mock()
+        mock_put_resp.json.return_value = {'id': 'DUCKUMENT', 'rev': 'DUCK3'}
         self.mock_session.put.return_value = mock_put_resp
         mock_get_resp = mock.Mock()
         mock_get_resp.status_code = 200
         self.mock_session.get.return_value = mock_get_resp
 
         doc.save()
+        self.assertEqual(doc['_rev'], 'DUCK3')
+        self.assertEqual(doc['_id'], 'DUCKUMENT')
         self.failUnless(self.mock_session.get.called)
         self.failUnless(self.mock_session.put.called)
 
@@ -118,7 +122,7 @@ class DocumentTest(unittest.TestCase):
         self.mock_session.delete.assert_has_calls(
             [ mock.call(
                   'https://bob.cloudant.com/unittest/DUCKUMENT',
-                  params={'rev': 'DUCK2'}
+                  params={'rev': 'DUCK3'}
             ) ]
         )
         self.mock_session.delete.reset_mock()
@@ -162,6 +166,8 @@ class DocumentTest(unittest.TestCase):
         mock_save_resp = mock.Mock()
         mock_save_resp.status_code = 200
         mock_save_resp.raise_for_status = mock.Mock()
+        mock_save_resp.json = mock.Mock()
+        mock_save_resp.json.return_value = {'id': "ID", "rev": "updated"}
         self.mock_session.put.return_value = mock_save_resp
 
         mock_encode = mock.Mock()
@@ -208,6 +214,7 @@ class DocumentTest(unittest.TestCase):
         mock_put_resp.side_effect = mock.Mock()
         mock_put_resp.status_code = 200
         mock_put_resp.raise_for_status = raise_conflict
+        mock_put_resp.json.side_effect = lambda: {'id': "ID", "rev": "updated"}
         self.mock_session.put.return_value = mock_put_resp
         mock_get_resp = mock.Mock()
         mock_get_resp.status_code = 200


### PR DESCRIPTION
_What:_

Fix bug to set the _rev of a document after successful update of the document to the db.

_Why:_

The local Document object needs to have the _rev updated so that it will be consistent with the _rev of the remote document.

_How:_

The HTTP PUT response contains the updated _rev value.  Set the Document object _rev value to the value from the response before returning from the save() method.

reviewer: @gadamc 

BugId: 52406
