### PR TITLE
Clean up docstring content

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,17 @@
 Cloudant Python Client
 ======================
 
-.. image:: https://travis-ci.org/cloudant/python-cloudant.png
+|build-status| |docs|
+
+.. |build-status| image:: https://travis-ci.org/cloudant/python-cloudant.png
+    :alt: build status
+    :scale: 100%
     :target: https://travis-ci.org/cloudant/python-cloudant
+
+.. |docs| image:: https://readthedocs.org/projects/pip/badge/
+    :alt: docs
+    :scale: 100%
+    :target: http://python-cloudant.readthedocs.org
 
 This library is currently a preview (alpha version) of Cloudant's new official 
 Python library.  As such it currently does not have complete API coverage nor is the
@@ -46,20 +55,20 @@ In order to install the deprecated 0.5.10, execute
 ===============
 Getting started
 ===============
-.. TODO - REPLACE LINK TO MASTER VERSION BEFORE PR MERGE
-See `Getting started (readthedocs.org) <http://python-cloudant.readthedocs.org/en/53377-docs-via-sphinx/getting_started.html>`_
+
+See `Getting started (readthedocs.org) <http://python-cloudant.readthedocs.org/en/latest/getting_started.html>`_
 
 =============
 API Reference
 =============
-.. TODO - REPLACE LINK TO MASTER VERSION BEFORE PR MERGE
-See `API reference docs (readthedocs.org) <http://python-cloudant.readthedocs.org/en/53377-docs-via-sphinx/cloudant.html>`_
+
+See `API reference docs (readthedocs.org) <http://python-cloudant.readthedocs.org/en/latest/cloudant.html>`_
 
 =====================
 Related Documentation
 =====================
-.. TODO - REPLACE LINK TO MASTER VERSION BEFORE PR MERGE
-* `Cloudant Python client library docs (readthedocs.org) <http://python-cloudant.readthedocs.org/en/53377-docs-via-sphinx/>`_
+
+* `Cloudant Python client library docs (readthedocs.org) <http://python-cloudant.readthedocs.org>`_
 * `Cloudant documentation <http://docs.cloudant.com/>`_
 * `Cloudant for developers <https://cloudant.com/for-developers/>`_
 

--- a/docs/compatibility.rst
+++ b/docs/compatibility.rst
@@ -1,0 +1,12 @@
+Compatibility
+=============
+
+This library can be used with the following databases
+
+* `IBM Cloudant® Database-as-a-Service <https://cloudant.com/>`_
+* `IBM Cloudant® Data Layer Local Edition (Cloudant Local) <http://www.ibm.com/software/products/cloudant-data-layer-local-edition>`_
+* `Apache CouchDB™ <http://couchdb.apache.org/>`_
+
+Note that some features are Cloudant specific.
+
+The library is developed using `Python™ 2.7.10 <https://www.python.org/downloads/release/python-2710/>`_ and should be 2.x compatible.  It is currently not 3.x compatible.  We have plans to add that in the future.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@ This is the official Cloudant client library for Python.
 .. toctree::
    :maxdepth: 4
 
+   compatibility
    getting_started
    cloudant
 

--- a/src/cloudant/__init__.py
+++ b/src/cloudant/__init__.py
@@ -13,10 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-_cloudant_
-
-Cloudant / CouchDB Python Client API
-
+Cloudant / CouchDB Python client library API package
 """
 __version__ = '2.0.0b1.dev'
 
@@ -24,30 +21,69 @@ import contextlib
 
 from .account import Cloudant, CouchDB
 
-
 @contextlib.contextmanager
 def cloudant(user, passwd, **kwargs):
     """
-    _cloudant_
-
-    Context helper to create a cloudant session and
+    Provides a context manager to create a Cloudant session and
     provide access to databases, docs etc.
 
+    :param str user: Username used to connect to Cloudant.
+    :param str passwd: Authentication token used to connect to Cloudant.
+    :param str account: The Cloudant account name.  If the account parameter
+        is present, it will be used to construct the Cloudant service URL.
+    :param str url: If the account is not present and the url parameter is
+        present then it will be used to set the Cloudant service URL.  The
+        url must be a fully qualified http/https URL.
+    :param str x_cloudant_user: Override the X-Cloudant-User setting used to
+        authenticate. This is needed to authenticate on one's behalf,
+        eg with an admin account.  This parameter must be accompanied
+        by the url parameter.  If the url parameter is omitted then
+        the x_cloudant_user parameter setting is ignored.
+    :param str encoder: Optional json Encoder object used to encode
+        documents for storage. Defaults to json.JSONEncoder.
+
+    For example:
+
+    .. code-block:: python
+
+        # cloudant context manager
+        from cloudant import cloudant
+
+        with cloudant(USERNAME, PASSWORD, account=ACCOUNT_NAME) as client:
+            # Context handles connect() and disconnect() for you.
+            # Perform library operations within this context.  Such as:
+            print client.all_dbs()
+            # ...
     """
     cloudant_session = Cloudant(user, passwd, **kwargs)
     cloudant_session.connect()
     yield cloudant_session
     cloudant_session.disconnect()
 
-
 @contextlib.contextmanager
 def couchdb(user, passwd, **kwargs):
     """
