### PR TITLE
Remove the fields parameter from required Query parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,6 @@
 2.0.0b2.dev (Unreleased)
 ========================
-
+- [FIX] Remove the fields parameter from required Query parameters
 
 2.0.0b1 (2016-01-11)
 ====================

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -919,7 +919,8 @@ class CloudantDatabase(CouchDatabase):
             raise CloudantArgumentError(msg)
         index.delete()
 
-    def get_query_result(self, selector, raw_result=False, **kwargs):
+    def get_query_result(self, selector, fields=None, raw_result=False,
+                         **kwargs):
         """
         Retrieves the query result from the specified database based on the
         query parameters provided.  By default the result is returned as a
@@ -987,7 +988,10 @@ class CloudantDatabase(CouchDatabase):
         :returns: The result content either wrapped in a QueryResult or
             as the raw response JSON content
         """
-        query = Query(self, selector=selector)
+        if fields:
+            query = Query(self, selector=selector, fields=fields)
+        else:
+            query = Query(self, selector=selector)
         if raw_result:
             return query(**kwargs)
         if kwargs:

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -919,7 +919,7 @@ class CloudantDatabase(CouchDatabase):
             raise CloudantArgumentError(msg)
         index.delete()
 
-    def get_query_result(self, selector, fields=None, raw_result=False, **kwargs):
+    def get_query_result(self, selector, raw_result=False, **kwargs):
         """
         Retrieves the query result from the specified database based on the
         query parameters provided.  By default the result is returned as a
@@ -987,7 +987,7 @@ class CloudantDatabase(CouchDatabase):
         :returns: The result content either wrapped in a QueryResult or
             as the raw response JSON content
         """
-        query = Query(self, selector=selector, fields=fields)
+        query = Query(self, selector=selector)
         if raw_result:
             return query(**kwargs)
         if kwargs:

--- a/src/cloudant/query.py
+++ b/src/cloudant/query.py
@@ -182,12 +182,6 @@ class Query(dict):
                 'Add a selector to define the query and retry.'
             )
             raise CloudantArgumentError(msg)
-        if data.get('fields', None) is None or data.get('fields') == []:
-            msg = (
-                'No fields list in the query or the fields list was empty.  '
-                'Add a list of fields for the query and retry.'
-            )
-            raise CloudantArgumentError(msg)
 
         # Execute query find
         headers = {'Content-Type': 'application/json'}

--- a/tests/unit/db/database_tests.py
+++ b/tests/unit/db/database_tests.py
@@ -696,6 +696,57 @@ class CloudantDatabaseTests(UnitTestDbBase):
             ['julia001', 'julia002', 'julia003', 'julia004']
         )
 
+    def test_get_query_result_without_fields(self):
+        """
+        Assert that the QueryResult docs include all the expected fields when
+        no fields parameter is provided.
+        """
+        self.populate_db_with_documents(100)
+        expected_fields = ['_id', '_rev', 'age', 'name']
+        # Sort the list of expected fields so we can assert list equality later
+        expected_fields.sort()
+        result = self.db.get_query_result(
+            {'$and': [
+                {'_id': {'$gte': 'julia001'}},
+                {'_id': {'$lt': 'julia005'}}
+            ]}
+        )
+        self.assertIsInstance(result, QueryResult)
+        for doc in result:
+            doc_fields = doc.keys()
+            doc_fields.sort()
+            self.assertEqual(doc_fields, expected_fields)
+        self.assertEqual(
+            [doc['_id'] for doc in result],
+            ['julia001', 'julia002', 'julia003', 'julia004']
+        )
+
+    def test_get_query_result_with_empty_fields_list(self):
+        """
+        Assert that the QueryResult docs include all the expected fields when
+        an empty fields list is provided.
+        """
+        self.populate_db_with_documents(100)
+        expected_fields = ['_id', '_rev', 'age', 'name']
+        # Sort the list of expected fields so we can assert list equality later
+        expected_fields.sort()
+        result = self.db.get_query_result(
+            {'$and': [
+                {'_id': {'$gte': 'julia001'}},
+                {'_id': {'$lt': 'julia005'}}
+            ]},
+            fields=[]
+        )
+        self.assertIsInstance(result, QueryResult)
+        for doc in result:
+            doc_fields = doc.keys()
+            doc_fields.sort()
+            self.assertEqual(doc_fields, expected_fields)
+        self.assertEqual(
+            [doc['_id'] for doc in result],
+            ['julia001', 'julia002', 'julia003', 'julia004']
+        )
+
     def test_create_json_index(self):
         """
         Ensure that a JSON index is created as expected.

--- a/tests/unit/db/query_tests.py
+++ b/tests/unit/db/query_tests.py
@@ -149,36 +149,6 @@ class QueryTests(UnitTestDbBase):
                 'Add a selector to define the query and retry.'
             )
 
-    def test_callable_without_fields(self):
-        """
-        Test Query __call__ without providing a fields list
-        """
-        query = Query(self.db)
-        try:
-            query(selector={'_id': {'$gt': 0}})
-            self.fail('Above statement should raise an Exception')
-        except CloudantArgumentError, err:
-            self.assertEqual(
-                str(err),
-                'No fields list in the query or the fields list was empty.  '
-                'Add a list of fields for the query and retry.'
-            )
-
-    def test_callable_with_empty_field_list(self):
-        """
-        Test Query __call__ without providing a fields list
-        """
-        query = Query(self.db)
-        try:
-            query(selector={'_id': {'$gt': 0}}, fields=[])
-            self.fail('Above statement should raise an Exception')
-        except CloudantArgumentError, err:
-            self.assertEqual(
-                str(err),
-                'No fields list in the query or the fields list was empty.  '
-                'Add a list of fields for the query and retry.'
-            )
-
     def test_callable_executes_query(self):
         """
         Test Query __call__ executes a query


### PR DESCRIPTION
_What:_

Remove the enforcement of the `fields` as a required parameter for making a query.

_Why:_

Cloudant supports not passing in the `fields` when making a query. If no fields are provided then all the fields of each document are returned. This PR makes sure that python-cloudant mimics that behavior.

_How:_

- In `CloudantDatabase.get_query_result()` the `fields` parameter is checked for existence before instantiating the `Query`.
- In `Query.__call__` I removed the check for `fields` being `None` or empty.

_Tests:_

- The query callable tests that test for `fields` being empty or `None` were removed. 
- The tests were updated to treat `fields` as a `**kwargs` argument.
- Test that calling `db.get_query_result` handles a nonexistent `fields` parameter.

_Issues:_
- #86 

reviewer @alfinkel 
reviewer @ricellis