### PR TITLE
Refactor the replicator and add tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@
 - [FIX] The Document local dictionary ``_id`` key is now synched with ``_document_id`` private attribute.
 - [FIX] The Document local dictionary is now refreshed after an add/update/delete of an attachment.
 - [FIX] The Document ``fetch()`` method now refreshes the Document local dictionary content correctly.
+- [BREAKING] Replace the ReplicatorDatabase class with the Replicator class.  A Replicator object has a database attribute that represents the _replicator database.  This allows the Replicator to work for both a CloudantDatabase and a CouchDatabase.
 
 2.0.0a1 (2015-10-13)
 ====================

--- a/src/cloudant/account.py
+++ b/src/cloudant/account.py
@@ -86,6 +86,7 @@ class CouchDB(dict):
         """
         self.session_logout()
         self.r_session = None
+        self.clear()
 
     def session(self):
         """

--- a/tests/integration/replicator_test.py
+++ b/tests/integration/replicator_test.py
@@ -28,7 +28,7 @@ import unittest
 
 from cloudant import cloudant
 from cloudant.credentials import read_dot_cloudant
-from cloudant.replicator import ReplicatorDatabase
+from cloudant.replicator import Replicator
 
 def setup_logging():
     log = logging.getLogger()
@@ -54,10 +54,10 @@ class ReplicatorTest(unittest.TestCase):
 
     def tearDown(self):
         with cloudant(self.user, self.passwd, account=self.user) as c:
-            replicator_db = ReplicatorDatabase(c)
+            replicator = Replicator(c)
 
             while self.replication_ids:
-                replicator_db.stop_replication(self.replication_ids.pop())
+                replicator.stop_replication(self.replication_ids.pop())
 
             while self.dbs:
                 c.delete_database(self.dbs.pop())
@@ -71,7 +71,7 @@ class ReplicatorTest(unittest.TestCase):
 
         """
         with cloudant(self.user, self.passwd, account=self.user) as c:
-            replicator = ReplicatorDatabase(c)
+            replicator = Replicator(c)
             replicator.all_docs()
 
     def test_create_replication(self):
@@ -103,7 +103,7 @@ class ReplicatorTest(unittest.TestCase):
                 {"_id": "doc3", "testing": "document 1"}
             )
 
-            replicator = ReplicatorDatabase(c)
+            replicator = Replicator(c)
             repl_id = u"test_create_replication_{}".format(
                 unicode(uuid.uuid4()))
             self.replication_ids.append(repl_id)
@@ -112,7 +112,7 @@ class ReplicatorTest(unittest.TestCase):
                 source_db=dbs,
                 target_db=dbt,
                 repl_id=repl_id,
-                continuous=False,
+                continuous=False
             )
 
             try:
@@ -120,7 +120,7 @@ class ReplicatorTest(unittest.TestCase):
             except KeyError:
                 repl_doc = None
             if not repl_doc or not (repl_doc.get(
-                    '_replication_state', "none") in ('completed, error')):
+                    '_replication_state', "none") in ('completed', 'error')):
                 for change in replicator.changes():
                     if change.get('id') == repl_id:
                         try:
@@ -172,7 +172,7 @@ class ReplicatorTest(unittest.TestCase):
                 {"_id": "doc3", "testing": "document 1"}
             )
 
-            replicator = ReplicatorDatabase(c)
+            replicator = Replicator(c)
             repl_id = u"test_follow_replication_{}".format(
                 unicode(uuid.uuid4()))
             self.replication_ids.append(repl_id)
@@ -219,7 +219,7 @@ class ReplicatorTest(unittest.TestCase):
                 {"_id": "doc3", "testing": "document 1"}
             )
 
-            replicator = ReplicatorDatabase(c)
+            replicator = Replicator(c)
             repl_id = u"test_follow_replication_{}".format(
                 unicode(uuid.uuid4()))
             self.replication_ids.append(repl_id)
@@ -268,7 +268,7 @@ class ReplicatorTest(unittest.TestCase):
                 {"_id": "doc3", "testing": "document 1"}
             )
 
-            replicator = ReplicatorDatabase(c)
+            replicator = Replicator(c)
             repl_id = u"test_replication_state_{}".format(
                 unicode(uuid.uuid4()))
             self.replication_ids.append(repl_id)
@@ -309,7 +309,7 @@ class ReplicatorTest(unittest.TestCase):
         """
 
         with cloudant(self.user, self.passwd, account=self.user) as c:
-            replicator = ReplicatorDatabase(c)
+            replicator = Replicator(c)
             repl_ids = []
             num_reps = 3
 

