### PR TITLE
Fix database __iter__ method

### DIFF
--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -463,7 +463,7 @@ class CouchDatabase(dict):
                     limit=self._fetch_limit + 1,  # Get one extra doc
                                                   # to use as
                                                   # next_startkey
-                    include_docs="true",
+                    include_docs=True,
                     startkey=json.dumps(next_startkey)
                 ).get('rows', [])
 


### PR DESCRIPTION
_What:_

Currently the **iter** method for CouchDatabase and CloudantDatabase sets the `include_docs` parameter to "true".  It needs to be set to `True`.

_Why:_ 

Because the parameter values get processed as Python arguments and translated to CouchDB syntax so `True` will translate to `"true"` which is what the `_all_docs` end point expects.

_How:_
- Change Line 466 of database.py from `"true"` to 'True`

reviewer: @gadamc

BugId:  53162