-    _couchdb_
-
-    Context helper to create a couchdb session and
+    Provides a context manager to create a CouchDB session and
     provide access to databases, docs etc.
 
+    :param str user: Username used to connect to CouchDB.
+    :param str passwd: Passcode used to connect to CouchDB.
+    :param str url: URL for CouchDB server.
+    :param str encoder: Optional json Encoder object used to encode
+        documents for storage.  Defaults to json.JSONEncoder.
+
+    For example:
+
+    .. code-block:: python
+
+        # couchdb context manager
+        from cloudant import couchdb
+
+        with couchdb(USERNAME, PASSWORD, url=COUCHDB_URL) as client:
+            # Context handles connect() and disconnect() for you.
+            # Perform library operations within this context.  Such as:
+            print client.all_dbs()
+            # ...
     """
     couchdb_session = CouchDB(user, passwd, **kwargs)
     couchdb_session.connect()

--- a/src/cloudant/credentials.py
+++ b/src/cloudant/credentials.py
@@ -13,11 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-_credentials_
-
-Utilities to support using a ~/.cloudant INI style configuration file
-to allow users to pass credentials in
-
+Module providing utilities to support using an INI style configuration file
+to allow users to pass credentials.
 """
 import os
 import ConfigParser
@@ -29,14 +26,19 @@ def read_dot_couch(
         username='user',
         password='password'):
     """
-    _read_dot_couch_
+    Provides a way to read an INI file containing a ``couchdb`` section
+    that contains authentication credentials for connecting to a
+    CouchDB instance.
 
-    If you have a INI file containing a CouchDB section
-    with a username and password in it, you can read it
-    to get the credentials with this function.
+    :param str filename: Path and name of INI file.  Defaults to ``~/.couch``.
+    :param str section: Name of the section in the INI file to find credentials.
+        Defaults to ``couchdb``.
+    :param str username: Name of the user entry in the INI file and section.
+        Defaults to ``user``.
+    :param str password: Name of the password entry in the INI file and section.
+        Defaults to ``password``.
 
-    :returns: tuple (user, password)
-
+    :returns: A tuple containing user and password
     """
     return _read_dot_file(filename, section, username, password)
 
@@ -47,23 +49,33 @@ def read_dot_cloudant(
         username='user',
         password='password'):
     """
-    _read_dot_cloudant_
+    Provides a way to read an INI file containing a ``cloudant`` section
+    that contains authentication credentials for connecting to a
+    Cloudant instance.
 
-    If you have an INI file containing a Cloudant section
-    with a username and password in it, you can read it
-    to get the credentials with this function.
+    :param str filename: Path and name of INI file.  Defaults to
+        ``~/.cloudant``.
+    :param str section: Name of the section in the INI file to find credentials.
+        Defaults to ``cloudant``.
+    :param str username: Name of the user entry in the INI file and section.
+        Defaults to ``user``.
+    :param str password: Name of the password entry in the INI file and section.
+        Defaults to ``password``.
 
-    :returns: tuple (user, password)
-
+    :returns: A tuple containing user and password
     """
     return _read_dot_file(filename, section, username, password)
 
 def _read_dot_file(filename, section, username, password):
     """
-    __read_dot_file_
-
     Handles the parsing of the configuration file for the username
     and password.
+
+    :param str filename: Path and name of INI file.
+    :param str section: Name of the section in the INI file to find credentials.
+    :param str username: Name of the user entry in the INI file and section.
+
+    :returns: A tuple containing user and password
     """
     config_file = os.path.expanduser(filename)
     config = ConfigParser.RawConfigParser()

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -13,10 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-_database_
-
-API class representing a database
-
+API module that maps to a Cloudant or CouchDB database instance.
 """
 import json
 import contextlib
@@ -31,35 +28,34 @@ from .errors import CloudantException
 from .result import python_to_couch, Result
 from .changes import Feed
 
-
 class CouchDatabase(dict):
     """
-    _CouchDatabase_
+    Encapsulates a CouchDB database.  A CouchDatabase object is
+    instantiated with a reference to a client/session.
+    It supports accessing the documents, and various database
+    features such as the document indexes, changes feed, design documents, etc.
 
