### PR TITLE
Clean up docstring content part #2

### DIFF
--- a/src/cloudant/errors.py
+++ b/src/cloudant/errors.py
@@ -13,17 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-_errors_
-
-Common exception classes for Cloudant Python client
-
+Module that contains common exception classes for the Cloudant Python client
+library.
 """
-
 
 class CloudantException(Exception):
     """
-    _CloudantException_
+    Provides a way to issue Cloudant Python client library specific exceptions.
+    A CloudantException object is instantiated with a message and optional code.
 
+    Note:  The intended use for this class is internal to the Cloudant Python
+    client library.
+
+    :param str msg: A message that describes the exception.
+    :param int code: A code value used to identify the exception.
     """
     def __init__(self, msg, code=None):
         super(CloudantException, self).__init__(msg)
@@ -32,8 +35,17 @@ class CloudantException(Exception):
 
 class CloudantArgumentError(CloudantException):
     """
-    Exception class used to indicate an invalid argument being passed
-    to a CouchDB API
+    Provides a way to issue Cloudant Python client library specific exceptions
+    that pertain to invalid argument errors.  A CloudantArgumentError object is
+    instantiated with a message and optional code where the code defaults to
+    400.
+
+    Note:  The intended use for this class is internal to the Cloudant Python
+    client library.
+
+    :param str msg: A message that describes the exception.
+    :param int code: An optional code value used to identify the exception.
+        Defaults to 400.
     """
     def __init__(self, msg, code=400):
         super(CloudantArgumentError, self).__init__(msg, code)

--- a/src/cloudant/views.py
+++ b/src/cloudant/views.py
@@ -13,31 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-_views_
-
-Utilities for handling design docs and the resulting views they create
-
+API module for interacting with a view in a design document.
 """
 import contextlib
 import posixpath
 
 from .result import Result, python_to_couch
 
-
 class Code(str):
     """
-    _Code_
-
-    string derived object that allows us to wrap/manipulate javascript blobs
-
+    Wraps a ``str`` object as a Code object providing the means to handle
+    Javascript blob content.  Used internally by the View object when
+    codifying map and reduce Javascript content.
     """
-    def __init__(self, s):
-        super(Code, self).__init__(s)
-
+    def __init__(self, code):
+        super(Code, self).__init__(code)
 
 def _codify(code_or_str):
     """
-    helper to rationalise None, str or Code objects
+    Provides a helper to rationalize code content.
     """
     if code_or_str is None:
         return None
@@ -45,54 +39,67 @@ def _codify(code_or_str):
         return Code(code_or_str)
     return code_or_str
 
-
 class View(dict):
     """
-    Dictionary based object representing a view, exposing the map, reduce
-    functions as attributes and supporting query/data access via the view
+    Encapsulates a view as a dictionary based object, exposing the map and
+    reduce functions as attributes and supporting query/data access through
+    the view.  A View object is instantiated with a reference to a
+    DesignDocument and is typically used as part of the
+    :class:`~cloudant.design_document.DesignDocument` view management API.
 
-    Provides a sliceable and iterable default result collection that can
-    be used to query the view data via the result attribute.
-
-    Eg:
-
-    Using integers to skip/limit:
-    view.result[100:200]
-    view.result[:200]
-    view.result[100:]
-
-    Using strings or lists as startkey/endkey:
-
-    view.result[ ["2013","10"]:["2013","11"] ]
-    view.result[["2013","10"]]
-    view.result[["2013","10"]:]
-
-    For large views, iteration is supported via result:
-
-    for doc in view.result:
-        print doc
-
-    The default result collection provides basic functionality,
-    which can be customised with other arguments to the view URL
-    using the custom_result context.
+    A View object provides a sliceable and iterable default result collection
+    that can be used to query the view data through the ``result`` attribute.
 
     For example:
 
-    #including documents
-    with view.custom_result(include_docs=True) as rslt:
-        rslt[100:200] # slice by result
-        rslt[["2013","10"]:["2013","11"]] # slice by startkey/endkey
+    .. code-block:: python
 
-        #iteration
-        for doc in rslt:
+        # Using integers to skip/limit:
+        view.result[100:200]
+        view.result[:200]
+        view.result[100:]
+
+        # Using strings or lists as startkey/endkey:
+        view.result[['2013','10']:['2013','11']]
+        view.result[['2013','10']]
+        view.result[['2013','10']:]
+
+        # Iteration is supported via the result attribute:
+        for doc in view.result:
             print doc
 
-    Iteration over a view within startkey/endkey range:
+    The default ``result`` collection provides basic functionality,
+    which can be customized with other arguments using the
+    :func:`~cloudant.views.View.custom_result` context.
 
-    with view.custom_result(startkey="2013", endkey="2014") as rslt:
-        for doc in rslt:
-            print doc
+    For example:
 
+    .. code-block:: python
+
+        # Including documents as part of a custom result
+        with view.custom_result(include_docs=True) as rslt:
+            rslt[100:200] # slice by result
+            rslt[['2013','10']:['2013','11']] # slice by startkey/endkey
+
+            # Iteration
+            for doc in rslt:
+                print doc
+
+        # Iteration over a view within startkey/endkey range:
+        with view.custom_result(startkey='2013', endkey='2014') as rslt:
+            for doc in rslt:
+                print doc
+
+    Note:  A view must exist as part of a design document remotely in order to
+    access result content as depicted in the above examples.
+
+    :param DesignDocument ddoc: DesignDocument instance used in part to
+        identify the view.
+    :param str view_name: Name used in part to identify the view.
+    :param str map_func: Optional Javascript map function.  Can also be a
+        :class:`~cloudant.views.Code` object.
+    :param str reduce_func: Optional Javascript reduce function.  Can also be a
+        :class:`~cloudant.views.Code` object.
     """
     def __init__(self, ddoc, view_name, map_func=None, reduce_func=None):
         super(View, self).__init__()