--- a/tests/unit/db/replicator_tests.py
+++ b/tests/unit/db/replicator_tests.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python
+# Copyright (c) 2015 IBM. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+_replicator_tests_
+
+replicator module - Unit tests for the Replicator class
+
+See configuration options for environment variables in unit_t_db_base
+module docstring.
+
+"""
+
+import unittest
+import uuid
+import time
+import requests
+
+from cloudant.replicator import Replicator
+from cloudant.document import Document
+from cloudant.errors import CloudantException
+
+from unit_t_db_base import UnitTestDbBase
+
+class ReplicatorTests(UnitTestDbBase):
+    """
+    Replicator unit tests
+    """
+
+    def setUp(self):
+        """
+        Set up test attributes
+        """
+        super(ReplicatorTests, self).setUp()
+        self.db_set_up()
+        self.test_target_dbname = self.dbname()
+        self.target_db = self.client._DATABASE_CLASS(
+            self.client,
+            self.test_target_dbname
+        )
+        self.target_db.create()
+        self.replicator = Replicator(self.client)
+        self.replication_ids = []
+
+    def tearDown(self):
+        """
+        Reset test attributes
+        """
+        self.target_db.delete()
+        del self.test_target_dbname
+        del self.target_db
+        while self.replication_ids:
+                self.replicator.stop_replication(self.replication_ids.pop())
+        del self.replicator
+        self.db_tear_down()
+        super(ReplicatorTests, self).tearDown()
+
+    def test_constructor(self):
+        """
+        Test constructing a Replicator
+        """
+        self.assertIsInstance(self.replicator, Replicator)
+        self.assertIsInstance(
+            self.replicator.database,
+            self.client._DATABASE_CLASS
+        )
+        self.assertEqual(self.replicator.database, self.client['_replicator'])
+
+    def test_constructor_failure(self):
+        """
+        Test that constructing a Replicator will not work
+        without a valid account.
+        """
+        repl = None
+        try:
+            self.client.disconnect()
+            repl = Replicator(self.client)
+            self.fail('Above statement should raise a CloudantException')
+        except CloudantException, err:
+            self.assertEqual(
+                str(err),
+                'Unable to acquire _replicator database.  '
+                'Verify that the account client is valid and try again.'
+            )
+        finally:
+            self.assertIsNone(repl)
+            self.client.connect()
+
+    def test_create_replication(self):
+        """
+        Test that the replication document gets created and that the 
+        replication is successful.
+        """
+        self.populate_db_with_documents(3)
+        repl_id = 'test-repl-{}'.format(unicode(uuid.uuid4()))
+
+        repl_doc = self.replicator.create_replication(
+            self.db,
+            self.target_db,
+            repl_id
+        )
+        self.replication_ids.append(repl_id)
+        # Test that the replication document was created
+        expected_keys = ['_id', '_rev', 'source', 'target', 'user_ctx']
+        self.assertTrue(all(x in repl_doc.keys() for x in expected_keys))
+        self.assertEqual(repl_doc['_id'], repl_id)
+        self.assertTrue(repl_doc['_rev'].startswith('1-'))
+        # Now that we know that the replication document was created,
+        # check that the replication occurred.
+        repl_doc = Document(self.replicator.database, repl_id)
+        repl_doc.fetch()
+        if not (repl_doc.get('_replication_state')
+            in ('completed', 'error')):
+            for change in self.replicator.database.changes():
+                if change.get('id') == repl_id:
+                    repl_doc = Document(self.replicator.database, repl_id)
+                    repl_doc.fetch()
+                    if (repl_doc.get('_replication_state')
+                        in ('completed', 'error')):
+                        break
+        self.assertEqual(repl_doc['_replication_state'], 'completed')
+        self.assertEqual(self.db.all_docs(), self.target_db.all_docs())
+        self.assertTrue(
+            all(x in self.target_db.keys(True) for x in [
+                'julia000',
+                'julia001',
+                'julia002'
+            ])
+        )
+
+    def test_create_replication_without_a_source(self):
+        """
+        Test that the replication document is not created and fails as expected
+        when no source database is provided. 
+        """
+        try:
+            repl_doc = self.replicator.create_replication()
+            self.fail('Above statement should raise a CloudantException')
+        except CloudantException, err:
+            self.assertEqual(
+                str(err),
+                'You must specify either a source_db Database '
+                'object or a manually composed \'source\' string/dict.'
+            )
+
+    def test_create_replication_without_a_target(self):
+        """
+        Test that the replication document is not created and fails as expected
+        when no target database is provided. 
+        """
+        try:
+            repl_doc = self.replicator.create_replication(self.db)
+            self.fail('Above statement should raise a CloudantException')
+        except CloudantException, err:
+            self.assertEqual(
+                str(err),
+                'You must specify either a target_db Database '
+                'object or a manually composed \'target\' string/dict.'
+            )
+
+    def test_list_replications(self):
+        """
+        Test that a list of Document wrapped objects are returned.
+        """
+        self.populate_db_with_documents(3)
+        repl_ids = ['test-repl-{}'.format(
+            unicode(uuid.uuid4())
+        ) for _ in xrange(3)]
+        repl_docs = [self.replicator.create_replication(
+            self.db,
+            self.target_db,
+            repl_id
+        ) for repl_id in repl_ids]
+        self.replication_ids.extend(repl_ids)
+        replications = self.replicator.list_replications()
+        all_repl_ids = [doc['_id'] for doc in replications]
+        match = [repl_id for repl_id in all_repl_ids if repl_id in repl_ids]
+        self.assertEqual(set(repl_ids), set(match))
+
+    def test_retrieve_replication_state(self):
+        """
+        Test that the replication state can be retrieved for a replication
+        """
+        self.populate_db_with_documents(3)
+        repl_id = "test-repl-{}".format(unicode(uuid.uuid4()))
+        repl_doc = self.replicator.create_replication(
+            self.db,
+            self.target_db,
+            repl_id
+        )
+        self.replication_ids.append(repl_id)
+        repl_state = None
+        valid_states = ['completed', 'error', 'triggered', None]
+        finished = False
+        for _ in xrange(300):
+            repl_state = self.replicator.replication_state(repl_id)
+            self.assertTrue(repl_state in valid_states)
+            if repl_state in ('error', 'completed'):
+                finished = True
+                break
+            time.sleep(1)
+        self.assertTrue(finished)
+
+    def test_retrieve_replication_state_using_invalid_id(self):
+        """
+        Test that replication_state(...) raises an exception as expected
+        when an invalid replication id is provided.
+        """
+        repl_id = 'fake-repl-id-{}'.format(unicode(uuid.uuid4()))
+        repl_state = None
+        try:
+            self.replicator.replication_state(repl_id)
+            self.fail('Above statement should raise a CloudantException')
+        except CloudantException, err:
+            self.assertEqual(
+                str(err),
+                'Replication {} not found'.format(repl_id)
+            )
+            self.assertIsNone(repl_state)
+
+    def test_stop_replication(self):
+        """
+        Test that a replication can be stopped.
+        """
+        self.populate_db_with_documents(3)
+        repl_id = "test-repl-{}".format(unicode(uuid.uuid4()))
+        repl_doc = self.replicator.create_replication(
+            self.db,
+            self.target_db,
+            repl_id
+        )
+        self.replicator.stop_replication(repl_id)
+        try:
+            # The .fetch() will fail since the replication has been stopped
+            # and the replication document has been removed from the db.
+            repl_doc.fetch()
+            self.fail('Above statement should raise a CloudantException')
+        except requests.HTTPError, err:
+            self.assertEqual(err.response.status_code, 404)
+
+    def test_stop_replication_using_invalid_id(self):
+        """
+        Test that stop_replication(...) raises an exception as expected
+        when an invalid replication id is provided.
+        """
+        repl_id = 'fake-repl-id-{}'.format(unicode(uuid.uuid4()))
+        try:
+            self.replicator.stop_replication(repl_id)
+            self.fail('Above statement should raise a CloudantException')
+        except CloudantException, err:
+            self.assertEqual(
+                str(err),
+                'Could not find replication with id {}'.format(repl_id)
+            )
+
+    def test_follow_replication(self):
+        """
+        Test that follow_replication(...) properly iterates updated
+        replication documents while the replication is executing.
+        """
+        self.populate_db_with_documents(3)
+        repl_id = "test-repl-{}".format(unicode(uuid.uuid4()))
+        repl_doc = self.replicator.create_replication(
+            self.db,
+            self.target_db,
+            repl_id
+        )
+        self.replication_ids.append(repl_id)
+        valid_states = ['completed', 'error', 'triggered', None]
+        repl_states = []
+        for doc in self.replicator.follow_replication(repl_id):
+            self.assertTrue(doc.get('_replication_state') in valid_states)
+            repl_states.append(doc.get('_replication_state'))
+        self.assertTrue(len(repl_states) > 0)
+        self.assertEqual(repl_states[-1], 'completed')
+        self.assertTrue('error' not in repl_states)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
_What:_

- Refactor ReplicatorDatabase to Replicator.
- Add Replicator unit tests that target a Cloudant or CouchDB instance.

_Why:_

The new Replicator class has the database as an attribute so the Replicator provides an API that works with both a CloudantDatabase and a CouchDatabase _replicator database.

_How:_

- Based on the account client provided when constructing a Replicator object, the Replicator provides a user friendly API for replication tasks for either a Cloudant or a CouchDB account.
- The list_replications method now returns a list of Document wrapped objects.
- Update the integration/replicator_test.py module based on refactoring.
- Update the mocked/replicator_test.py module based on refactoring.
- Add Replicator tests that target a database instance.

reviewer: @emlaver

BugId: 55839