### PR TITLE
Re-Organize database methods and add more database tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,12 @@ Document object.
 renamed the previous bulk_insert method as bulk_docs.  The previous bulk_docs
 functionality is available through the all_docs method using the "keys"
 parameter.
+- [FIX] Made missing_revisions, revisions_diff, get_revision_limit,
+set_revision_limit, and view_cleanup API methods available for CouchDB as well
+as Cloudant.
+- [BREAKING] Moved the db_update method to the account module.
+- [FIX] Fixed missing_revisions to key on 'missing_revs'.
+- [FIX] Fixed set_revision_limit to encode the request data payload correctly.
 
 
 2.0.0a1 (2015-10-13)

--- a/src/cloudant/account.py
+++ b/src/cloudant/account.py
@@ -25,6 +25,7 @@ import requests
 import sys
 
 from .database import CloudantDatabase, CouchDatabase
+from .changes import Feed
 from .errors import CloudantException
 
 _USER_AGENT = 'python-cloudant/{0} (Python, Version {1}.{2}.{3})'.format(
@@ -216,6 +217,28 @@ class CouchDB(dict):
         db.delete()
         if dbname in self.keys():
             super(CouchDB, self).__delitem__(dbname)
+
+    def db_updates(self, since=None, continuous=True):
+        """
+        _db_updates_
+
+        Implement streaming from _db_updates feed. Yields information about
+          databases that have been updated.
+
+        :param str since: Start from this sequence
+        :param boolean continuous: Stream results
+
+        """
+        db_updates_feed = Feed(
+            self.r_session,
+            posixpath.join(self.cloudant_url, '_db_updates'),
+            since=since,
+            continuous=continuous
+        )
+
+        for update in db_updates_feed:
+            if update:
+                yield update
 
     def keys(self, remote=False):
         """

--- a/tests/unit/db/account_tests.py
+++ b/tests/unit/db/account_tests.py
@@ -104,9 +104,7 @@ class AccountTests(UnitTestDbBase):
         """
         Test getting a list of all of the databases in the account
         """
-        dbnames = []
-        for _ in range(3):
-            dbnames.append(self.dbname())
+        dbnames = [self.dbname() for _ in xrange(3)]
         try:
             self.client.connect()
             for dbname in dbnames:

--- a/tests/unit/mocked/account_test.py
+++ b/tests/unit/mocked/account_test.py
@@ -49,6 +49,25 @@ class CouchDBAccountTests(unittest.TestCase):
     def tearDown(self):
         self.patcher.stop()
 
+    def test_db_updates(self):
+        c = CouchDB(self.username, self.password, url=self.url)
+        c.connect()
+        updates_feed = """
+            {"dbname": "somedb3", "type": "created", "account": "bob", "seq": "3-g1AAAABteJzLYWBgYMxgTmFQSElKzi9KdUhJMtHLTc1NzTcwMNdLzskvTUnMK9HLSy3JAapkSmTIY2H4DwRZGcyJzLlAIfa0tKQUQ2NTIkzIAgD_wSJc"}
+            {"dbname": "somedb2", "type": "updated", "account": "bob", "seq": "4-g1AAAABteJzLYWBgYMxgTmFQSElKzi9KdUhJMtHLTc1NzTcwMNdLzskvTUnMK9HLSy3JAapkSmTIY2H4DwRZGcyJLLlAIfa0tKQUQ2NTIkzIAgAAASJd"}
+            {"dbname": "somedb1", "type": "deleted", "account": "bob", "seq": "9-g1AAAABteJzLYWBgYMxgTmFQSElKzi9KdUhJMtHLTc1NzTcwMNdLzskvTUnMK9HLSy3JAapkSmTIY2H4DwRZGcyJnLlAIfa0tKQUQ2NTIkzIAgAA9iJi"}
+            {"dbname": "somedb2", "type": "created", "account": "bob", "seq": "11-g1AAAABteJzLYWBgYMxgTmFQSElKzi9KdUhJMtHLTc1NzTcwMNdLzskvTUnMK9HLSy3JAapkSmTIY2H4DwRZGcyJ3LlAIfa0tKQUQ2NTIkzIAgABWCJk"}
+            {"dbname": "somedb1", "type": "updated", "account": "bob", "seq": "12-g1AAAABteJzLYWBgYMxgTmFQSElKzi9KdUhJMtHLTc1NzTcwMNdLzskvTUnMK9HLSy3JAapkSmTIY2H4DwRZGcyJPLlAIfa0tKQUQ2NTIkzIAgABiSJl"}
+        """
+        with mock.patch('cloudant.account.Feed') as mock_feed:
+            feed = (x.strip() for x in updates_feed.split('\n'))
+            mock_feed.__iter__ = mock.MagicMock()
+            mock_feed.return_value = feed
+
+            updates = [u for u in c.db_updates()]
+
+            self.assertEqual(len(updates), 5)
+
     def test_session_calls(self):
         """test session related methods"""
         c = CouchDB(self.username, self.password, url=self.url)
@@ -225,7 +244,6 @@ class CouchDBAccountTests(unittest.TestCase):
             self.assertTrue(isinstance(c.get('b', remote=True), c._DATABASE_CLASS))
 
         self.assertTrue(c.get('d', None, remote=True) is None)
-
 
 class CloudantAccountTests(unittest.TestCase):
     """

--- a/tests/unit/mocked/database_test.py
+++ b/tests/unit/mocked/database_test.py
@@ -196,24 +196,6 @@ class CouchDBTest(unittest.TestCase):
             headers={'Content-Type': 'application/json'}
         )
 