-    dict based interface to a CouchDB Database.
-    Instantiated with a reference to an account/session
-    it supports accessing the documents, and various database
-    features such as the document indexes, changes feed, and
-    design documents.
-
-    :param account: CouchAccount instance corresponding to the db server
-    :param database_name: Name of the database
-    :param fetch_limit: Optional, sets the max number of docs to fetch per
-      query during iteration cycles
-
+    :param CouchDB client: Client instance used by the database.
+    :param str database_name: Database name used to reference the database.
+    :param int fetch_limit: Optional fetch limit used to set the max number of
+        documents to fetch per query during iteration cycles.  Defaults to 100.
     """
-    def __init__(self, account, database_name, fetch_limit=100):
+    def __init__(self, client, database_name, fetch_limit=100):
         super(CouchDatabase, self).__init__()
-        self.cloudant_account = account
-        self._database_host = account.cloudant_url
+        self.cloudant_account = client
+        self._database_host = client.cloudant_url
         self.database_name = database_name
-        self.r_session = account.r_session
+        self.r_session = client.r_session
         self._fetch_limit = fetch_limit
         self.result = Result(self.all_docs)
 
     @property
     def database_url(self):
-        """constructs and returns the database URL"""
+        """
+        Constructs and returns the database URL.
+
+        :returns: Database URL
+        """
         return posixpath.join(
             self._database_host,
             urllib.quote_plus(self.database_name)
@@ -68,11 +64,10 @@ class CouchDatabase(dict):
     @property
     def creds(self):
         """
-        _creds_
+        Retrieves a dictionary of useful authentication information
+        that can be used to authenticate against this database.
 
-        Return a dict of useful strings to use to authenicate against
-        this database, using various methods.
-
+        :returns: Dictionary containing authentication information
         """
         return {
             "basic_auth": self.cloudant_account.basic_auth_str(),
@@ -81,18 +76,18 @@ class CouchDatabase(dict):
 
     def exists(self):
         """
-        performs an existence check on the database,
+        Performs an existence check on the remote database.
 
-        :returns: boolean, True if database exists
+        :returns: Boolean True if the database exists, False otherwise
         """
         resp = self.r_session.get(self.database_url)
         return resp.status_code == 200
 
     def metadata(self):
         """
-        Get the database metadata dictionary
+        Retrieves the remote database metadata dictionary.
 
-        :returns: dictionary containing db info details
+        :returns: Dictionary containing database metadata details
         """
         resp = self.r_session.get(self.database_url)
         resp.raise_for_status()
@@ -100,21 +95,23 @@ class CouchDatabase(dict):
 
     def doc_count(self):
         """
-        :returns: number of documents in the database
+        Retrieves the number of documents in the remote database
+
+        :returns: Database document count
         """
         return self.metadata().get('doc_count')
 
     def create_document(self, data, throw_on_exists=False):
         """
-        Create a new document in the database, using the data
-        provided, assuming that there is an _id field provided.
+        Creates a new document in the remote and locally cached database, using
+        the data provided, assuming that there is an _id field provided.
 
-        :param data: dictionary of document JSON data, containing _id
-        :param throw_on_exists: Optional control on whether to raise an
-          exception if the _id already exists as a document in the database
+        :param dict data: Dictionary of document JSON data, containing _id.
+        :param bool throw_on_exists: Optional flag dictating whether to raise
+            an exception if the document already exists in the database.
 
-        :returns: Document instance corresponding to the new doc
-
+        :returns: Document instance corresponding to the new document in the
+            database
         """
         docid = data.get('_id')
         doc = Document(self, docid)
@@ -130,13 +127,11 @@ class CouchDatabase(dict):
 
     def new_document(self):
         """
-        _new_document_
+        Creates a new, empty document in the remote and locally cached database,
+        auto-generating the _id.
 
-        Creates new, empty document, autogenerating the _id.
-
-        :returns: Document instance corresponding to newly created
-          document.
-
+        :returns: Document instance corresponding to the new document in the
+            database
         """
         doc = Document(self, None)
         doc.create()
@@ -145,10 +140,10 @@ class CouchDatabase(dict):
 
     def design_documents(self):
         """
-        _design_documents_
+        Retrieve the JSON content for all design documents in this database.
+        Performs a remote call to retrieve the content.
 
-        Return the raw JSON content of the design documents for this database
-
+        :returns: All design documents found in this database in JSON format
         """
         url = posixpath.join(self.database_url, '_all_docs')
         query = "startkey=\"_design\"&endkey=\"_design0\"&include_docs=true"
@@ -159,10 +154,10 @@ class CouchDatabase(dict):
 
     def list_design_documents(self):
         """
-        _list_design_documents_
+        Retrieves a list of design document names in this database.
+        Performs a remote call to retrieve the content.
 
-        Return a list of design document names on this database
-
+        :returns: List of names for all design documents in this database
         """
         url = posixpath.join(self.database_url, '_all_docs')
         query = "startkey=\"_design\"&endkey=\"_design0\""
@@ -173,17 +168,14 @@ class CouchDatabase(dict):
 
     def get_design_document(self, ddoc_id):
         """
