### PR TITLE
Add CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,25 @@
+Developing this library
+=======================
+
+Python-Cloudant Client Library is written in Python.
+
+=============================
+Contributor License Agreement
+=============================
+
+In order for us to accept pull-requests, the contributor must first complete
+a Contributor License Agreement (CLA). This clarifies the intellectual
+property license granted with any contribution. It is for your protection as a
+Contributor as well as the protection of IBM and its customers; it does not
+change your rights to use your own Contributions for any other purpose.
+
+This is a quick process: one option is signing using Preview on a Mac,
+then sending a copy to us via email.
+
+You can download the CLAs here:
+
+- `Individual <http://cloudant.github.io/cloudant-sync-eap/cla/cla-individual.pdf>`_
+- `Corporate <http://cloudant.github.io/cloudant-sync-eap/cla/cla-corporate.pdf>`_
+
+If you are an IBMer, please contact us directly as the contribution process is
+slightly different.


### PR DESCRIPTION
_What:_

Add a CONTRIBUTING.rst file

_Why:_

This file is necessary to provide any developer that wishes to contribute to this repository to have access to the IBM CLA documents so that they are aware of their rights and the rights of IBM as they relate to the code that they will contribute.

_How:_

Add the CONTRIBUTING.rst file which contains links to pdf documents for individual and corporate CLAs.

reviewer: @mikerhodes