-    def test_db_updates(self):
-        updates_feed = """
-            {"dbname": "somedb3", "type": "created", "account": "bob", "seq": "3-g1AAAABteJzLYWBgYMxgTmFQSElKzi9KdUhJMtHLTc1NzTcwMNdLzskvTUnMK9HLSy3JAapkSmTIY2H4DwRZGcyJzLlAIfa0tKQUQ2NTIkzIAgD_wSJc"}
-            {"dbname": "somedb2", "type": "updated", "account": "bob", "seq": "4-g1AAAABteJzLYWBgYMxgTmFQSElKzi9KdUhJMtHLTc1NzTcwMNdLzskvTUnMK9HLSy3JAapkSmTIY2H4DwRZGcyJLLlAIfa0tKQUQ2NTIkzIAgAAASJd"}
-            {"dbname": "somedb1", "type": "deleted", "account": "bob", "seq": "9-g1AAAABteJzLYWBgYMxgTmFQSElKzi9KdUhJMtHLTc1NzTcwMNdLzskvTUnMK9HLSy3JAapkSmTIY2H4DwRZGcyJnLlAIfa0tKQUQ2NTIkzIAgAA9iJi"}
-            {"dbname": "somedb2", "type": "created", "account": "bob", "seq": "11-g1AAAABteJzLYWBgYMxgTmFQSElKzi9KdUhJMtHLTc1NzTcwMNdLzskvTUnMK9HLSy3JAapkSmTIY2H4DwRZGcyJ3LlAIfa0tKQUQ2NTIkzIAgABWCJk"}
-            {"dbname": "somedb1", "type": "updated", "account": "bob", "seq": "12-g1AAAABteJzLYWBgYMxgTmFQSElKzi9KdUhJMtHLTc1NzTcwMNdLzskvTUnMK9HLSy3JAapkSmTIY2H4DwRZGcyJPLlAIfa0tKQUQ2NTIkzIAgABiSJl"}
-        """
-        with mock.patch('cloudant.database.Feed') as mock_feed:
-            feed = (x.strip() for x in updates_feed.split('\n'))
-            mock_feed.__iter__ = mock.MagicMock()
-            mock_feed.return_value = feed
-
-            updates = [u for u in self.c.db_updates()]
-
-            self.assertEqual(len(updates), 5)
-
-
 class CloudantDBTest(unittest.TestCase):
     """
     Tests for additional Cloudant database features
@@ -320,7 +302,7 @@ class CloudantDBTest(unittest.TestCase):
     def test_missing_revs(self):
         doc_id = 'somedocument'
         ret_val = {
-            "missed_revs": {doc_id: ['rev1']}
+            "missing_revs": {doc_id: ['rev1']}
         }
         mock_resp = mock.Mock()
         mock_resp.status_code = 201
@@ -342,7 +324,7 @@ class CloudantDBTest(unittest.TestCase):
             headers={'Content-Type': 'application/json'},
             data=json.dumps(expected_data)
         )
-        self.assertEqual(missed_revs, ret_val["missed_revs"][doc_id])
+        self.assertEqual(missed_revs, ret_val["missing_revs"][doc_id])
 
     def test_revs_diff(self):
         doc_id = 'somedocument'
@@ -394,7 +376,7 @@ class CloudantDBTest(unittest.TestCase):
         self.assertTrue(self.mock_session.put.called)
         self.mock_session.put.assert_called_once_with(
             expected_url,
-            data=limit
+            data=json.dumps(limit)
         )
         self.assertEqual(set_limit, '{"ok": true}')
 
@@ -439,7 +421,10 @@ class CloudantDBTest(unittest.TestCase):
         cleanup = self.cl.view_cleanup()
 
         self.assertTrue(self.mock_session.post.called)
-        self.mock_session.post.assert_called_once_with(expected_url)
+        self.mock_session.post.assert_called_once_with(
+            expected_url,
+            headers={'Content-Type': 'application/json'}
+        )
         self.assertEqual(cleanup, '{"ok": true}')
 
 if __name__ == '__main__':


### PR DESCRIPTION
_What:_

- Moved database API methods to appropriate locations.
  - Moved db_update to account module.
  - Moved missing_revisions, revisions_diff, get_revision_limit, set_revision_limit, and view_cleanup methods from CloudantDatabase to CouchDatabase class.
- Added common database tests for the methods mentioned above.
- Added Cloudant specific tests.

_Why:_

- The _db_update endpoint provides account level information.  Its db_update API method belongs in the account module.
- The methods moved to the CouchDatabase class work for both CouchDB and Cloudant instances.  They belong in the CouchDatabase class which the CloudantDatabase class extends.
- Tests needed to be added to thoroughly test all of the database functionality.

_How:_

- Moved database API methods to appropriate locations.
  - Moved db_update to account module.
  - Moved missing_revisions, revisions_diff, get_revision_limit, set_revision_limit, and view_cleanup methods from CloudantDatabase to CouchDatabase class.
- Added common database tests for the methods mentioned above.
- Added Cloudant specific tests.
- Fixed bugs in missing_revisions and set revision_limit.
- General code cleanup.

reviewer: @emlaver

BugId: 55549