### PR TITLE
Fix database iterator and bulk docs method call

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,15 @@
-2.0.0b1 (Unreleased)
+2.0.0a2 (Unreleased)
 ====================
 
 - [NEW] Added unit tests targeting CouchDB and Cloudant databases.
 - [FIX] Fixed bug in database create validation check to work if response code
 is either 201 (created) or 202 (accepted).
+- [FIX] Fixed database iterator infinite loop problem and to now yield a 
+Document object.
+- [BREAKING] Removed previous bulk_docs method from the CouchDatabase class and 
+renamed the previous bulk_insert method as bulk_docs.  The previous bulk_docs
+functionality is available through the all_docs method using the "keys"
+parameter.
 
 
 2.0.0a1 (2015-10-13)

--- a/src/cloudant/result.py
+++ b/src/cloudant/result.py
@@ -34,6 +34,7 @@ ARG_TYPES = {
     "include_docs": bool,
     "inclusive_end": bool,
     "key": (int, basestring, Sequence),
+    "keys": list,
     "limit": (int, types.NoneType),
     "reduce": bool,
     "skip": (int, types.NoneType),

--- a/tests/integration/changes_test.py
+++ b/tests/integration/changes_test.py
@@ -53,7 +53,7 @@ class ChangesTest(unittest.TestCase):
 
     def tearDown(self):
         if self.last_db is not None:
-            with cloudant(self.user, self.password) as c:
+            with cloudant(self.user, self.password, account=self.user) as c:
                 c.delete_database(self.last_db)
 
     def test_changes(self):

--- a/tests/unit/mocked/database_test.py
+++ b/tests/unit/mocked/database_test.py
@@ -176,18 +176,6 @@ class CouchDBTest(unittest.TestCase):
         mock_resp.raise_for_status = mock.Mock(return_value=False)
         self.mock_session.post = mock.Mock(return_value=mock_resp)
 
-        self.c.bulk_docs(['a', 'b', 'c'])
-
-        self.mock_session.post.assert_called_once_with(
-            posixpath.join(self.db_url, '_all_docs'),
-            data=json.dumps({'keys': ['a', 'b', 'c']})
-        )
-
-    def test_bulk_insert(self):
-        mock_resp = mock.Mock()
-        mock_resp.raise_for_status = mock.Mock(return_value=False)
-        self.mock_session.post = mock.Mock(return_value=mock_resp)
-
         docs = [
             {
                 '_id': 'somedoc',
@@ -200,7 +188,7 @@ class CouchDBTest(unittest.TestCase):
             }
         ]
 
-        self.c.bulk_insert(docs)
+        self.c.bulk_docs(docs)
 
         self.mock_session.post.assert_called_once_with(
             posixpath.join(self.db_url, '_bulk_docs'),


### PR DESCRIPTION
_What:_

We need to fix the database object iterator so that it does not drop into an infinite loop when returning a set of documents that is greater than the fetch limit.  The database iterator also needs to return objects wrapped as Documents.  Finally the bulk_docs functionality needs to be clarified.

_Why:_

The iterator issue is a bug and needs to be fixed.  The bulk_docs functionality currently is redundant and confusing.

_How:_

- Fix iterator to not fall into infinite loop when documents being retrieved is greater than the fetch limit on the database object.
- Fix iterator to return a Document or a DesignDocument object.
- Fix iterator to attach a Document or a DesignDocument to the database object.
- Remove the current bulk_docs method from the database.py module.
- Rename the bulk_insert method as bulk_docs
- Make "keys" a valid argument in results.py so that it can be passed to the all_docs method which would replicate the functionality of the soon to be removed bulk_docs method.
- Update comments appropriately.
- Remove now unnecessary mocked test for bulk_docs.
- Fix changes integration test bug.

reviewer: @gadamc 

BugId: 55526