-        _get_design_document_
+        Retrieves a design document.  If a design document exists remotely
+        then that content is wrapped in a DesignDocument object and returned
+        to the caller.  Otherwise a "shell" DesignDocument object is returned.
 
-        Returns a DesignDocument object.  If a remote design
-        document exists with the specified id then the
-        returned DesignDocument is populated with the remote
-        design document content.
+        :param str ddoc_id: Design document id
 
-        :param ddoc_id: Design document id
-
-        :returns: Design document instance (possibly populated)
-
+        :returns: A DesignDocument instance, if exists remotely then it will
+            be populated accordingly
         """
         ddoc = DesignDocument(self, ddoc_id)
         try:
@@ -196,52 +188,60 @@ class CouchDatabase(dict):
 
     def get_view_result(self, ddoc_id, view_name, **kwargs):
         """
-        _get_view_result_
-
-        Returns a Result object based on the design document
+        Retrieves a Result object based on the design document
         and view name.  If you intend to iterate through the
-        result, do not use skip and/or limit in the kwargs as
+        result, do not use ``skip`` and/or ``limit`` in the kwargs as
         that is handled in the Result.  If you would like to
         manage paging and iteration manually over the result
-        then try the get_view_raw_result method instead.
+        then use the
+        :func:`~cloudant.database.CouchDatabase.get_view_raw_result`
+        method instead.
 
-        For example to retrieve the default Result object based
-        on a design document view do:
+        For example to retrieve the default Result object based on a
+        design document view do:
 
-        db.get_view_result('_design/ddoc_id_001', 'view_001')
+        .. code-block:: python
+
+            db.get_view_result('_design/ddoc_id_001', 'view_001')
 
         But to retrieve a customized Result object based on the
         same design document view do something like:
 
-        db.get_view_result('_design/ddoc_id_001', 'view_001',
-            include_docs=True, reduce=False)
+        .. code-block:: python
 
-        For more detail on slicing and iteration using a Result
-        object, refer to the Result Class docstring.
+            db.get_view_result('_design/ddoc_id_001', 'view_001',
+                include_docs=True, reduce=False)
 
-        :param ddoc_id: Design document id
-        :param view_name: Name of the view
-        :param **kwargs: Parameters to index the query results by
-            Valid parameters include:
+        For more detail on slicing and iteration, refer to the
+        :class:`~cloudant.result.Result` documentation.
 
-            descending bool
-            endkey string or array
-            endkey_docid  string
-            group bool
-            group_level ??
-            include_docs bool
-            inclusive_end  bool
-            key string
-            keys list
-            reduce  boolean
-            stale   enum(ok, update_after)
-            startkey  string or array
-            startkey_docid  string
+        :param str ddoc_id: Design document id used to get result.
+        :param str view_name: Name of the view used to get result.
+        :param bool descending: Return documents in descending key order.
+        :param endkey: Stop returning records at this specified key.  Can be
+            either a ``str`` or, for complex keys, a ``list``.
+        :param str endkey_docid: Stop returning records when the specified
+            document id is reached.
+        :param bool group: Using the reduce function, group the results to a
+            group or single row.
+        :param group_level: Only applicable if the view uses complex keys: keys
+            that are lists. Groups reduce results for the specified number
+            of list fields.
+        :param bool include_docs: Include the full content of the documents.
+        :param bool inclusive_end: Include rows with the specified endkey.
+        :param str key: Return only documents that match the specified key.
+        :param list keys: Return only documents that match the specified keys.
+        :param bool reduce: True to use the reduce function, false otherwise.
+        :param str stale: Allow the results from a stale view to be used. This
+            makes the request return immediately, even if the view has not been
+            completely built yet. If this parameter is not given, a response is
+            returned only after the view has been built.
+        :param startkey: Return records starting with the specified key.  Can be
+            either a ``str`` or, for complex keys, a ``list``.
+        :param str startkey_docid: Return records starting with the specified
+            document ID.
 
-        :returns: The result content wrapped in a Result object that
-            allows for paging and pythonic slicing and iteration over
-            the result data
-
+        :returns: The result content wrapped in a Result object
         """
         view = View(DesignDocument(self, ddoc_id), view_name)
         if kwargs:
@@ -251,57 +251,72 @@ class CouchDatabase(dict):
 
     def get_view_raw_result(self, ddoc_id, view_name, **kwargs):
         """
-        _get_view_raw_result_
+        Retrieves the raw JSON content based on the design document
+        and view name.  Unlike
+        :func:`~cloudant.database.CouchDatabase.get_view_result` the use
+        of ``skip`` and ``limit`` as kwargs is valid and
+        actually necessary in order to manage paging and iteration.
+        If you would like paging and iteration handled automatically for you
+        then use the
+        :func:`~cloudant.database.CouchDatabase.get_view_result`
+        method instead.
 
