### PR TITLE
Fix group_level type to `int` and add new test case class

### DIFF
--- a/src/cloudant/result.py
+++ b/src/cloudant/result.py
@@ -26,7 +26,7 @@ ARG_TYPES = {
     'endkey': (basestring, Sequence),
     'endkey_docid': basestring,
     'group': bool,
-    'group_level': basestring,
+    'group_level': (int, types.NoneType),
     'include_docs': bool,
     'inclusive_end': bool,
     'key': (int, basestring, Sequence),
@@ -71,7 +71,16 @@ def python_to_couch(options):
         if key not in ARG_TYPES:
             msg = 'Invalid argument {0}'.format(key)
             raise CloudantArgumentError(msg)
-        if not isinstance(val, ARG_TYPES[key]):
+        # pylint: disable=unidiomatic-typecheck
+        # Validate argument values and ensure that a boolean is not passed in
+        # if an integer is expected
+        if (
+                not isinstance(val, ARG_TYPES[key]) or
+                (
+                    cmp(ARG_TYPES[key], (int, types.NoneType)) == 0 and
+                    type(val) is bool
+                )
+        ):
             msg = 'Argument {0} not instance of expected type: {1}'.format(
                 key,
                 ARG_TYPES[key]

--- a/tests/unit/db/result_tests.py
+++ b/tests/unit/db/result_tests.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+# Copyright (c) 2016 IBM. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+result module - Unit tests for Result class
+"""
+import unittest
+
+from cloudant.design_document import DesignDocument
+from cloudant.errors import CloudantArgumentError
+from cloudant.result import python_to_couch, Result
+from tests.unit.db.unit_t_db_base import UnitTestDbBase
+
+class PythonToCouchTests(unittest.TestCase):
+    """
+    Test cases for validating python_to_couch's options
+    """
+
+    # TODO more python_to_couch test cases to be added to completely cover issue #42
+
+    def test_valid_option_group_level(self):
+        """
+        Test group_level option is valid
+        """
+        opts = {'group_level': 100}
+        translation = python_to_couch(opts)
+        self.assertEqual(translation['group_level'], 100)
+
+    def test_invalid_option_group_level(self):
+        """
+        Test group_level options are invalid
+        """
+        opts = {'group_level': True}
+        self.assertRaises(CloudantArgumentError, python_to_couch, opts)
+        opts = {'group_level': '100'}
+        self.assertRaises(CloudantArgumentError, python_to_couch, opts)
+
+class ResultTests(UnitTestDbBase):
+    """
+    Result unit tests
+    """
+
+    # TODO more Result test cases to be added to completely cover issue #42
+
+    def setUp(self):
+        """
+        Set up test attributes
+        """
+        super(ResultTests, self).setUp()
+        self.db_set_up()
+        self.ddoc = DesignDocument(self.db, 'ddoc001')
+        self.ddoc.add_view(
+            'view001',
+            'function (doc) {\n  emit(doc._id, 1);\n}',
+            '_count'
+        )
+        self.ddoc.save()
+
+    def tearDown(self):
+        """
+        Reset test attributes
+        """
+        self.db_tear_down()
+        super(ResultTests, self).tearDown()
+
+    def test_constructor(self):
+        """
+        Test instantiating a Result
+        """
+        result = Result(
+            self.ddoc.get_view('view001'),
+            startkey='1',
+            endkey='9',
+            page_size=1000
+        )
+        self.assertIsInstance(result, Result)
+        self.assertEquals(result.options, {'startkey': '1', 'endkey': '9'})
+
+    def test_group_level(self):
+        """
+        Test group_level option in Result
+        """
+        self.populate_db_with_documents(10)
+        result_set = Result(self.ddoc.get_view('view001'), group_level=1)
+        self.assertIsInstance(result_set, Result)
+        self.assertEquals(result_set.options, {'group_level': 1})
+        # Test Result iteration
+        i = 0
+        for result in result_set:
+            self.assertEqual(
+                result,
+                {'key': 'julia{0:03d}'.format(i), 'value': 1}
+            )
+            i += 1
+        # Test Result key retrieval
+        self.assertEqual(
+            result_set['julia000'],
+            [{'key': 'julia000', 'value': 1}]
+        )
+        # Test Result key slicing
+        self.assertEqual(
+            result_set['julia001': 'julia003'],
+            [
+                {'key': 'julia001', 'value': 1},
+                {'key': 'julia002', 'value': 1},
+                {'key': 'julia003', 'value': 1}
+            ]
+        )
+        # Test Result element slicing
+        self.assertEqual(
+            result_set[9:],
+            [
+                {'key': 'julia009', 'value': 1},
+            ]
+        )
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/mocked/result_test.py
+++ b/tests/unit/mocked/result_test.py
@@ -39,7 +39,7 @@ class PythonToCouchTests(unittest.TestCase):
             "endkey": ['string'],
             "endkey_docid": 'string',
             "group": True,
-            "group_level": "string",
+            "group_level": 12,
             "include_docs": True,
             "inclusive_end": True,
             "key": 12,


### PR DESCRIPTION
*What*
- The group_level is mis-typed in our result module ARG_TYPES. It should be set to `(int, types.NoneType)` but is currently set to `basestring`. Issue #55.
- Add Result and python_to_couch test cases for option group_level as part of issue #42.
- Boolean values for group_level should throw an exception.

*How*
- Replace current group_level type `basestring` with `int`
- Throw Cloudant argument exception when a boolean value exists in a python_to_couch option, and the `ARG_TYPES` is expecting '(int, types.NoneType)`.

*Testing*
Add new test class that contains Result and python_to_couch testing with group_level option.
Future tests (#42) will be added for the existing python_to_couch options.

reviewer: @alfinkel
reviewer: @ricellis