### PR TITLE
Fix document url so that it is appropriately encoded

### DIFF
--- a/src/cloudant/document.py
+++ b/src/cloudant/document.py
@@ -76,10 +76,21 @@ class Document(dict):
         """
         if self._document_id is None:
             return None
+
+        # handle design document url
+        if self._document_id.startswith('_design/'):
+            return posixpath.join(
+                self._database_host,
+                urllib.quote_plus(self._database_name),
+                '_design',
+                urllib.quote(self._document_id[8:], safe='')
+            )
+
+        # handle document url
         return posixpath.join(
             self._database_host,
             urllib.quote_plus(self._database_name),
-            self._document_id
+            urllib.quote(self._document_id, safe='')
         )
 
     def exists(self):


### PR DESCRIPTION
_What:_

Ensure that if the document id of a document contains special characters that the document url generated from that document id is encoded appropriately.

_Why:_

A bug was discovered #32 that sites that you cannot use special characters such as `/` in the document id because it creates a problem in the document id because it is not being encoded correctly.  This fix resolves that issue.

_How:_

- Handle the url for a document by encoding the private `_document_id` attribute before using it to generate the `document_url`.
- Handle the url for a design document by stripping `_design/` from the start of `_document_id` and then encoding the remainder of the `document_id` before using it to generate the `document_url`.  This is being done in the Document class rather than the DesignDocument class because the Document class can be used to create a DesignDocument if desired by the user and the DesignDocument extends  the Document.

_Tests:_

- Document tests added to check for url encoding.
- Document tests added to check create, read, update, delete of documents where document id has special characters and the url needs to be encoded.
- DesignDocument tests added to check create, read, update, delete of design documents where document id has special characters and the url needs to be encoded.

_Issues:_

- #32 
- #56 

reviewer @emlaver
reviewer @rhyshort 