-        Returns the raw response JSON content for the view query
-        based on the design document, view name and parameters
-        depicted as the kwargs.
+        For example to retrieve the raw JSON response content based on a
+        design document view do:
 
-        For example to retrieve the full resulting set of raw data
-        from a design document view do:
+        .. code-block:: python
 
-        db.get_view_raw_result('_design/ddoc_id_001', 'view_001')
+            db.get_view_raw_result('_design/ddoc_id_001', 'view_001')
 
-        or to provide parameters to the view query and return a
-        resulting set of raw data do something like:
+        But to retrieve the raw JSON response content based on a set of
+        parameters on the same design document view do something like:
 
-        db.get_view_raw_result('_design/ddoc_id_001', 'view_001',
-            include_docs=True, reduce=False)
+        .. code-block:: python
 
-        :param ddoc_id: Design document id
-        :param view_name: Name of the view
-        :param **kwargs: Parameters to index the query results by
-            Valid parameters include:
+            db.get_view_raw_result('_design/ddoc_id_001', 'view_001',
+                include_docs=True, skip=100, limit=100, reduce=False)
 
-            descending bool
-            endkey string or array
-            endkey_docid  string
-            group bool
-            group_level ??
-            include_docs bool
-            inclusive_end  bool
-            key string
-            keys list
-            limit   int
-            reduce  boolean
-            skip    int
-            stale   enum(ok, update_after)
-            startkey  string or array
-            startkey_docid  string
+        :param str ddoc_id: Design document id used to get result.
+        :param str view_name: Name of the view used to get result.
+        :param bool descending: Return documents in descending key order.
+        :param endkey: Stop returning records at this specified key.  Can be
+            either a ``str`` or, for complex keys, a ``list``.
+        :param str endkey_docid: Stop returning records when the specified
+            document id is reached.
+        :param bool group: Using the reduce function, group the results to a
+            group or single row.
+        :param group_level: Only applicable if the view uses complex keys: keys
+            that are lists. Groups reduce results for the specified number
+            of list fields.
+        :param bool include_docs: Include the full content of the documents.
+        :param bool inclusive_end: Include rows with the specified endkey.
+        :param str key: Return only documents that match the specified key.
+        :param list keys: Return only documents that match the specified keys.
+        :param int limit: Limit the number of returned documents to the
+            specified count.
+        :param bool reduce: True to use the reduce function, false otherwise.
+        :param int skip: Skip this number of rows from the start.
+        :param str stale: Allow the results from a stale view to be used. This
+            makes the request return immediately, even if the view has not been
+            completely built yet. If this parameter is not given, a response is
+            returned only after the view has been built.
+        :param startkey: Return records starting with the specified key.  Can be
+            either a ``str`` or, for complex keys, a ``list``.
+        :param str startkey_docid: Return records starting with the specified
+            document ID.
 
         :returns: The raw JSON response content for the query requested
-
         """
         view = View(DesignDocument(self, ddoc_id), view_name)
         return view(**kwargs)
 
     def create(self):
         """
-        _create_
+        Creates a database defined by the current database object, if it
+        does not already exist and raises a CloudantException if the operation
+        fails.  If the database already exists then this method call is a no-op.
 
-        Create this database if it does not exist,
-        raises a CloudantException if the operation fails.
-        Is a no-op if the database already exists
+        :returns: The database object
         """
         if self.exists():
             return self
@@ -311,7 +326,7 @@ class CouchDatabase(dict):
             return self
 
         raise CloudantException(
-            u"Unable to create database {0}: Reason:{1}".format(
+            u"Unable to create database {0}: Reason: {1}".format(
                 self.database_url, resp.text
             ),
             code=resp.status_code
@@ -319,48 +334,39 @@ class CouchDatabase(dict):
 
     def delete(self):
         """
-        _delete_
-
-        Delete this database
-
+        Delete the current database from the remote instance.
         """
         resp = self.r_session.delete(self.database_url)
         resp.raise_for_status()
 
     def all_docs(self, **kwargs):
         """
-        _all_docs_
-
         Wraps the _all_docs primary index on the database,
         and returns the results by value. This can be used
-        as a direct query to the CouchDB all_docs endpoint.
+        as a direct query to the _all_docs endpoint.
         More convenient/efficient access using slices
         and iterators can be accessed via the result attribute.
 
-        Keyword arguments supported are those of the CouchDB
-        view/index access API.
+        Keyword arguments supported are those of the view/index access API.
 
