### PR TITLE
Update documentation to add Cloudant Query support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 ====================
 
 - [NEW] Added support for Cloudant Query execution.
+- [NEW] Added support for Cloudant Query index management.
 
 2.0.0a4 (2015-12-03)
 ====================

--- a/docs/indexes.rst
+++ b/docs/indexes.rst
@@ -1,0 +1,7 @@
+indexes
+=======
+
+.. automodule:: cloudant.indexes
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -9,6 +9,8 @@ Modules
    document
    design_document
    views
+   query
+   indexes
    result
    replicator
    changes

--- a/docs/query.rst
+++ b/docs/query.rst
@@ -1,0 +1,8 @@
+query
+=====
+
+.. automodule:: cloudant.query
+    :members:
+    :undoc-members:
+    :special-members: __call__
+    :show-inheritance:


### PR DESCRIPTION
_What:_

We need to add .rst files to being in the docstring comments from the new indexes and query modules.

_Why:_

To provide documentation for the recently merged #39 and #40 Cloudant Query and index management functionality.

_How:_

- Added indexes.rst
- Added query.rst
- Updated modules.rst to include indexes and query in the TOC
- Updated changes.rst

_Issues:_

- #72 
- #39 
- #40 

reviewer @ricellis
reviewer @rhyshort 