### PR TITLE
Add document module unit tests and make Document class fixes

### DIFF
--- a/tests/unit/db/database_tests.py
+++ b/tests/unit/db/database_tests.py
@@ -229,7 +229,7 @@ class DatabaseTests(UnitTestDbBase):
         """
         # Get an empty design document object that does not exist remotely
         local_ddoc = self.db.get_design_document('_design/ddoc01')
-        self.assertEqual(local_ddoc, {'views': {}})
+        self.assertEqual(local_ddoc, {'_id': '_design/ddoc01', 'views': {}})
 
         # Add the design document to the database
         map_func = 'function(doc) {\n emit(doc._id, 1); \n}'

--- a/tests/unit/db/document_tests.py
+++ b/tests/unit/db/document_tests.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python
+# Copyright (c) 2015 IBM. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+_document_tests_
+
+document module - Unit tests for the Document class
+
+See configuration options for environment variables in unit_t_db_base
+module docstring.
+
+"""
+
+import unittest
+import posixpath
+import json
+import requests
+import StringIO
+
+from cloudant.document import Document
+from cloudant.errors import CloudantException
+
+from unit_t_db_base import UnitTestDbBase
+
+class DocumentTests(UnitTestDbBase):
+    """
+    CouchDatabase/CloudantDatabase unit tests
+    """
+
+    def setUp(self):
+        """
+        Set up test attributes
+        """
+        super(DocumentTests, self).setUp()
+        self.db_set_up()
+
+    def tearDown(self):
+        """
+        Reset test attributes
+        """
+        self.db_tear_down()
+        super(DocumentTests, self).tearDown()
+
+    def test_constructor_with_docid(self):
+        """
+        Test instantiating a Document providing an id
+        """
+        doc = Document(self.db, 'julia006')
+        self.assertIsInstance(doc, Document)
+        self.assertEqual(doc.r_session, self.db.r_session)
+        self.assertEqual(doc.get('_id'), 'julia006')
+        self.assertEqual(
+            doc.document_url, posixpath.join(self.db.database_url, 'julia006')
+        )
+
+    def test_constructor_without_docid(self):
+        """
+        Test instantiating a Document without providing an id
+        """
+        doc = Document(self.db)
+        self.assertIsInstance(doc, Document)
+        self.assertEqual(doc.r_session, self.db.r_session)
+        self.assertIsNone(doc.get('_id'))
+        self.assertIsNone(doc.document_url)
+
+    def test_document_exists(self):
+        """
+        Test whether a document exists remotely
+        """
+        doc = Document(self.db)
+        self.assertFalse(doc.exists())
+        doc['_id'] = 'julia006'
+        self.assertFalse(doc.exists())
+        doc.create()
+        self.assertTrue(doc.exists())
+
+    def test_retrieve_document_json(self):
+        """
+        Test the document dictionary renders as json appropriately
+        """
+        doc = Document(self.db)
+        doc['_id'] = 'julia006'
+        doc['name'] = 'julia'
+        doc['age'] = 6
+        doc_as_json = doc.json()
+        self.assertIsInstance(doc_as_json, str)
+        self.assertEqual(json.loads(doc_as_json), doc)
+
+    def test_create_document_with_docid(self):
+        """
+        Test creating a document providing an id
+        """
+        doc = Document(self.db, 'julia006')
+        doc['name'] = 'julia'
+        doc['age'] = 6
+        self.assertFalse(doc.exists())
+        self.assertIsNone(doc.get('_rev'))
+        doc.create()
+        self.assertTrue(doc.exists())
+        self.assertTrue(doc.get('_rev').startswith('1-'))
+
+    def test_create_document_without_docid(self):
+        """
+        Test creating a document remotely without providing an id
+        """
+        doc = Document(self.db)
+        doc['name'] = 'julia'
+        doc['age'] = 6
+        self.assertFalse(doc.exists())
+        self.assertIsNone(doc.get('_id'))
+        self.assertIsNone(doc.get('_rev'))
+        doc.create()
+        self.assertTrue(doc.exists())
+        self.assertIsNotNone(doc.get('_id'))
+        self.assertTrue(doc.get('_rev').startswith('1-'))
+
+    def test_create_existing_document(self):
+        """
+        Test creating an already existing document
+        """
+        doc = Document(self.db, 'julia006')
+        doc.create()
+        try:
+            doc.create()
+            self.fail('Above statement should raise an Exception')
+        except requests.HTTPError, err:
+            self.assertEqual(err.response.status_code, 409)
+
+    def test_fetch_document_without_docid(self):
+        """
+        Test fetching document content with no id provided
+        """
+        doc = Document(self.db)
+        try:
+            doc.fetch()
+            self.fail('Above statement should raise an Exception')
+        except CloudantException, err:
+            self.assertEqual(
+                str(err),
+                'A document id is required to fetch document contents.  '
+                'Add an _id key and value to the document and re-try.'
+            )
+
+    def test_fetch_non_existing_document(self):
+        """
+        Test fetching document content from a non-existing document
+        """
+        doc = Document(self.db, 'julia006')
+        try:
+            doc.fetch()
+            self.fail('Above statement should raise an Exception')
+        except requests.HTTPError, err:
+            self.assertEqual(err.response.status_code, 404)
+
+    def test_fetch_existing_document_with_docid(self):
+        """
+        Test fetching document content from an existing document
+        """
+        doc = Document(self.db, 'julia006')
+        doc['name'] = 'julia'
+        doc['age'] = 6
+        doc.create()
+        new_doc = Document(self.db, 'julia006')
+        new_doc.fetch()
+        self.assertEqual(new_doc, doc)
+
+    def test_create_document_using_save(self):
+        """
+        Test that save functionality works.  If a document does
+        not exist remotely then create it.
+        """
+        doc = Document(self.db, 'julia006')
+        doc['name'] = 'julia'
+        doc['age'] = 6
+        self.assertIsNone(doc.get('_rev'))
+        doc.save()
+        self.assertTrue(doc.exists())
+        self.assertTrue(doc['_rev'].startswith('1-'))
+        remote_doc = Document(self.db, 'julia006')
+        remote_doc.fetch()
+        self.assertEqual(remote_doc, doc)
+
+    def test_update_document_using_save(self):
+        """
+        Test that save functionality works.  If a document exists
+        remotely then update it.
+        """
+        # First create the document
+        doc = Document(self.db, 'julia006')
+        doc['name'] = 'julia'
+        doc['age'] = 6
+        doc.save()
+        # Now test that the document gets updated
+        doc['name'] = 'jules'
+        doc.save()
+        self.assertTrue(doc['_rev'].startswith('2-'))
+        remote_doc = Document(self.db, 'julia006')
+        remote_doc.fetch()
+        self.assertEqual(remote_doc, doc)
+        self.assertEqual(remote_doc['name'], 'jules')
+
+    def test_list_field_append_successfully(self):
+        """
+        Test the static helper method to successfully append to a list field.
+        """
+        doc = Document(self.db)
+        self.assertEqual(doc, {})
+        doc.list_field_append(doc, 'pets', 'cat')
+        self.assertEqual(doc, {'pets': ['cat']})
+        doc.list_field_append(doc, 'pets', 'dog')
+        self.assertEqual(doc, {'pets': ['cat', 'dog']})
+        doc.list_field_append(doc, 'pets', None)
+        self.assertEqual(doc, {'pets': ['cat', 'dog']})
+
+    def test_list_field_append_failure(self):
+        """
+        Test the static helper method to append to a list
+        field errors as expected.
+        """
+        doc = Document(self.db)
+        doc.field_set(doc, 'name', 'julia')
+        try:
+            doc.list_field_append(doc, 'name', 'isabel')
+            self.fail('Above statement should raise an Exception')
+        except CloudantException, err:
+            self.assertEqual(str(err), 'The field name is not a list.')
+        self.assertEqual(doc, {'name': 'julia'})
+
+    def test_list_field_remove_successfully(self):
+        """
+        Test the static helper method to successfully remove from a list field.
+        """
+        doc = Document(self.db)
+        self.assertEqual(doc, {})
+        doc.list_field_append(doc, 'pets', 'cat')
+        doc.list_field_append(doc, 'pets', 'dog')
+        self.assertEqual(doc, {'pets': ['cat', 'dog']})
+        doc.list_field_remove(doc, 'pets', 'dog')
+        self.assertEqual(doc, {'pets': ['cat']})
+
+    def test_list_field_remove_failure(self):
+        """
+        Test the static helper method to remove from a list
+        field errors as expected.
+        """
+        doc = Document(self.db)
+        doc.field_set(doc, 'name', 'julia')
+        try:
+            doc.list_field_remove(doc, 'name', 'julia')
+            self.fail('Above statement should raise an Exception')
+        except CloudantException, err:
+            self.assertEqual(str(err), 'The field name is not a list.')
+        self.assertEqual(doc, {'name': 'julia'})
+
+    def test_field_set_and_replace(self):
+        """
+        Test the static helper method to set or replace a field value.
+        """
+        doc = Document(self.db)
+        self.assertEqual(doc, {})
+        doc.field_set(doc, 'name', 'julia')
+        self.assertEqual(doc, {'name': 'julia'})
+        doc.field_set(doc, 'name', 'jules')
+        self.assertEqual(doc, {'name': 'jules'})
+        doc.field_set(doc, 'pets', ['cat', 'dog'])
+        self.assertEqual(doc, {'name': 'jules', 'pets': ['cat', 'dog']})
+        doc.field_set(doc, 'pets', None)
+        self.assertEqual(doc, {'name': 'jules'})
+
+    def test_update_field(self):
+        """
+        Test that we can update a single field remotely using the
+        update_field method.
+        """
+        doc = Document(self.db, 'julia006')
+        doc['name'] = 'julia'
+        doc['age'] = 6
+        doc['pets'] = ['cat', 'dog']
+        doc.create()
+        self.assertTrue(doc['_rev'].startswith('1-'))
+        self.assertEqual(doc['pets'], ['cat', 'dog'])
+        doc.update_field(doc.list_field_append, 'pets', 'fish')
+        self.assertTrue(doc['_rev'].startswith('2-'))
+        self.assertEqual(doc['pets'], ['cat', 'dog', 'fish'])
+
+    def test_delete_document_failure(self):
+        """
+        Test failure condition when attempting to remove a document
+        from the remote database.
+        """
+        doc = Document(self.db, 'julia006')
+        doc['name'] = 'julia'
+        doc['age'] = 6
+        doc['pets'] = ['cat', 'dog']
+        try:
+            doc.delete()
+            self.fail('Above statement should raise an Exception')
+        except CloudantException, err:
+            self.assertEqual(
+                str(err), 
+                'Attempting to delete a doc with no _rev. '
+                'Try running .fetch first!'
+            )
+
+    def test_delete_document_success(self):
+        """
+        Test that we can remove a document from the remote
+        database successfully.
+        """
+        doc = Document(self.db, 'julia006')
+        doc['name'] = 'julia'
+        doc['age'] = 6
+        doc['pets'] = ['cat', 'dog']
+        doc.create()
+        self.assertTrue(doc.exists())
+        doc.delete()
+        self.assertFalse(doc.exists())
+        self.assertEqual(doc, {'_id': 'julia006'})
+
+    def test_document_context_manager(self):
+        """
+        Test that the __enter__ and __exit__ methods perform as expected
+        when initiated through a document context manager.
+        """
+        new_doc = Document(self.db, 'julia006')
+        new_doc.create()
+        self.assertTrue(new_doc.exists())
+        del new_doc
+        with Document(self.db, 'julia006') as doc:
+            self.assertTrue(all(x in doc.keys() for x in ['_id', '_rev']))
+            self.assertTrue(doc['_rev'].startswith('1-'))
+            doc['name'] = 'julia'
+            doc['age'] = 6
+        self.assertTrue(doc['_rev'].startswith('2-'))
+        self.assertEqual(self.db['julia006'], doc)
+
+    def test_setting_id(self):
+        """
+        Ensure that proper processing occurs when setting the _id
+        """
+        doc = Document(self.db)
+        self.assertIsNone(doc.get('_id'))
+        self.assertEqual(doc._document_id, None)
+        doc['_id'] = 'julia006'
+        self.assertEqual(doc['_id'], 'julia006')
+        self.assertEqual(doc._document_id, 'julia006')
+
+    def test_removing_id(self):
+        """
+        Ensure that proper processing occurs when removing the _id
+        """
+        doc = Document(self.db)
+        doc['_id'] = 'julia006'
+        del doc['_id']
+        self.assertIsNone(doc.get('_id'))
+        self.assertEqual(doc._document_id, None)
+
+    def test_attachment_management(self):
+        """
+        Test the adding, retrieving, updating, and deleting of attachments
+        """
+        doc = self.db.create_document(
+            {'_id': 'julia006', 'name': 'julia', 'age': 6}
+        )
+        attachment = StringIO.StringIO()
+        try:
+            attachment.write('This is line one of the attachment.\n')
+            attachment.write('This is line two of the attachment.\n')
+            self.assertTrue(doc['_rev'].startswith('1-'))
+            # Test adding an attachment
+            resp = doc.put_attachment(
+                'attachment.txt',
+                'text/plain',
+                attachment.getvalue()
+            )
+            self.assertTrue(resp['ok'])
+            self.assertTrue(resp['rev'].startswith('2-'))
+            self.assertEqual(doc['_rev'], resp['rev'])
+            self.assertTrue(
+                all(x in doc.keys() for x in [
+                    '_id',
+                    '_rev',
+                    'name',
+                    'age',
+                    '_attachments'
+                ])
+            )
+            self.assertTrue(
+                all(x in doc['_attachments'].keys() for x in [
+                    'attachment.txt'
+                ])
+            )
+            orig_size = doc['_attachments']['attachment.txt']['length']
+            self.assertEqual(orig_size, len(attachment.getvalue()))
+            # Confirm that the local document dictionary matches 
+            # the document on the database.
+            expected = Document(self.db, 'julia006')
+            expected.fetch()
+            # Test retrieving an attachment
+            self.assertEqual(
+                doc.get_attachment('attachment.txt',attachment_type='text'),
+                attachment.getvalue()
+            )
+            # Test update an attachment
+            attachment.write('This is line three of the attachment.\n')
+            resp = doc.put_attachment(
+                'attachment.txt',
+                'text/plain',
+                attachment.getvalue()
+            )
+            self.assertTrue(resp['ok'])
+            self.assertTrue(resp['rev'].startswith('3-'))
+            self.assertEqual(doc['_rev'], resp['rev'])
+            self.assertTrue(
+                all(x in doc.keys() for x in [
+                    '_id',
+                    '_rev',
+                    'name',
+                    'age',
+                    '_attachments'
+                ])
+            )
+            self.assertTrue(
+                all(x in doc['_attachments'].keys() for x in [
+                    'attachment.txt'
+                ])
+            )
+            updated_size = doc['_attachments']['attachment.txt']['length']
+            self.assertTrue(updated_size > orig_size)
+            self.assertEqual(updated_size, len(attachment.getvalue()))
+            self.assertEqual(
+                doc.get_attachment('attachment.txt',attachment_type='text'),
+                attachment.getvalue()
+            )
+            # Confirm that the local document dictionary matches 
+            # the document on the database.
+            expected = Document(self.db, 'julia006')
+            expected.fetch()
+            # Test delete attachments
+            # Add a second attachment so we can fully test
+            # delete functionality.
+            resp = doc.put_attachment(
+                'attachment2.txt',
+                'text/plain',
+                attachment.getvalue()
+            )
+            # Test deleting an attachment from a document
+            # with multiple atatchments.
+            resp = doc.delete_attachment('attachment.txt')
+            self.assertTrue(resp['ok'])
+            self.assertTrue(resp['rev'].startswith('5-'))
+            self.assertEqual(doc['_rev'], resp['rev'])
+            self.assertTrue(
+                all(x in doc.keys() for x in [
+                    '_id',
+                    '_rev',
+                    'name',
+                    'age',
+                    '_attachments'
+                ])
+            )
+            # Confirm that the local document dictionary matches 
+            # the document on the database.
+            expected = Document(self.db, 'julia006')
+            expected.fetch()
+            self.assertEqual(doc, expected)
+            # Test deleting an attachment from a document
+            # with a single attachment.
+            resp = doc.delete_attachment('attachment2.txt')
+            self.assertTrue(resp['ok'])
+            self.assertTrue(resp['rev'].startswith('6-'))
+            self.assertEqual(doc['_rev'], resp['rev'])
+            self.assertTrue(
+                all(x in doc.keys() for x in [
+                    '_id',
+                    '_rev',
+                    'name',
+                    'age'
+                ])
+            )
+            # Confirm that the local document dictionary matches 
+            # the document on the database.
+            expected = Document(self.db, 'julia006')
+            expected.fetch()
+            self.assertEqual(doc, expected)
+        finally:
+            attachment.close()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
_What:_

- Add unit tests that check Document class functionality against a database.
- Enhance the Document class based on unit test results.

_Why:_

Unit tests that target a database provide a more accurate testing platform.

_How:_

- Add Document unit tests that test functionality against either a CouchDB or a Cloudant database.
- Change the Document class in the following ways:
  - Only construct the document_url if the _document_id has a value.
  - Only execute the exists() request if a _document_id has a value.
  - Ensure that a create() request will only create and not update a document remotely.
  - Ensure that a fetch() request replaces the entire dictionary contents of the current Document object. 
  - Rename field_append to list_field_append, rename field_remove to list_field_remove, and rename field_replace to field_set for added clarity.
  - Add validation to list_field_append, list_field_remove, and field_set methods.
  - Clear the dictionary contents, aside from the _id of a Document object that was deleted remotely.
  - Ensure that the dictionary key '_id' and the private attribute _document_id are kept in sync.
  - Retrieve the latest _rev value for put_attachment, get_attachment, and delete_attachment by performing a fetch() call.  The fetch() call provides validation checks as well as refreshes the local Document object.
  - After a successful add/update/delete of an attachment, refresh the local Document object to have the latest content.

reviewer: @ricellis 

BugId: 55710