-        :param descending: Boolean. Return the documents in descending by key
-            order
-        :param endkey: string/list Stop returning records when the specified
-            key is reached
-        :param include_docs: Boolean. Include the full content of the documents
-            in the return
-        :param inclusive_end: Boolean. Include rows whose key equals the endkey
-            boolean
-        :param key: string. Return only documents that match the
-            specified key
-        :param keys: list. Return only documents that match the
-            specified keys
-        :param limit: int. Limit the number of the returned documents
-            to the specified number
-        :param skip: int. Skip this number of records before starting to
-           return the results
-        :param startkey: str/list. Start returning records when the specified
-          key matches this value
+        :param bool descending: Return documents in descending key order.
+        :param endkey: Stop returning records at this specified key.  Can be
+            either a ``str`` or, for complex keys, a ``list``.
+        :param str endkey_docid: Stop returning records when the specified
+            document id is reached.
+        :param bool include_docs: Include the full content of the documents.
+        :param bool inclusive_end: Include rows with the specified endkey.
+        :param str key: Return only documents that match the specified key.
+        :param list keys: Return only documents that match the specified keys.
+        :param int limit: Limit the number of returned documents to the
+            specified count.
+        :param int skip: Skip this number of rows from the start.
+        :param startkey: Return records starting with the specified key.  Can be
+            either a ``str`` or, for complex keys, a ``list``.
+        :param str startkey_docid: Return records starting with the specified
+            document ID.
 
-        :returns: Raw data JSON response from the all_docs endpoint containing
-          rows, counts etc.
+        :returns: Raw JSON response content from ``_all_docs`` endpoint
 
         """
         params = python_to_couch(kwargs)
@@ -377,17 +383,30 @@ class CouchDatabase(dict):
     @contextlib.contextmanager
     def custom_result(self, **options):
         """
-        _custom_result_
+        Provides a context manager that can be used to customize the
+        ``_all_docs`` behavior and wrap the output as a
+        :class:`~cloudant.result.Result`.
 
-        If you want to customise the result behaviour on all_docs
-        you can build your own with extra options to the result
-        call using this context manager.
+        :param bool descending: Return documents in descending key order.
+        :param endkey: Stop returning records at this specified key.  Can be
+            either a ``str`` or ``list``.
+        :param str endkey_docid: Stop returning records when the specified
+            document id is reached.
+        :param bool include_docs: Include the full content of the documents.
+        :param bool inclusive_end: Include rows with the specified endkey.
+        :param str key: Return only documents that match the specified key.
+        :param list keys: Return only documents that match the specified keys.
+        :param startkey: Return records starting with the specified key.  Can be
+            either a ``str`` or ``list``
+        :param str startkey_docid: Return records starting with the specified
+            document ID.
 
-        Example:
+        For example:
 
-        with database.custom_result(include_docs=True, reduce=False) as rslt:
-            data = rslt[100:200]
+        .. code-block:: python
 
+            with database.custom_result(include_docs=True) as rslt:
+                data = rslt[100:200]
         """
         rslt = Result(self.all_docs, **options)
         yield rslt
@@ -395,13 +414,17 @@ class CouchDatabase(dict):
 
     def keys(self, remote=False):
         """
-        _keys_
+        Retrieves the list of document ids in the database.  Default is
+        to return only the locally cached document ids, specify remote=True
+        to make a remote request to include all document ids from the remote
+        database instance.
 
-        return the list of document ids in the database
+        :param bool remote: Dictates whether the list of locally cached
+            document ids are returned or a remote request is made to include
+            an up to date list of document ids from the server.
+            Defaults to False.
 
-        :param remote: If False will use the local in memory copy
-          of the document, if True will call out to the DB
-
+        :returns: List of document ids
         """
         if not remote:
             return super(CouchDatabase, self).keys()
@@ -410,10 +433,14 @@ class CouchDatabase(dict):
 
     def changes(self, since=None, continuous=True, include_docs=False):
         """
-        Implement streaming from changes feed. Yields any changes that occur.
+        Streams data from _changes feed. Yields information about
+        changes that have been made.
 
-        @param str since: Start from this sequence
-        @param boolean continuous: Stream results?
+        :param str since: Change streaming starts from this sequence identifier.
+        :param bool continuous: Dictates the streaming of data.
+            Defaults to True.
+
+        :returns: Iterable stream of changes
         """
         changes_feed = Feed(
             self.r_session,
@@ -429,8 +456,24 @@ class CouchDatabase(dict):
 
     def __getitem__(self, key):
         """
-        override [] operator access to return the
-        appropriate instance of Document
+        Overrides dictionary __getitem__ behavior to provide a document
+        instance for the specified key from the current database.
+
+        If the document instance does not exist locally, then a remote request
+        is made and the document is subsequently added to the local cache and
+        returned to the caller.
+
+        If the document instance already exists locally then it is returned and
+        a remote request is not performed.
+
+        A KeyError will result if the document does not exist locally or in the
+        remote database.
+
+        :param str key: Document id used to retrieve the document from the
+            database.
+
+        :returns: A Document or DesignDocument object depending on the
+            specified document id (key)
         """
         if key in self.keys():
             return super(CouchDatabase, self).__getitem__(key)
@@ -447,17 +490,21 @@ class CouchDatabase(dict):
 
     def __iter__(self, remote=True):
         """