@@ -107,27 +114,68 @@ class View(dict):
 
     @property
     def map(self):
-        """map property getter"""
+        """
+        Provides an map property accessor and setter.  A ``str`` or a ``Code``
+        object is acceptable when setting the map property.
+
+        For example:
+
+        .. code-block:: python
+
+            # Set the View map property
+            view.map = 'function (doc) {\\n  emit(doc._id, 1);\\n}'
+            print view.map
+
+        :param str js_func: Javascript function.  Can also be a
+            :class:`~cloudant.views.Code` object.
+
+        :returns: Codified map function
+        """
         return self.get('map')
 
     @map.setter
     def map(self, js_func):
-        """map property setter, accepts str or Code obj"""
+        """
+        Provides a map property setter, accepts ``str`` or ``Code`` object.
+        """
         self['map'] = _codify(js_func)
 
     @property
     def reduce(self):
-        """reduce property getter"""
+        """
+        Provides an reduce property accessor and setter.  A ``str`` or a
+        ``Code`` object is acceptable when setting the reduce property.
+
+        For example:
+
+        .. code-block:: python
+
+            # Set the View reduce property
+            view.reduce = '_count'
+            # Get and print the View reduce property
+            print view.reduce
+
+        :param str js_func: Javascript function.  Can also be a
+            :class:`~cloudant.views.Code` object.
+
+        :returns: Codified map function
+        """
         return self.get('reduce')
 
     @reduce.setter
     def reduce(self, js_func):
-        """reduce property setter, accepts str or Code obj"""
+        """
+        Provides a reduce property setter, accepts ``str`` or ``Code`` object.
+        """
         self['reduce'] = _codify(js_func)
 
     @property
     def url(self):
