### PR TITLE
Fix database iterator to wrap documents correctly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@
 - [NEW] Added support for Cloudant Query index management.
 - [FIX] DesignDocument content is no longer limited to just views.
 - [FIX] Document url encoding is now enforced.
+- [FIX] Database iterator now yields Document/DesignDocument objects with valid document urls.
 
 2.0.0a4 (2015-12-03)
 ====================

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -539,14 +539,11 @@ class CouchDatabase(dict):
                     # document object before yielding it.
                     document = {}
                     if doc['id'].startswith('_design/'):
-                        document = DesignDocument(self)
+                        document = DesignDocument(self, doc['id'])
                     else:
-                        document = Document(self)
+                        document = Document(self, doc['id'])
                     document.update(doc['doc'])
-                    super(CouchDatabase, self).__setitem__(
-                        doc['id'],
-                        document
-                    )
+                    super(CouchDatabase, self).__setitem__(doc['id'], document)
                     yield document
 
             raise StopIteration


### PR DESCRIPTION
_What:_

Fix a bug with the database iterator so that the documents that it returns have a valid document_url property.  Previously it was not being set.

_Why:_

WIthout a document_url property the Document/DesignDocument cannot be used to update or delete the corresponding document in the remote database.

_How:_

When instantiating the Document/DesignDocument object in the database iterator we now pass in the document id to the Document/DesignDocument constructor so that the _document_id private variable is set correctly thereby ensuring the document_url will also be set correctly.

_Issues:_

- #50 

reviewer: @emlaver 
reviewer: @brynh 