-        ___iter___ wrapper around dict.__iter__
+        Overrides dictionary __iter__ behavior to provide iterable Document
+        results.  By default, Documents are fetched from the remote database,
+        in batches equal to the database object's defined ``fetch_limit``,
+        yielding Document/DesignDocument objects.
 
-        By default, fetch docs from couch, in batches equal to
-        self._fetch_limit, yielding results as we get them.
+        If ``remote=False`` then the locally cached Document objects are
+        iterated over with no attempt to retrieve documents from the remote
+        database.
 
-        Otherwise, pass through to built-in __iter__.
+        :param bool remote: Dictates whether the locally cached
+            Document objects are returned or a remote request is made to
+            retrieve Document objects from the remote database.
+            Defaults to True.
 
-        @param boolean remote: Governs default behavior of freshly
-            fetching docs from couch (if True), or just digging through
-            locally cached docs (if False)
-
+        :returns: Iterable of Document and/or DesignDocument objects
         """
         if not remote:
             super(CouchDatabase, self).__iter__()
@@ -499,15 +546,15 @@ class CouchDatabase(dict):
 
     def bulk_docs(self, docs):
         """
-        _bulk_docs_
+        Performs multiple document inserts and/or updates through a single
+        request.  Each document must either be or extend a dict as
+        is the case with Document and DesignDocument objects.  A document
+        must contain the ``_id`` and ``_rev`` fields if the document
+        is meant to be updated.
 
-        Using the _bulk_docs endpoint, POST multiple documents for
-        insert/update through a single request.  Each document must
-        be a dict containing _id and _rev if the included document
-        is being updated.
+        :param list docs: List of Documents to be created/updated.
 
-        :param list docs: List of documents to be created/updated
-
+        :returns: Bulk document creation/update status in JSON format
         """
         url = posixpath.join(self.database_url, '_bulk_docs')
         data = {'docs': docs}
@@ -522,14 +569,15 @@ class CouchDatabase(dict):
 
     def missing_revisions(self, doc_id, *revisions):
         """
-        _missing_revisions_
+        Returns a list of document revision values that do not exist in the
+        current remote database for the specified document id and specified
+        list of revision values.
 
-        Given a document id and list of document revisions, returns the
-          document revisions that do not exist in the database
+        :param str doc_id: Document id to check for missing revisions against.
+        :param list revisions: List of document revisions values to check
+            against.
 
-        :param doc_id: document _id to check for missing revisions on
-        :param revisions: document _revs to check
-
+        :returns: List of missing document revision values
         """
         url = posixpath.join(self.database_url, '_missing_revs')
         data = {doc_id: list(revisions)}
@@ -550,14 +598,15 @@ class CouchDatabase(dict):
 
     def revisions_diff(self, doc_id, *revisions):
         """
-        _revisions_diff_
+        Returns the differences in the current remote database for the specified
+        document id and specified list of revision values.
 
-        Given a list of document revisions, returns differences between the
-          given revisions and ones that are in the database
+        :param str doc_id: Document id to check for revision differences
+            against.
+        :param list revisions: List of document revisions values to check
+            against.
 
-        :param doc_id: document _id to check for revision differences on
-        :param revisions: document _revs to check
-
+        :returns: The revision differences in JSON format
         """
         url = posixpath.join(self.database_url, '_revs_diff')
         data = {doc_id: list(revisions)}
@@ -573,11 +622,10 @@ class CouchDatabase(dict):
 
     def get_revision_limit(self):
         """
-        _get_revision_limit_
+        Retrieves the limit of historical revisions to store for any single
+        document in the current remote database.
 
-        Gets the limit of historical revisions to store for a single document
-          in the database
-
+        :returns: Revision limit value for the current remote database
         """
         url = posixpath.join(self.database_url, '_revs_limit')
         resp = self.r_session.get(url)
@@ -595,13 +643,13 @@ class CouchDatabase(dict):
 
     def set_revision_limit(self, limit):
         """
-        _set_revision_limit_
+        Sets the limit of historical revisions to store for any single document
+        in the current remote database.
 
-        Sets the limit of historical revisions to store for a single document
-          in the database
+        :param int limit: Number of revisions to store for any single document
+            in the current remote database.
 
-        :param int limit: Number of revisions to store for a document
-
+        :returns: Revision limit set operation status in JSON format
         """
         url = posixpath.join(self.database_url, '_revs_limit')
 
@@ -612,10 +660,10 @@ class CouchDatabase(dict):
 
     def view_cleanup(self):
         """