-        """property that builds the view URL"""
+        """
+        Constructs and returns the View URL.
+
+        :returns: View URL
+        """
         return posixpath.join(
             self.design_doc.document_url,
             '_view',
@@ -136,24 +184,54 @@ class View(dict):
 
     def __call__(self, **kwargs):
         """
-        retrieve data from the view, using the kwargs provided
-        as query parameters
+        Makes the View object callable and retrieves the raw JSON content
+        from the remote database based on the View definition on the server,
+        using the kwargs provided as query parameters.
 
-        descending bool
-        endkey string or array
-        endkey_docid  string
-        group bool
-        group_level ??
-        include_docs bool
-        inclusive_end  bool
-        key string
-        limit   int
-        reduce  boolean
-        skip    int
-        stale   enum(ok, update_after)
-        startkey  string or array
-        startkey_docid  string
+        For example:
 
+        .. code-block:: python
+
+            # Construct a View
+            view = View(ddoc, 'view001')
+            # Assuming that 'view001' exists as part of the
+            # design document ddoc in the remote database...
+            # Use view as a callable
+            for row in view(include_docs=True, limit=100, skip=100)['rows']:
+                # Process view data (in JSON format).
+
+        Note:  Rather than using the View callable directly, if you wish to
+        retrieve view results in raw JSON format use the provided database API
+        of :func:`~cloudant.database.CouchDatabase.get_view_raw_result` instead.
+
+        :param bool descending: Return documents in descending key order.
+        :param endkey: Stop returning records at this specified key.  Can be
+            either a ``str`` or ``list``.
+        :param str endkey_docid: Stop returning records when the specified
+            document id is reached.
+        :param bool group: Using the reduce function, group the results to a
+            group or single row.
+        :param group_level: Only applicable if the view uses complex keys: keys
+            that are JSON arrays. Groups reduce results for the specified number
+            of array fields.
+        :param bool include_docs: Include the full content of the documents.
+        :param bool inclusive_end: Include rows with the specified endkey.
+        :param str key: Return only documents that match the specified key.
+        :param list keys: Return only documents that match the specified keys.
+        :param int limit: Limit the number of returned documents to the
+            specified count.
+        :param bool reduce: True to use the reduce function, false otherwise.
+        :param int skip: Skip this number of rows from the start.
+        :param str stale: Allow the results from a stale view to be used. This
+            makes the request return immediately, even if the view has not been
+            completely built yet. If this parameter is not given, a response is
+            returned only after the view has been built.
+        :param startkey: Return records starting with the specified key.  Can be
+            either a ``str`` or ``list``
+        :param str startkey_docid: Return records starting with the specified
+            document ID.
+
+        :returns: View result data in JSON format
         """
         params = python_to_couch(kwargs)
         resp = self._r_session.get(self.url, params=params)
@@ -162,25 +240,85 @@ class View(dict):
 
     def make_result(self, **options):
         """
-        Wrap the call to get result data in a Result object.
+        Wraps the raw JSON content of the View object callable in a
+        :class:`~cloudant.result.Result` object.  The use of ``skip``
+        and ``limit`` as options are not valid when using a Result since the
+        ``skip`` and ``limit`` functionality is handled in the Result.
 
+        Note:  Rather than using this method directly, if you wish to
+        retrieve view data as a Result object, use the provided database
+        API of :func:`~cloudant.database.CouchDatabase.get_view_result` instead.
+
+        :param bool descending: Return documents in descending key order.
+        :param endkey: Stop returning records at this specified key.  Can be
+            either a ``str`` or ``list``.
+        :param str endkey_docid: Stop returning records when the specified
+            document id is reached.
+        :param bool group: Using the reduce function, group the results to a
+            group or single row.
+        :param group_level: Only applicable if the view uses complex keys: keys
+            that are JSON arrays. Groups reduce results for the specified number
+            of array fields.
+        :param bool include_docs: Include the full content of the documents.
+        :param bool inclusive_end: Include rows with the specified endkey.
+        :param str key: Return only documents that match the specified key.
+        :param list keys: Return only documents that match the specified keys.
+        :param bool reduce: True to use the reduce function, false otherwise.
+        :param str stale: Allow the results from a stale view to be used. This
+            makes the request return immediately, even if the view has not been
+            completely built yet. If this parameter is not given, a response is
+            returned only after the view has been built.
+        :param startkey: Return records starting with the specified key.  Can be
+            either a ``str`` or ``list``
+        :param str startkey_docid: Return records starting with the specified
+            document ID.
+
+        :returns: View result data wrapped in a Result instance
         """
         return Result(self, **options)
 
     @contextlib.contextmanager
     def custom_result(self, **options):
         """
-        _custom_result_
+        Customizes the :class:`~cloudant.result.Result` behavior and provides
+        a convenient context manager for the Result.  Result customizations
+        can be made by providing extra options to the result call using this
+        context manager.  The use of ``skip`` and ``limit`` as options are not
+        valid when using a Result since the ``skip`` and ``limit``
+        functionality is handled in the Result.
 
-        If you want to customise the result behaviour,
-        you can build your own with extra options to the result
-        call using this context manager.
+        For example:
 
-        Example:
+        .. code-block:: python
 
-        with view.custom_result(include_docs=True, reduce=False) as rslt:
-            data = rslt[100:200]
+            with view.custom_result(include_docs=True, reduce=False) as rslt:
+                data = rslt[100:200]
 
+        :param bool descending: Return documents in descending key order.
+        :param endkey: Stop returning records at this specified key.  Can be
+            either a ``str`` or ``list``.
+        :param str endkey_docid: Stop returning records when the specified
+            document id is reached.
+        :param bool group: Using the reduce function, group the results to a
+            group or single row.
+        :param group_level: Only applicable if the view uses complex keys: keys
+            that are JSON arrays. Groups reduce results for the specified number
+            of array fields.
+        :param bool include_docs: Include the full content of the documents.
+        :param bool inclusive_end: Include rows with the specified endkey.
+        :param str key: Return only documents that match the specified key.
+        :param list keys: Return only documents that match the specified keys.
+        :param bool reduce: True to use the reduce function, false otherwise.
+        :param str stale: Allow the results from a stale view to be used. This
+            makes the request return immediately, even if the view has not been
+            completely built yet. If this parameter is not given, a response is
+            returned only after the view has been built.
+        :param startkey: Return records starting with the specified key.  Can be
+            either a ``str`` or ``list``
+        :param str startkey_docid: Return records starting with the specified
+            document ID.
+
+        :returns: View result data wrapped in a Result instance
         """
         rslt = self.make_result(**options)
         yield rslt


### PR DESCRIPTION
_What:_

Clean up the content found in docstrings throughout the codebase.  design_document, document, errors, replicator, result, and views modules have been cleaned up in this PR.  This is part two of a two part PR.  Part one can be found at https://github.com/cloudant/python-cloudant/pull/34.

_Why:_

In order for the documentation to appear as desired on readthedocs.org we needed to update the docstring content accordingly.

_How:_

Changes have been made to design_document, document, errors, replicator, result, and views modules.  The changes made looked to standardize the way in which we presented each class and their methods to provide a more consistent look and feel to the documentation.

BugId: 57063

reviewer: @rhyshort
reviewer: @brynh