### PR TITLE
Add query execution support - part two (tests)

### DIFF
--- a/src/cloudant/query.py
+++ b/src/cloudant/query.py
@@ -178,13 +178,13 @@ class Query(dict):
                 raise CloudantArgumentError(msg)
         if data.get('selector', None) is None or data.get('selector') == {}:
             msg = (
-                'No selector in the query.  '
+                'No selector in the query or the selector was empty.  '
                 'Add a selector to define the query and retry.'
             )
             raise CloudantArgumentError(msg)
         if data.get('fields', None) is None or data.get('fields') == []:
             msg = (
-                'No fields list in the query.  '
+                'No fields list in the query or the fields list was empty.  '
                 'Add a list of fields for the query and retry.'
             )
             raise CloudantArgumentError(msg)

--- a/tests/unit/db/query_result_tests.py
+++ b/tests/unit/db/query_result_tests.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python
+# Copyright (c) 2015 IBM. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for the QueryResult class tested against Cloudant only.
+
+See configuration options for environment variables in unit_t_db_base
+module docstring.
+
+"""
+
+import unittest
+import os
+import posixpath
+import requests
+
+from cloudant.query import Query
+from cloudant.result import QueryResult
+from cloudant.errors import CloudantArgumentError
+
+from unit_t_db_base import UnitTestDbBase
+
+@unittest.skipUnless(
+    os.environ.get('RUN_CLOUDANT_TESTS') is not None,
+    'Skipping Cloudant QueryResult tests'
+    )
+class QueryResultTests(UnitTestDbBase):
+    """
+    QueryResult unit tests
+    """
+
+    def setUp(self):
+        """
+        Set up test attributes
+        """
+        super(QueryResultTests, self).setUp()
+        self.db_set_up()
+
+    def tearDown(self):
+        """
+        Reset test attributes
+        """
+        self.db_tear_down()
+        super(QueryResultTests, self).tearDown()
+
+    def test_constructor_with_options(self):
+        """
+        Test instantiating a QueryResult by passing in query parameters
+        """
+        query = Query(self.db)
+        result = QueryResult(query, foo='bar', page_size=10)
+        self.assertIsInstance(result, QueryResult)
+        self.assertEqual(result.options, {'foo': 'bar'})
+        self.assertEqual(result._ref, query)
+        self.assertEqual(result._page_size, 10)
+
+    def test_constructor_without_options(self):
+        """
+        Test instantiating a Query without parameters
+        """
+        query = Query(self.db)
+        result = QueryResult(query)
+        self.assertIsInstance(result, QueryResult)
+        self.assertEqual(result.options, {})
+        self.assertEqual(result._ref, query)
+        self.assertEqual(result._page_size, 100)
+
+    def test_slicing_with_skip_option_fails(self):
+        """
+        Test __getitem__() fails when "skip" option is provided
+        """
+        self.populate_db_with_documents(100)
+        result = QueryResult(
+            Query(self.db),
+            selector={'_id': {'$gt': 0}},
+            fields=['_id', '_rev'],
+            skip=10
+        )
+        try:
+            docs = result[:]
+            self.fail('Above statement should raise an Exception')
+        except CloudantArgumentError, err:
+            self.assertEqual(
+                str(err),
+                'Cannot use skip parameter with QueryResult slicing.'
+            )
+
+    def test_slicing_with_limit_option_fails(self):
+        """
+        Test __getitem__() fails when "limit" option is provided
+        """
+        self.populate_db_with_documents(100)
+        result = QueryResult(
+            Query(self.db),
+            selector={'_id': {'$gt': 0}},
+            fields=['_id', '_rev'],
+            limit=10
+        )
+        try:
+            docs = result[:]
+            self.fail('Above statement should raise an Exception')
+        except CloudantArgumentError, err:
+            self.assertEqual(
+                str(err),
+                'Cannot use limit parameter with QueryResult slicing.'
+            )
+
+    def test_slicing_with_start(self):
+        """
+        Test __getitem__() handles when only a start value is provided
+        """
+        self.populate_db_with_documents(100)
+        result = QueryResult(
+            Query(self.db),
+            selector={'_id': {'$gt': 0}},
+            fields=['_id', '_rev']
+        )
+        self.assertEqual(result[95:], result[95:100])
+        self.assertEqual(
+            [doc['_id'] for doc in result[95:]],
+            ['julia095', 'julia096', 'julia097', 'julia098', 'julia099']
+        )
+
+    def test_slicing_with_stop(self):
+        """
+        Test __getitem__() handles when only a stop value is provided
+        """
+        self.populate_db_with_documents(100)
+        result = QueryResult(
+            Query(self.db),
+            selector={'_id': {'$gt': 0}},
+            fields=['_id', '_rev']
+        )
+        self.assertEqual(result[:5], result[0:5])
+        self.assertEqual(
+            [doc['_id'] for doc in result[:5]],
+            ['julia000', 'julia001', 'julia002', 'julia003', 'julia004']
+        )
+
+    def test_slicing_without_start_stop(self):
+        """
+        Test __getitem__() handles when neither a start or a stop value is
+        provided
+        """
+        self.populate_db_with_documents(100)
+        result = QueryResult(
+            Query(self.db),
+            selector={'_id': {'$gt': 0}},
+            fields=['_id', '_rev']
+        )
+        self.assertEqual(result[:], result[0:100])
+        self.assertEqual(len(result[:]), 100)
+        i = 0
+        for doc in result[:]:
+            self.assertEqual(doc['_id'], 'julia{0:03d}'.format(i))
+            i += 1
+        self.assertEqual(i, 100)
+
+    def test_slicing_with_start_stop(self):
+        """
+        Test __getitem__() handles when both a start and stop values are
+        provided
+        """
+        self.populate_db_with_documents(100)
+        result = QueryResult(
+            Query(self.db),
+            selector={'_id': {'$gt': 0}},
+            fields=['_id', '_rev']
+        )
+        self.assertEqual(
+            [doc['_id'] for doc in result[5:10]],
+            ['julia005', 'julia006', 'julia007', 'julia008', 'julia009']
+        )
+
+    def test_slicing_with_same_start_stop(self):
+        """
+        Test __getitem__() handles when both a start and stop values are same
+        """
+        self.populate_db_with_documents(100)
+        result = QueryResult(
+            Query(self.db),
+            selector={'_id': {'$gt': 0}},
+            fields=['_id', '_rev']
+        )
+        self.assertEqual(result[5:5], [])
+
+    def test_slicing_with_start_gt_stop(self):
+        """
+        Test __getitem__() fails when start int value > stop int value
+        """
+        self.populate_db_with_documents(100)
+        result = QueryResult(
+            Query(self.db),
+            selector={'_id': {'$gt': 0}},
+            fields=['_id', '_rev']
+        )
+        try:
+            docs = result[10:5]
+            self.fail('Above statement should raise an Exception')
+        except requests.HTTPError, err:
+            self.assertEqual(err.response.status_code, 400)
+
+    def test_key_access_is_not_supported(self):
+        """
+        Test __getitem__() fails when a key value is provided
+        """
+        self.populate_db_with_documents(100)
+        result = QueryResult(
+            Query(self.db),
+            selector={'_id': {'$gt': 0}},
+            fields=['_id', '_rev']
+        )
+        try:
+            docs = result['julia006']
+            self.fail('Above statement should raise an Exception')
+        except CloudantArgumentError, err:
+            self.assertEqual(
+                str(err),
+                'Failed to interpret the argument julia006 as an element slice.'
+                '  Only slicing by integer values is supported with '
+                'QueryResult.__getitem__.'
+            )
+
+    def test_non_integer_value_slicing_is_not_supported(self):
+        """
+        Test __getitem__() fails when non-integer values for start and stop are
+        provided
+        """
+        self.populate_db_with_documents(100)
+        result = QueryResult(
+            Query(self.db),
+            selector={'_id': {'$gt': 0}},
+            fields=['_id', '_rev']
+        )
+        try:
+            docs = result['julia006': 'julia010']
+            self.fail('Above statement should raise an Exception')
+        except CloudantArgumentError, err:
+            self.assertEqual(
+                str(err),
+                'Failed to interpret the argument '
+                'slice(\'julia006\', \'julia010\', None) as an element slice.'
+                '  Only slicing by integer values is supported with '
+                'QueryResult.__getitem__.'
+            )
+
+    def test_iteration_with_skip_option_fails(self):
+        """
+        Test __iter__() fails when "skip" option is provided
+        """
+        self.populate_db_with_documents(100)
+        result = QueryResult(
+            Query(self.db),
+            selector={'_id': {'$gt': 0}},
+            fields=['_id', '_rev'],
+            skip=10
+        )
+        try:
+            for doc in result:
+                self.fail('Above statement should raise an Exception')
+        except CloudantArgumentError, err:
+            self.assertEqual(
+                str(err),
+                'Cannot use skip for iteration'
+            )
+
+    def test_iteration_with_limit_option_fails(self):
+        """
+        Test __iter__() fails when "limit" option is provided
+        """
+        self.populate_db_with_documents(100)
+        result = QueryResult(
+            Query(self.db),
+            selector={'_id': {'$gt': 0}},
+            fields=['_id', '_rev'],
+            limit=10
+        )
+        try:
+            for doc in result:
+                self.fail('Above statement should raise an Exception')
+        except CloudantArgumentError, err:
+            self.assertEqual(
+                str(err),
+                'Cannot use limit for iteration'
+            )
+
+    def test_iteration_invalid_page_size(self):
+        """
+        Test __iter__() fails as expected when page_size is set to 0 or less
+        """
+        self.populate_db_with_documents(5)
+        result = QueryResult(
+            Query(self.db),
+            selector={'_id': {'$gt': 0}},
+            fields=['_id', '_rev'],
+            page_size=0
+        )
+        try:
+            for doc in result:
+                self.fail('Above statement should raise an Exception')
+        except CloudantArgumentError, err:
+            self.assertEqual(str(err), 'Invalid page_size: 0')
+
+    def test_iteration_result_eq_page_size(self):
+        """
+        Test __iter__() works as expected when the result size is equal to the
+        page_size
+        """
+        self.populate_db_with_documents(5)
+        result = QueryResult(
+            Query(self.db),
+            selector={'_id': {'$gt': 0}},
+            fields=['_id', '_rev'],
+            page_size=5
+        )
+        self.assertEqual(
+            [doc['_id'] for doc in result],
+            ['julia000', 'julia001', 'julia002', 'julia003', 'julia004']
+        )
+
+    def test_iteration_result_gt_page_size(self):
+        """
+        Test __iter__() works as expected when the result size is more than the
+        page_size
+        """
+        self.populate_db_with_documents(5)
+        result = QueryResult(
+            Query(self.db),
+            selector={'_id': {'$gt': 0}},
+            fields=['_id', '_rev'],
+            page_size=3
+        )
+        self.assertEqual(
+            [doc['_id'] for doc in result],
+            ['julia000', 'julia001', 'julia002', 'julia003', 'julia004']
+        )
+
+    def test_iteration_result_lt_page_size(self):
+        """
+        Test __iter__() works as expected when the result size is less than the
+        page_size
+        """
+        self.populate_db_with_documents(5)
+        result = QueryResult(
+            Query(self.db),
+            selector={'_id': {'$gt': 0}},
+            fields=['_id', '_rev'],
+            page_size=100
+        )
+        self.assertEqual(
+            [doc['_id'] for doc in result],
+            ['julia000', 'julia001', 'julia002', 'julia003', 'julia004']
+        )
+
+    def test_iteration_no_results(self):
+        """
+        Test __iter__() returns empty result set when no results are found
+        """
+        self.populate_db_with_documents(5)
+        result = QueryResult(
+            Query(self.db),
+            selector={'_id': {'$lt': 0}},
+            fields=['_id', '_rev'],
+            page_size=100
+        )
+        self.assertEqual([doc['_id'] for doc in result], [])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/db/query_tests.py
+++ b/tests/unit/db/query_tests.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python
+# Copyright (c) 2015 IBM. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for the Query class tested against Cloudant only.
+
+See configuration options for environment variables in unit_t_db_base
+module docstring.
+
+"""
+
+import unittest
+import os
+import posixpath
+
+from cloudant.query import Query
+from cloudant.result import QueryResult
+from cloudant.errors import CloudantArgumentError
+
+from unit_t_db_base import UnitTestDbBase
+
+@unittest.skipUnless(
+    os.environ.get('RUN_CLOUDANT_TESTS') is not None,
+    'Skipping Cloudant Query tests'
+    )
+class QueryTests(UnitTestDbBase):
+    """
+    Query unit tests
+    """
+
+    def setUp(self):
+        """
+        Set up test attributes
+        """
+        super(QueryTests, self).setUp()
+        self.db_set_up()
+
+    def tearDown(self):
+        """
+        Reset test attributes
+        """
+        self.db_tear_down()
+        super(QueryTests, self).tearDown()
+
+    def test_constructor_with_kwargs(self):
+        """
+        Test instantiating a Query by passing in query parameters
+        """
+        query = Query(self.db, foo={'bar': 'baz'})
+        self.assertIsInstance(query, Query)
+        self.assertIsInstance(query.result, QueryResult)
+        self.assertEqual(query, {'foo': {'bar': 'baz'}})
+
+    def test_constructor_without_kwargs(self):
+        """
+        Test instantiating a Query without parameters
+        """
+        query = Query(self.db)
+        self.assertIsInstance(query, Query)
+        self.assertIsInstance(query.result, QueryResult)
+        self.assertEqual(query, {})
+
+    def test_retrieve_query_url(self):
+        """
+        Test constructing the query test url
+        """
+        query = Query(self.db)
+        self.assertEqual(
+            query.url,
+            posixpath.join(self.db.database_url, '_find')
+        )
+
+    def test_callable_with_invalid_argument(self):
+        """
+        Test Query __call__ by passing in invalid arguments
+        """
+        query = Query(self.db)
+        try:
+            query(foo={'bar': 'baz'})
+            self.fail('Above statement should raise an Exception')
+        except CloudantArgumentError, err:
+            self.assertEqual(str(err), 'Invalid argument: foo')
+
+    def test_callable_with_invalid_value_types(self):
+        """
+        Test Query __call__ by passing in invalid selector
+        """
+        test_data = [
+            {'selector': 'blah'},  # Should be a dict
+            {'limit': 'blah'},     # Should be an int
+            {'skip': 'blah'},      # Should be an int
+            {'sort': 'blah'},      # Should be a list
+            {'fields': 'blah'},    # Should be a list
+            {'r': 'blah'},         # Should be an int
+            {'bookmark': 1},       # Should be a basestring
+            {'use_index': 1}       # Should be a basestring
+        ]
+
+        for argument in test_data:
+            query = Query(self.db)
+            try:
+                query(**argument)
+                self.fail('Above statement should raise an Exception')
+            except CloudantArgumentError, err:
+                self.assertTrue(str(err).startswith(
+                    'Argument {0} is not an instance of expected type:'.format(
+                        argument.keys()[0]
+                    )
+                ))
+
+    def test_callable_without_selector(self):
+        """
+        Test Query __call__ without providing a selector
+        """
+        query = Query(self.db)
+        try:
+            query(fields=['_id', '_rev'])
+            self.fail('Above statement should raise an Exception')
+        except CloudantArgumentError, err:
+            self.assertEqual(
+                str(err),
+                'No selector in the query or the selector was empty.  '
+                'Add a selector to define the query and retry.'
+            )
+
+    def test_callable_with_empty_selector(self):
+        """
+        Test Query __call__ without providing a selector
+        """
+        query = Query(self.db)
+        try:
+            query(selector={}, fields=['_id', '_rev'])
+            self.fail('Above statement should raise an Exception')
+        except CloudantArgumentError, err:
+            self.assertEqual(
+                str(err),
+                'No selector in the query or the selector was empty.  '
+                'Add a selector to define the query and retry.'
+            )
+
+    def test_callable_without_fields(self):
+        """
+        Test Query __call__ without providing a fields list
+        """
+        query = Query(self.db)
+        try:
+            query(selector={'_id': {'$gt': 0}})
+            self.fail('Above statement should raise an Exception')
+        except CloudantArgumentError, err:
+            self.assertEqual(
+                str(err),
+                'No fields list in the query or the fields list was empty.  '
+                'Add a list of fields for the query and retry.'
+            )
+
+    def test_callable_with_empty_field_list(self):
+        """
+        Test Query __call__ without providing a fields list
+        """
+        query = Query(self.db)
+        try:
+            query(selector={'_id': {'$gt': 0}}, fields=[])
+            self.fail('Above statement should raise an Exception')
+        except CloudantArgumentError, err:
+            self.assertEqual(
+                str(err),
+                'No fields list in the query or the fields list was empty.  '
+                'Add a list of fields for the query and retry.'
+            )
+
+    def test_callable_executes_query(self):
+        """
+        Test Query __call__ executes a query
+        """
+        self.populate_db_with_documents(100)
+        query = Query(self.db)
+        resp = query(
+            selector={'_id': {'$lt': 'julia050'}},
+            fields=['_id'],
+            sort=[{'_id': 'desc'}],
+            skip=10,
+            limit=3,
+            r=1
+        )
+        self.assertEqual(
+            resp['docs'],
+            [{'_id': 'julia039'}, {'_id': 'julia038'}, {'_id': 'julia037'}]
+        )
+
+    def test_make_result(self):
+        """
+        Test that make_result wraps the query response as a QueryResult
+        """
+        self.populate_db_with_documents(100)
+        query = Query(
+            self.db,
+            selector={'_id': {'$lt': 'julia050'}},
+            fields=['_id'],
+            sort=[{'_id': 'desc'}],
+            r=1
+        )
+        rslt = query.make_result()
+        self.assertIsInstance(rslt, QueryResult)
+        self.assertEqual(
+            rslt[10:13],
+            [{'_id': 'julia039'}, {'_id': 'julia038'}, {'_id': 'julia037'}]
+        )
+
+    def test_custom_result_context_manager(self):
+        """
+        Test that custom_result yields a context manager and returns expected
+        content
+        """
+        self.populate_db_with_documents(100)
+        query = Query(
+            self.db,
+            selector={'_id': {'$lt': 'julia050'}},
+            fields=['_id'],
+            r=1
+        )
+        with query.custom_result(sort=[{'_id': 'desc'}]) as rslt:
+            self.assertEqual(
+                rslt[10:13],
+                [{'_id': 'julia039'}, {'_id': 'julia038'}, {'_id': 'julia037'}]
+            )
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
_What:_

This PR contains the unit tests for code added in https://github.com/cloudant/python-cloudant/pull/37

_Why:_

Unit tests needed to test code

_How:_

- Added Query unit tests
- Added QueryResult unit tests
- Added database convenience method unit tests for get_query_result

_Issue:_ #39 

reviewer: @ricellis
reviewer: @emlaver