-        _view_cleanup_
+        Removes view files that are not used by any design document in the
+        remote database.
 
-        Removes view files that are not used by any design document
-
+        :returns: View cleanup status in JSON format
         """
         url = posixpath.join(self.database_url, '_view_cleanup')
         resp = self.r_session.post(
@@ -628,31 +676,30 @@ class CouchDatabase(dict):
 
 class CloudantDatabase(CouchDatabase):
     """
-    _CloudantDatabase_
+    Encapsulates a Cloudant database.  A CloudantDatabase object is
+    instantiated with a reference to a client/session.
+    It supports accessing the documents, and various database
+    features such as the document indexes, changes feed, design documents, etc.
 
-    Extend the base CouchDB database to include additional
-    Cloudant database features
-
+    :param Cloudant client: Client instance used by the database.
+    :param str database_name: Database name used to reference the database.
+    :param int fetch_limit: Optional fetch limit used to set the max number of
+        documents to fetch per query during iteration cycles.  Defaults to 100.
     """
-    def __init__(self, cloudant, database_name, fetch_limit=100):
+    def __init__(self, client, database_name, fetch_limit=100):
         super(CloudantDatabase, self).__init__(
-            cloudant,
+            client,
             database_name,
             fetch_limit=100
         )
 
     def security_document(self):
         """
-        _security_document_
+        Retrieves the security document for the current database
+        containing information about the users that the database
+        is shared with.
 
-        Fetch the security document for this database
-        which contains information about who the database
-        is shared with
-
-        GET _api/v2/db/<dbname>/_security
-
-        :returns: Security doc JSON data
-
+        :returns: Security document in JSON format
         """
         resp = self.r_session.get(self.security_url)
         resp.raise_for_status()
@@ -660,27 +707,30 @@ class CloudantDatabase(CouchDatabase):
 
     @property
     def security_url(self):
-        """construct the URL of the security document for this db"""
+        """
+        Constructs and returns the security document URL.
+
+        :returns: Security document URL
+        """
         parts = ['_api', 'v2', 'db', self.database_name, '_security']
         url = posixpath.join(self._database_host, *parts)
         return url
 
     def share_database(self, username, reader=True, writer=False, admin=False):
         """
-        _share_database_
-
-        Share this database with the username provided.
+        Shares the current remote database with the username provided.
         You can grant varying degrees of access rights,
         default is to share read-only, but writing or admin
         permissions can be added by setting the appropriate flags
         If the user already has this database shared with them it
-        will modify/overwrite the existing permissions
+        will modify/overwrite the existing permissions.
 
-        :param username: Cloudant Username to share the database with
-        :param reader: Grant named user read access if true
-        :param writer: Grant named user write access if true
-        :param admin: Grant named user admin access if true
+        :param str username: Cloudant user to share the database with.
+        :param bool reader: Grant named user read access if True.
+        :param bool writer: Grant named user write access if True.
+        :param bool admin: Grant named user admin access if True.
 
+        :returns: Share database status in JSON format
         """
         doc = self.security_document()
         data = doc.get('cloudant', {})
@@ -704,13 +754,15 @@ class CloudantDatabase(CouchDatabase):
 
     def unshare_database(self, username):
         """
-        _unshare_database_
-
-        Remove all sharing with the named user for this database.
-        This will remove the entry for the user from the security doc.
+        Removes all sharing with the named user for the current remote database.
+        This will remove the entry for the user from the security document.
         To modify permissions, use the
-        :func:`~database.CloudantDatabase.share_database` method instead.
+        :func:`~cloudant.database.CloudantDatabase.share_database` method
+        instead.
 
+        :param str username: Cloudant user to unshare the database from.
+
+        :returns: Unshare database status in JSON format
         """
         doc = self.security_document()
         data = doc.get('cloudant', {})
@@ -727,10 +779,9 @@ class CloudantDatabase(CouchDatabase):
 
     def shards(self):
         """
-        _shards_
+        Retrieves information about the shards in the current remote database.
 
-        Returns information about the shards in a database
-
+        :returns: Shard information retrieval status in JSON format
         """
         url = posixpath.join(self.database_url, '_shards')
         resp = self.r_session.get(url)


### PR DESCRIPTION
_What:_

Clean up the content found in docstrings throughout the codebase.  Session context helpers, account, changes, credentials, and database modules have been cleaned up in this PR.  Additional PR to follow with the remainder of the cleaned up docstring content.

_Why:_

In order for the documentation to appear as desired on readthedocs.org we needed to update the docstring content accordingly.

_How:_

Changes have been made to Session context helpers, account, changes, credentials, and database modules.  The changes made looked to standardize the way in which we presented each class and their methods to provide a more consistent look and feel to the documentation.

reviewer: @emlaver 
reviewer: @ricellis

BugId: 57063