### PR TITLE
Add Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 
 python:
   - "2.7"
+  - "3.5"
 
 services:
   - couchdb

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 2.0.0b2.dev (Unreleased)
 ========================
-- [FIX] Remove the fields parameter from required Query parameters
+- [FIX] Remove the fields parameter from required Query parameters.
+- [NEW] Add Python 3 support.
 
 2.0.0b1 (2016-01-11)
 ====================

--- a/docs/compatibility.rst
+++ b/docs/compatibility.rst
@@ -9,4 +9,7 @@ This library can be used with the following databases
 
 Note that some features are Cloudant specific.
 
-The library is developed using `Python™ 2.7.10 <https://www.python.org/downloads/release/python-2710/>`_ and should be 2.x compatible.  It is currently not 3.x compatible.  We have plans to add that in the future.
+This library has been tested with the following versions of Python
+
+*  `Python™ 2.7 <https://www.python.org/downloads/release/python-2711/>`_
+*  `Python™ 3.5 <https://www.python.org/downloads/release/python-351/>`_

--- a/pylintrc
+++ b/pylintrc
@@ -206,7 +206,7 @@ single-line-if-stmt=no
 no-space-check=trailing-comma,dict-separator
 
 # Maximum number of lines in a module
-max-module-lines=1000
+max-module-lines=2000
 
 # String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
 # tab).

--- a/setup.py
+++ b/setup.py
@@ -30,13 +30,13 @@ setup_args = {
     'install_requires': requirements,
     'name': 'cloudant',
     'version': '2.0.0b2.dev',
-    'author':'IBM',
-    'author_email':'alfinkel@us.ibm.com',
-    'url':'https://github.com/cloudant/python-cloudant',
+    'author': 'IBM',
+    'author_email': 'alfinkel@us.ibm.com',
+    'url': 'https://github.com/cloudant/python-cloudant',
     'packages': find_packages('./src'),
     'provides': find_packages('./src'),
     'package_dir': {'': 'src'},
-    'classifiers' :[
+    'classifiers': [
           'Intended Audience :: Developers',
           'Natural Language :: English',
           'License :: OSI Approved :: Apache Software License',

--- a/src/cloudant/_2to3.py
+++ b/src/cloudant/_2to3.py
@@ -12,67 +12,72 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-python 2 to 3 compatibility methods
+Python 2 to 3 compatibility methods
+
+The philosophy employed here is to treat py2 as the special case vs. py3 as
+future Python releases presumably will retain new semamtics in py3.
 """
 import sys
 
 PY2 = sys.version_info[0] < 3
 ENCODING = 'utf-8'
 NONETYPE = type(None)
+STRTYPE = basestring if PY2 else str  # pylint: disable=undefined-variable
+UNITYPE = unicode if PY2 else str  # pylint: disable=undefined-variable
 
-# pylint: disable=undefined-variable
-STRTYPE = basestring if PY2 else str
+if PY2:
+    def iteritems_(adict):
+        """
+        iterate dict key, value tuples in a py2 and 3 compatible way
 
-# pylint: disable=undefined-variable
-UNITYPE = unicode if PY2 else str
+        :param dict adict:
+        :return: iterator of (key, value) tuples
+        """
+        return adict.iteritems()
 
+    def next_(itr):
+        """
+        return next item from an iterable is a py2 and 3 compatible way
 
-def iteritems_(adict):
-    """
-    py2 to py3 helper
+        :param Iterable itr:
+        :return: the next item in itr
+        """
+        return itr.next()
+else:
+    def iteritems_(adict):
+        """
+        iterate dict key, value tuples in a py2 and 3 compatible way
 
-    :param dict adict:
-    :return:
-    """
-    return adict.iteritems() if PY2 else adict.items()
+        :param dict adict:
+        :return: iterator of (key, value) tuples
+        """
+        return adict.items()
 
+    def next_(itr):
+        """
+        return the next item in an iterable in a py2 and 3 compatible way
 
-def unicode_(astr):
-    """
-    py2 to py3 helper
-
-    :param str astr:
-    :return:
-    """
-    # pylint: disable=undefined-variable
-    return unicode(astr) if PY2 else astr
+        :param Iterable itr:
+        :return: the next item in itr
+        """
+        return next(itr)
 
 
 def bytes_(astr):
     """
-    py2 to py3 helper
+    return a bytes representation of astr in a py2 and 3 compatible way
 
     :param str astr:
-    :return:
+    :return: bytes object
     """
     return astr.encode(ENCODING) if hasattr(astr, 'encode') else astr
 
 
-def str_(astr):
+def unicode_(astr):
     """
-    py2 to py3 helper
+    return a unicode string representation of astr in a py2 and 3 compatible way
 
     :param bytes astr:
-    :return:
+    :return: unicode string
     """
     return astr.decode(ENCODING) if hasattr(astr, 'decode') else astr
-
-
-def next_(itr):
-    """
-    py2 to py3 helper
-
-    :param itr:
-    :return:
-    """
-    return itr.next() if PY2 else next(itr)

--- a/src/cloudant/_2to3.py
+++ b/src/cloudant/_2to3.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 IBM. All rights reserved.
+# Copyright (c) 2016 IBM. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,10 +22,19 @@ import sys
 PY2 = sys.version_info[0] < 3
 ENCODING = 'utf-8'
 NONETYPE = type(None)
-STRTYPE = basestring if PY2 else str  # pylint: disable=undefined-variable
-UNITYPE = unicode if PY2 else str  # pylint: disable=undefined-variable
+
+# pylint: disable=undefined-variable
+STRTYPE = basestring if PY2 else str
+
+# pylint: disable=undefined-variable
+UNITYPE = unicode if PY2 else str
+
 
 if PY2:
+    # pylint: disable=wrong-import-position,no-name-in-module,import-error,unused-import
+    from urllib import quote as url_quote, quote_plus as url_quote_plus
+    from ConfigParser import RawConfigParser
+
     def iteritems_(adict):
         """
         iterate dict key, value tuples in a py2 and 3 compatible way
@@ -44,6 +53,9 @@ if PY2:
         """
         return itr.next()
 else:
+    from urllib.parse import quote as url_quote, quote_plus as url_quote_plus  # pylint: disable=wrong-import-position,no-name-in-module,import-error,ungrouped-imports
+    from configparser import RawConfigParser  # pylint: disable=wrong-import-position,no-name-in-module,import-error
+
     def iteritems_(adict):
         """
         iterate dict key, value tuples in a py2 and 3 compatible way

--- a/src/cloudant/_2to3.py
+++ b/src/cloudant/_2to3.py
@@ -17,6 +17,7 @@ python 2 to 3 compatibility methods
 import sys
 
 PY2 = sys.version_info[0] < 3
+ENCODING = 'utf-8'
 NONETYPE = type(None)
 
 # pylint: disable=undefined-variable
@@ -54,7 +55,17 @@ def bytes_(astr):
     :param str astr:
     :return:
     """
-    return astr.encode('utf-8') if hasattr(astr, 'encode') else astr
+    return astr.encode(ENCODING) if hasattr(astr, 'encode') else astr
+
+
+def str_(astr):
+    """
+    py2 to py3 helper
+
+    :param bytes astr:
+    :return:
+    """
+    return astr.decode(ENCODING) if hasattr(astr, 'decode') else astr
 
 
 def next_(itr):

--- a/src/cloudant/__init__.py
+++ b/src/cloudant/__init__.py
@@ -18,6 +18,21 @@ Cloudant / CouchDB Python client library API package
 __version__ = '2.0.0b2.dev'
 
 # pylint: disable=wrong-import-position
+import sys
+
+# define these before importing sub-modules
+_PY2 = sys.version_info[0] < 3
+_STRTYPE = basestring if _PY2 else str
+_UNITYPE = unicode if _PY2 else str
+_NONETYPE = type(None)
+
+def _iteritems(d):
+    return d.iteritems() if _PY2 else d.items()
+
+def _unicode(s):
+    return unicode(s) if _PY2 else s
+
+# pylint: disable=wrong-import-position
 import contextlib
 # pylint: disable=wrong-import-position
 from .account import Cloudant, CouchDB

--- a/src/cloudant/__init__.py
+++ b/src/cloudant/__init__.py
@@ -18,21 +18,6 @@ Cloudant / CouchDB Python client library API package
 __version__ = '2.0.0b2.dev'
 
 # pylint: disable=wrong-import-position
-import sys
-
-# define these before importing sub-modules
-_PY2 = sys.version_info[0] < 3
-_STRTYPE = basestring if _PY2 else str
-_UNITYPE = unicode if _PY2 else str
-_NONETYPE = type(None)
-
-def _iteritems(d):
-    return d.iteritems() if _PY2 else d.items()
-
-def _unicode(s):
-    return unicode(s) if _PY2 else s
-
-# pylint: disable=wrong-import-position
 import contextlib
 # pylint: disable=wrong-import-position
 from .account import Cloudant, CouchDB

--- a/src/cloudant/_py2to3.py
+++ b/src/cloudant/_py2to3.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2015 IBM. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+python 2 to 3 compatibility methods
+"""
+import sys
+
+PY2 = sys.version_info[0] < 3
+NONETYPE = type(None)
+
+# pylint: disable=undefined-variable
+STRTYPE = basestring if PY2 else str
+
+# pylint: disable=undefined-variable
+UNITYPE = unicode if PY2 else str
+
+
+def iteritems_(adict):
+    """
+    py2 to py3 helper
+
+    :param dict adict:
+    :return:
+    """
+    return adict.iteritems() if PY2 else adict.items()
+
+
+def unicode_(astr):
+    """
+    py2 to py3 helper
+
+    :param str astr:
+    :return:
+    """
+    # pylint: disable=undefined-variable
+    return unicode(astr) if PY2 else astr
+
+
+def bytes_(astr):
+    """
+    py2 to py3 helper
+
+    :param str astr:
+    :return:
+    """
+    return astr.encode('utf-8') if hasattr(astr, 'encode') else astr
+
+
+def next_(itr):
+    """
+    py2 to py3 helper
+
+    :param itr:
+    :return:
+    """
+    return itr.next() if PY2 else next(itr)

--- a/src/cloudant/account.py
+++ b/src/cloudant/account.py
@@ -192,7 +192,7 @@ class CouchDB(dict):
                 "Database {0} does not exist".format(dbname)
             )
         db.delete()
-        if dbname in self.keys():
+        if dbname in list(self.keys()):
             super(CouchDB, self).__delitem__(dbname)
 
     def db_updates(self, since=None, continuous=True):
@@ -230,7 +230,7 @@ class CouchDB(dict):
         :returns: List of database names
         """
         if not remote:
-            return super(CouchDB, self).keys()
+            return list(super(CouchDB, self).keys())
         return self.all_dbs()
 
     def __getitem__(self, key):
@@ -252,7 +252,7 @@ class CouchDB(dict):
 
         :returns: Database object
         """
-        if key in self.keys():
+        if key in list(self.keys()):
             return super(CouchDB, self).__getitem__(key)
         db = self._DATABASE_CLASS(self, key)
         if db.exists():

--- a/src/cloudant/account.py
+++ b/src/cloudant/account.py
@@ -22,7 +22,7 @@ import posixpath
 import sys
 import requests
 
-from ._py2to3 import bytes_
+from ._2to3 import bytes_, str_
 from .database import CloudantDatabase, CouchDatabase
 from .changes import Feed
 from .errors import CloudantException
@@ -143,7 +143,7 @@ class CouchDB(dict):
             username=self._cloudant_user,
             password=self._cloudant_token
         )))
-        return "Basic {0}".format(hash_)
+        return "Basic {0}".format(str_(hash_))
 
     def all_dbs(self):
         """

--- a/src/cloudant/account.py
+++ b/src/cloudant/account.py
@@ -22,7 +22,7 @@ import posixpath
 import sys
 import requests
 
-from ._2to3 import bytes_, str_
+from ._2to3 import bytes_, unicode_
 from .database import CloudantDatabase, CouchDatabase
 from .changes import Feed
 from .errors import CloudantException
@@ -143,7 +143,7 @@ class CouchDB(dict):
             username=self._cloudant_user,
             password=self._cloudant_token
         )))
-        return "Basic {0}".format(str_(hash_))
+        return "Basic {0}".format(unicode_(hash_))
 
     def all_dbs(self):
         """

--- a/src/cloudant/account.py
+++ b/src/cloudant/account.py
@@ -22,6 +22,7 @@ import posixpath
 import sys
 import requests
 
+from ._py2to3 import bytes_
 from .database import CloudantDatabase, CouchDatabase
 from .changes import Feed
 from .errors import CloudantException
@@ -138,10 +139,10 @@ class CouchDB(dict):
 
         :returns: Basic http authentication string
         """
-        hash_ = base64.urlsafe_b64encode("{username}:{password}".format(
+        hash_ = base64.urlsafe_b64encode(bytes_("{username}:{password}".format(
             username=self._cloudant_user,
             password=self._cloudant_token
-        ))
+        )))
         return "Basic {0}".format(hash_)
 
     def all_dbs(self):

--- a/src/cloudant/changes.py
+++ b/src/cloudant/changes.py
@@ -19,7 +19,7 @@ changes-like feeds.
 
 import json
 
-from ._py2to3 import next_
+from ._2to3 import next_, str_
 
 class Feed(object):
     """
@@ -96,7 +96,7 @@ class Feed(object):
         if len(line.strip()) == 0:
             return {}
         try:
-            data = json.loads(line)
+            data = json.loads(str_(line))
         except ValueError:
             data = {"error": "Bad JSON line", "line": line}
 

--- a/src/cloudant/changes.py
+++ b/src/cloudant/changes.py
@@ -21,7 +21,6 @@ import json
 
 from ._2to3 import next_, unicode_
 
-
 class Feed(object):
     """
     Provides an infinite iterator for consuming database feeds such as

--- a/src/cloudant/changes.py
+++ b/src/cloudant/changes.py
@@ -19,7 +19,8 @@ changes-like feeds.
 
 import json
 
-from ._2to3 import next_, str_
+from ._2to3 import next_, unicode_
+
 
 class Feed(object):
     """
@@ -94,9 +95,9 @@ class Feed(object):
             self.start()
         line = next_(self._line_iter)
         if len(line.strip()) == 0:
-            return {}
+            return dict()
         try:
-            data = json.loads(str_(line))
+            data = json.loads(unicode_(line))
         except ValueError:
             data = {"error": "Bad JSON line", "line": line}
 

--- a/src/cloudant/changes.py
+++ b/src/cloudant/changes.py
@@ -19,6 +19,8 @@ changes-like feeds.
 
 import json
 
+from ._py2to3 import next_
+
 class Feed(object):
     """
     Provides an infinite iterator for consuming database feeds such as
@@ -90,7 +92,7 @@ class Feed(object):
             raise StopIteration
         if not self._resp:
             self.start()
-        line = self._line_iter.next()
+        line = next_(self._line_iter)
         if len(line.strip()) == 0:
             return {}
         try:
@@ -103,7 +105,7 @@ class Feed(object):
                 # forever mode => restart
                 self._last_seq = data['last_seq']
                 self.start()
-                return {}
+                return dict()
             else:
                 # not forever mode => break
                 return data

--- a/src/cloudant/credentials.py
+++ b/src/cloudant/credentials.py
@@ -18,11 +18,13 @@ to allow users to pass credentials.
 """
 import os
 
-# pylint: disable=wrong-import-position
-from . import _PY2
-if _PY2:
+# pylint: disable=wrong-import-order
+from ._py2to3 import PY2
+if PY2:
+    # pylint: disable=wrong-import-order
     from ConfigParser import RawConfigParser
 else:
+    # pylint: disable=wrong-import-order, import-error
     from configparser import RawConfigParser
 
 

--- a/src/cloudant/credentials.py
+++ b/src/cloudant/credentials.py
@@ -18,13 +18,7 @@ to allow users to pass credentials.
 """
 import os
 
-# pylint: disable=wrong-import-order
-from ._2to3 import PY2
-if PY2:
-    # pylint: disable=wrong-import-order
-    from ConfigParser import RawConfigParser
-else:
-    from configparser import RawConfigParser  # pylint: disable=import-error
+from ._2to3 import RawConfigParser
 
 
 def read_dot_couch(

--- a/src/cloudant/credentials.py
+++ b/src/cloudant/credentials.py
@@ -24,8 +24,7 @@ if PY2:
     # pylint: disable=wrong-import-order
     from ConfigParser import RawConfigParser
 else:
-    # pylint: disable=wrong-import-order, import-error
-    from configparser import RawConfigParser
+    from configparser import RawConfigParser  # pylint: disable=import-error
 
 
 def read_dot_couch(

--- a/src/cloudant/credentials.py
+++ b/src/cloudant/credentials.py
@@ -17,7 +17,13 @@ Module providing utilities to support using an INI style configuration file
 to allow users to pass credentials.
 """
 import os
-import ConfigParser
+
+# pylint: disable=wrong-import-position
+from . import _PY2
+if _PY2:
+    from ConfigParser import RawConfigParser
+else:
+    from configparser import RawConfigParser
 
 
 def read_dot_couch(
@@ -66,6 +72,7 @@ def read_dot_cloudant(
     """
     return _read_dot_file(filename, section, username, password)
 
+
 def _read_dot_file(filename, section, username, password):
     """
     Handles the parsing of the configuration file for the username
@@ -78,7 +85,7 @@ def _read_dot_file(filename, section, username, password):
     :returns: A tuple containing user and password
     """
     config_file = os.path.expanduser(filename)
-    config = ConfigParser.RawConfigParser()
+    config = RawConfigParser()
     config.read(config_file)
     username_value = config.get(section, username)
     password_value = config.get(section, password)

--- a/src/cloudant/credentials.py
+++ b/src/cloudant/credentials.py
@@ -19,7 +19,7 @@ to allow users to pass credentials.
 import os
 
 # pylint: disable=wrong-import-order
-from ._py2to3 import PY2
+from ._2to3 import PY2
 if PY2:
     # pylint: disable=wrong-import-order
     from ConfigParser import RawConfigParser

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -27,8 +27,7 @@ if PY2:
     # pylint: disable=wrong-import-order,no-name-in-module
     from urllib import quote_plus
 else:
-    # pylint: disable=wrong-import-order,no-name-in-module,import-error
-    from urllib.parse import quote_plus
+    from urllib.parse import quote_plus  # pylint: disable=import-error,no-name-in-module
 
 from .document import Document
 from .design_document import DesignDocument

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -21,14 +21,7 @@ import posixpath
 
 from requests.exceptions import HTTPError
 
-# pylint: disable=wrong-import-order
-from ._2to3 import PY2
-if PY2:
-    # pylint: disable=wrong-import-order,no-name-in-module
-    from urllib import quote_plus
-else:
-    from urllib.parse import quote_plus  # pylint: disable=import-error,no-name-in-module
-
+from ._2to3 import url_quote_plus
 from .document import Document
 from .design_document import DesignDocument
 from .views import View
@@ -71,7 +64,7 @@ class CouchDatabase(dict):
         """
         return posixpath.join(
             self._database_host,
-            quote_plus(self.database_name)
+            url_quote_plus(self.database_name)
         )
 
     @property
@@ -571,7 +564,11 @@ class CouchDatabase(dict):
         url = posixpath.join(self.database_url, '_bulk_docs')
         data = {'docs': docs}
         headers = {'Content-Type': 'application/json'}
-        resp = self.r_session.post(url, data=json.dumps(data), headers=headers)
+        resp = self.r_session.post(
+            url,
+            data=json.dumps(data),
+            headers=headers
+        )
         resp.raise_for_status()
         return resp.json()
 
@@ -590,8 +587,11 @@ class CouchDatabase(dict):
         url = posixpath.join(self.database_url, '_missing_revs')
         data = {doc_id: list(revisions)}
 
-        resp = self.r_session.post(url, headers={'Content-Type': 'application/json'},
-                                   data=json.dumps(data))
+        resp = self.r_session.post(
+            url,
+            headers={'Content-Type': 'application/json'},
+            data=json.dumps(data)
+        )
         resp.raise_for_status()
 
         resp_json = resp.json()
@@ -616,8 +616,11 @@ class CouchDatabase(dict):
         url = posixpath.join(self.database_url, '_revs_diff')
         data = {doc_id: list(revisions)}
 
-        resp = self.r_session.post(url, headers={'Content-Type': 'application/json'},
-                                   data=json.dumps(data))
+        resp = self.r_session.post(
+            url,
+            headers={'Content-Type': 'application/json'},
+            data=json.dumps(data)
+        )
         resp.raise_for_status()
 
         return resp.json()
@@ -668,7 +671,10 @@ class CouchDatabase(dict):
         :returns: View cleanup status in JSON format
         """
         url = posixpath.join(self.database_url, '_view_cleanup')
-        resp = self.r_session.post(url, headers={'Content-Type': 'application/json'})
+        resp = self.r_session.post(
+            url,
+            headers={'Content-Type': 'application/json'}
+        )
         resp.raise_for_status()
 
         return resp.json()

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -22,7 +22,7 @@ import posixpath
 from requests.exceptions import HTTPError
 
 # pylint: disable=wrong-import-order
-from ._py2to3 import PY2
+from ._2to3 import PY2
 if PY2:
     # pylint: disable=wrong-import-order,no-name-in-module
     from urllib import quote_plus

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -18,8 +18,13 @@ API module that maps to a Cloudant or CouchDB database instance.
 import json
 import contextlib
 import posixpath
-import urllib
 from requests.exceptions import HTTPError
+
+from . import _PY2
+if _PY2:
+    from urllib import quote_plus
+else:
+    from urllib.parse import quote_plus
 
 from .document import Document
 from .design_document import DesignDocument
@@ -63,7 +68,7 @@ class CouchDatabase(dict):
         """
         return posixpath.join(
             self._database_host,
-            urllib.quote_plus(self.database_name)
+            quote_plus(self.database_name)
         )
 
     @property
@@ -332,7 +337,7 @@ class CouchDatabase(dict):
             return self
 
         raise CloudantException(
-            u"Unable to create database {0}: Reason: {1}".format(
+            "Unable to create database {0}: Reason: {1}".format(
                 self.database_url, resp.text
             ),
             code=resp.status_code
@@ -434,7 +439,7 @@ class CouchDatabase(dict):
         :returns: List of document ids
         """
         if not remote:
-            return super(CouchDatabase, self).keys()
+            return list(super(CouchDatabase, self).keys())
         docs = self.all_docs()
         return [row['id'] for row in docs.get('rows', [])]
 
@@ -482,7 +487,7 @@ class CouchDatabase(dict):
         :returns: A Document or DesignDocument object depending on the
             specified document id (key)
         """
-        if key in self.keys():
+        if key in list(self.keys()):
             return super(CouchDatabase, self).__getitem__(key)
         if key.startswith('_design/'):
             doc = DesignDocument(self, key)

--- a/src/cloudant/design_document.py
+++ b/src/cloudant/design_document.py
@@ -15,6 +15,7 @@
 """
 API module/class for interacting with a design document in a database.
 """
+from . import _iteritems
 from .document import Document
 from .views import View, QueryIndexView
 from .errors import CloudantArgumentError, CloudantException
@@ -135,7 +136,7 @@ class DesignDocument(Document):
         ``dict`` types.
         """
         super(DesignDocument, self).fetch()
-        for view_name, view_def in self.get('views', {}).iteritems():
+        for view_name, view_def in _iteritems(self.get('views', dict())):
             if self.get('language', None) != QUERY_LANGUAGE:
                 self['views'][view_name] = View(
                     self,
@@ -205,7 +206,7 @@ class DesignDocument(Document):
 
         :returns: Iterable containing view name and associated View object
         """
-        for view_name, view in self.views.iteritems():
+        for view_name, view in _iteritems(self.views):
             yield view_name, view
 
     def list_views(self):
@@ -215,7 +216,7 @@ class DesignDocument(Document):
 
         :returns: List of view names
         """
-        return self.views.keys()
+        return list(self.views.keys())
 
     def get_view(self, view_name):
         """

--- a/src/cloudant/design_document.py
+++ b/src/cloudant/design_document.py
@@ -15,7 +15,7 @@
 """
 API module/class for interacting with a design document in a database.
 """
-from . import _iteritems
+from ._py2to3 import iteritems_
 from .document import Document
 from .views import View, QueryIndexView
 from .errors import CloudantArgumentError, CloudantException
@@ -45,7 +45,7 @@ class DesignDocument(Document):
         if document_id and not document_id.startswith('_design/'):
             document_id = '_design/{0}'.format(document_id)
         super(DesignDocument, self).__init__(database, document_id)
-        self.setdefault('views', {})
+        self.setdefault('views', dict())
 
     @property
     def views(self):
@@ -136,7 +136,7 @@ class DesignDocument(Document):
         ``dict`` types.
         """
         super(DesignDocument, self).fetch()
-        for view_name, view_def in _iteritems(self.get('views', dict())):
+        for view_name, view_def in iteritems_(self.get('views', dict())):
             if self.get('language', None) != QUERY_LANGUAGE:
                 self['views'][view_name] = View(
                     self,
@@ -206,7 +206,7 @@ class DesignDocument(Document):
 
         :returns: Iterable containing view name and associated View object
         """
-        for view_name, view in _iteritems(self.views):
+        for view_name, view in iteritems_(self.views):
             yield view_name, view
 
     def list_views(self):

--- a/src/cloudant/design_document.py
+++ b/src/cloudant/design_document.py
@@ -15,7 +15,7 @@
 """
 API module/class for interacting with a design document in a database.
 """
-from ._py2to3 import iteritems_
+from ._2to3 import iteritems_
 from .document import Document
 from .views import View, QueryIndexView
 from .errors import CloudantArgumentError, CloudantException

--- a/src/cloudant/document.py
+++ b/src/cloudant/document.py
@@ -20,13 +20,17 @@ import posixpath
 import requests
 from requests.exceptions import HTTPError
 
-from . import _PY2
-if _PY2:
+# pylint: disable=wrong-import-order
+from ._py2to3 import PY2
+if PY2:
+    # pylint: disable=wrong-import-order,no-name-in-module
     from urllib import quote, quote_plus
 else:
+    # pylint: disable=wrong-import-order,no-name-in-module,import-error
     from urllib.parse import quote, quote_plus
 
 from .errors import CloudantException
+
 
 class Document(dict):
     """

--- a/src/cloudant/document.py
+++ b/src/cloudant/document.py
@@ -21,10 +21,9 @@ import requests
 from requests.exceptions import HTTPError
 
 # pylint: disable=wrong-import-order
-from ._2to3 import PY2, str_
+from ._2to3 import PY2, unicode_
 if PY2:
-    # pylint: disable=wrong-import-order,no-name-in-module
-    from urllib import quote, quote_plus
+    from urllib import quote, quote_plus  # pylint: disable=no-name-in-module
 else:
     from urllib.parse import quote, quote_plus  # pylint: disable=import-error,no-name-in-module
 
@@ -404,7 +403,7 @@ class Document(dict):
 
         if attachment_type == 'json':
             return resp.json()
-        return str_(resp.content)
+        return unicode_(resp.content)
 
     def delete_attachment(self, attachment, headers=None):
         """

--- a/src/cloudant/document.py
+++ b/src/cloudant/document.py
@@ -17,10 +17,14 @@ API module/class for interacting with a document in a database.
 """
 import json
 import posixpath
-import urllib
 import requests
-
 from requests.exceptions import HTTPError
+
+from . import _PY2
+if _PY2:
+    from urllib import quote, quote_plus
+else:
+    from urllib.parse import quote, quote_plus
 
 from .errors import CloudantException
 
@@ -81,16 +85,16 @@ class Document(dict):
         if self._document_id.startswith('_design/'):
             return posixpath.join(
                 self._database_host,
-                urllib.quote_plus(self._database_name),
+                quote_plus(self._database_name),
                 '_design',
-                urllib.quote(self._document_id[8:], safe='')
+                quote(self._document_id[8:], safe='')
             )
 
         # handle document url
         return posixpath.join(
             self._database_host,
-            urllib.quote_plus(self._database_name),
-            urllib.quote(self._document_id, safe='')
+            quote_plus(self._database_name),
+            quote(self._document_id, safe='')
         )
 
     def exists(self):
@@ -304,8 +308,8 @@ class Document(dict):
         """
         if not self.get("_rev"):
             raise CloudantException(
-                u"Attempting to delete a doc with no _rev. Try running "
-                u".fetch first!"
+                "Attempting to delete a doc with no _rev. Try running "
+                ".fetch first!"
             )
 
         del_resp = self.r_session.delete(
@@ -371,7 +375,7 @@ class Document(dict):
             attachment.
         :param dict headers: Optional, additional headers to be sent
             with request.
-        :param str write_to: Optional file handler to write the attachment to.
+        :param file write_to: Optional file handler to write the attachment to.
             The write_to file must be opened for writing prior to including it
             as an argument for this method.
         :param str attachment_type: Data format of the attachment.  Valid

--- a/src/cloudant/document.py
+++ b/src/cloudant/document.py
@@ -26,8 +26,7 @@ if PY2:
     # pylint: disable=wrong-import-order,no-name-in-module
     from urllib import quote, quote_plus
 else:
-    # pylint: disable=wrong-import-order,no-name-in-module,import-error
-    from urllib.parse import quote, quote_plus
+    from urllib.parse import quote, quote_plus  # pylint: disable=import-error,no-name-in-module
 
 from .errors import CloudantException
 

--- a/src/cloudant/document.py
+++ b/src/cloudant/document.py
@@ -21,7 +21,7 @@ import requests
 from requests.exceptions import HTTPError
 
 # pylint: disable=wrong-import-order
-from ._py2to3 import PY2
+from ._2to3 import PY2, str_
 if PY2:
     # pylint: disable=wrong-import-order,no-name-in-module
     from urllib import quote, quote_plus
@@ -405,7 +405,7 @@ class Document(dict):
 
         if attachment_type == 'json':
             return resp.json()
-        return resp.content
+        return str_(resp.content)
 
     def delete_attachment(self, attachment, headers=None):
         """

--- a/src/cloudant/document.py
+++ b/src/cloudant/document.py
@@ -20,13 +20,7 @@ import posixpath
 import requests
 from requests.exceptions import HTTPError
 
-# pylint: disable=wrong-import-order
-from ._2to3 import PY2, unicode_
-if PY2:
-    from urllib import quote, quote_plus  # pylint: disable=no-name-in-module
-else:
-    from urllib.parse import quote, quote_plus  # pylint: disable=import-error,no-name-in-module
-
+from ._2to3 import unicode_, url_quote, url_quote_plus
 from .errors import CloudantException
 
 
@@ -87,16 +81,16 @@ class Document(dict):
         if self._document_id.startswith('_design/'):
             return posixpath.join(
                 self._database_host,
-                quote_plus(self._database_name),
+                url_quote_plus(self._database_name),
                 '_design',
-                quote(self._document_id[8:], safe='')
+                url_quote(self._document_id[8:], safe='')
             )
 
         # handle document url
         return posixpath.join(
             self._database_host,
-            quote_plus(self._database_name),
-            quote(self._document_id, safe='')
+            url_quote_plus(self._database_name),
+            url_quote(self._document_id, safe='')
         )
 
     def exists(self):

--- a/src/cloudant/indexes.py
+++ b/src/cloudant/indexes.py
@@ -19,6 +19,7 @@ API module for managing/viewing query indexes.
 import posixpath
 import json
 
+from . import _STRTYPE, _iteritems
 from .index_constants import JSON_INDEX_TYPE
 from .index_constants import TEXT_INDEX_TYPE
 from .index_constants import SPECIAL_INDEX_TYPE
@@ -121,7 +122,7 @@ class Index(object):
         """
         payload = {'type': self._type}
         if self._ddoc_id and self._ddoc_id != '':
-            if isinstance(self._ddoc_id, basestring):
+            if isinstance(self._ddoc_id, _STRTYPE):
                 if self._ddoc_id.startswith('_design/'):
                     payload['ddoc'] = self._ddoc_id[8:]
                 else:
@@ -132,7 +133,7 @@ class Index(object):
                 ).format(self._ddoc_id)
                 raise CloudantArgumentError(msg)
         if self._name and self._name != '':
-            if isinstance(self._name, basestring):
+            if isinstance(self._name, _STRTYPE):
                 payload['name'] = self._name
             else:
                 msg = 'The index name: {0} is not a string.'.format(self._name)
@@ -155,7 +156,7 @@ class Index(object):
         """
         Checks that the only definition provided is a "fields" definition.
         """
-        if self._def.keys() != ['fields']:
+        if list(self._def.keys()) != ['fields']:
             msg = (
                 '{0} provided as argument(s).  A JSON index requires that '
                 'only a \'fields\' argument is provided.'
@@ -213,8 +214,8 @@ class SearchIndex(Index):
         text index.
         """
         if self._def != {}:
-            for key, val in self._def.iteritems():
-                if key not in TEXT_INDEX_ARGS.keys():
+            for key, val in _iteritems(self._def):
+                if key not in list(TEXT_INDEX_ARGS.keys()):
                     msg = 'Invalid argument: {0}'.format(key)
                     raise CloudantArgumentError(msg)
                 if not isinstance(val, TEXT_INDEX_ARGS[key]):

--- a/src/cloudant/indexes.py
+++ b/src/cloudant/indexes.py
@@ -19,7 +19,7 @@ API module for managing/viewing query indexes.
 import posixpath
 import json
 
-from . import _STRTYPE, _iteritems
+from ._py2to3 import STRTYPE, iteritems_
 from .index_constants import JSON_INDEX_TYPE
 from .index_constants import TEXT_INDEX_TYPE
 from .index_constants import SPECIAL_INDEX_TYPE
@@ -122,7 +122,7 @@ class Index(object):
         """
         payload = {'type': self._type}
         if self._ddoc_id and self._ddoc_id != '':
-            if isinstance(self._ddoc_id, _STRTYPE):
+            if isinstance(self._ddoc_id, STRTYPE):
                 if self._ddoc_id.startswith('_design/'):
                     payload['ddoc'] = self._ddoc_id[8:]
                 else:
@@ -133,7 +133,7 @@ class Index(object):
                 ).format(self._ddoc_id)
                 raise CloudantArgumentError(msg)
         if self._name and self._name != '':
-            if isinstance(self._name, _STRTYPE):
+            if isinstance(self._name, STRTYPE):
                 payload['name'] = self._name
             else:
                 msg = 'The index name: {0} is not a string.'.format(self._name)
@@ -214,7 +214,7 @@ class SearchIndex(Index):
         text index.
         """
         if self._def != {}:
-            for key, val in _iteritems(self._def):
+            for key, val in iteritems_(self._def):
                 if key not in list(TEXT_INDEX_ARGS.keys()):
                     msg = 'Invalid argument: {0}'.format(key)
                     raise CloudantArgumentError(msg)

--- a/src/cloudant/indexes.py
+++ b/src/cloudant/indexes.py
@@ -213,7 +213,7 @@ class SearchIndex(Index):
         Checks that the definition provided contains only valid arguments for a
         text index.
         """
-        if self._def != {}:
+        if self._def != dict():
             for key, val in iteritems_(self._def):
                 if key not in list(TEXT_INDEX_ARGS.keys()):
                     msg = 'Invalid argument: {0}'.format(key)

--- a/src/cloudant/indexes.py
+++ b/src/cloudant/indexes.py
@@ -19,7 +19,7 @@ API module for managing/viewing query indexes.
 import posixpath
 import json
 
-from ._py2to3 import STRTYPE, iteritems_
+from ._2to3 import STRTYPE, iteritems_
 from .index_constants import JSON_INDEX_TYPE
 from .index_constants import TEXT_INDEX_TYPE
 from .index_constants import SPECIAL_INDEX_TYPE

--- a/src/cloudant/query.py
+++ b/src/cloudant/query.py
@@ -18,21 +18,21 @@ API module for composing and executing Cloudant queries.
 
 import posixpath
 import json
-import types
 import contextlib
 
+from . import _NONETYPE, _STRTYPE, _iteritems
 from .result import QueryResult
 from .errors import CloudantArgumentError
 
 ARG_TYPES = {
     'selector': dict,
-    'limit': (int, types.NoneType),
-    'skip': (int, types.NoneType),
+    'limit': (int, _NONETYPE),
+    'skip': (int, _NONETYPE),
     'sort': list,
     'fields': list,
-    'r': (int, types.NoneType),
-    'bookmark': basestring,
-    'use_index': basestring
+    'r': (int, _NONETYPE),
+    'bookmark': _STRTYPE,
+    'use_index': _STRTYPE
 }
 
 class Query(dict):
@@ -167,8 +167,8 @@ class Query(dict):
         data.update(kwargs)
 
         # Validate query arguments and values
-        for key, val in data.iteritems():
-            if key not in ARG_TYPES.keys():
+        for key, val in _iteritems(data):
+            if key not in list(ARG_TYPES.keys()):
                 msg = 'Invalid argument: {0}'.format(key)
                 raise CloudantArgumentError(msg)
             if not isinstance(val, ARG_TYPES[key]):

--- a/src/cloudant/query.py
+++ b/src/cloudant/query.py
@@ -20,7 +20,7 @@ import posixpath
 import json
 import contextlib
 
-from ._py2to3 import NONETYPE, STRTYPE, iteritems_
+from ._2to3 import NONETYPE, STRTYPE, iteritems_
 from .result import QueryResult
 from .errors import CloudantArgumentError
 

--- a/src/cloudant/query.py
+++ b/src/cloudant/query.py
@@ -20,19 +20,19 @@ import posixpath
 import json
 import contextlib
 
-from . import _NONETYPE, _STRTYPE, _iteritems
+from ._py2to3 import NONETYPE, STRTYPE, iteritems_
 from .result import QueryResult
 from .errors import CloudantArgumentError
 
 ARG_TYPES = {
     'selector': dict,
-    'limit': (int, _NONETYPE),
-    'skip': (int, _NONETYPE),
+    'limit': (int, NONETYPE),
+    'skip': (int, NONETYPE),
     'sort': list,
     'fields': list,
-    'r': (int, _NONETYPE),
-    'bookmark': _STRTYPE,
-    'use_index': _STRTYPE
+    'r': (int, NONETYPE),
+    'bookmark': STRTYPE,
+    'use_index': STRTYPE
 }
 
 class Query(dict):
@@ -167,7 +167,7 @@ class Query(dict):
         data.update(kwargs)
 
         # Validate query arguments and values
-        for key, val in _iteritems(data):
+        for key, val in iteritems_(data):
             if key not in list(ARG_TYPES.keys()):
                 msg = 'Invalid argument: {0}'.format(key)
                 raise CloudantArgumentError(msg)

--- a/src/cloudant/replicator.py
+++ b/src/cloudant/replicator.py
@@ -18,6 +18,7 @@ API module/class for handling database replications
 
 import uuid
 
+from . import _unicode
 from .errors import CloudantException
 from .document import Document
 
@@ -69,15 +70,15 @@ class Replicator(object):
         """
 
         data = dict(
-            _id=repl_id if repl_id else unicode(uuid.uuid4()),
+            _id=repl_id if repl_id else _unicode(uuid.uuid4()),
             **kwargs
         )
 
         if not data.get('source'):
             if source_db is None:
                 raise CloudantException(
-                    u"You must specify either a source_db Database "
-                    u"object or a manually composed 'source' string/dict."
+                    "You must specify either a source_db Database "
+                    "object or a manually composed 'source' string/dict."
                 )
             data['source'] = {
                 "url": source_db.database_url,
@@ -89,8 +90,8 @@ class Replicator(object):
         if not data.get('target'):
             if target_db is None:
                 raise CloudantException(
-                    u"You must specify either a target_db Database "
-                    u"object or a manually composed 'target' string/dict."
+                    "You must specify either a target_db Database "
+                    "object or a manually composed 'target' string/dict."
                 )
             data['target'] = {
                 "url": target_db.database_url,
@@ -113,7 +114,6 @@ class Replicator(object):
         docs = self.database.all_docs(include_docs=True)['rows']
         documents = []
         for doc in docs:
-            document = {}
             if doc['id'].startswith('_design/'):
                 continue
             document = Document(self.database, doc['id'])
@@ -206,7 +206,7 @@ class Replicator(object):
             repl_doc = self.database[repl_id]
         except KeyError:
             raise CloudantException(
-                u"Could not find replication with id {}".format(repl_id))
+                "Could not find replication with id {}".format(repl_id))
 
         repl_doc.fetch()
         repl_doc.delete()

--- a/src/cloudant/replicator.py
+++ b/src/cloudant/replicator.py
@@ -18,7 +18,7 @@ API module/class for handling database replications
 
 import uuid
 
-from . import _unicode
+from ._py2to3 import unicode_
 from .errors import CloudantException
 from .document import Document
 
@@ -70,7 +70,7 @@ class Replicator(object):
         """
 
         data = dict(
-            _id=repl_id if repl_id else _unicode(uuid.uuid4()),
+            _id=repl_id if repl_id else unicode_(uuid.uuid4()),
             **kwargs
         )
 

--- a/src/cloudant/replicator.py
+++ b/src/cloudant/replicator.py
@@ -18,7 +18,7 @@ API module/class for handling database replications
 
 import uuid
 
-from ._py2to3 import unicode_
+from ._2to3 import unicode_
 from .errors import CloudantException
 from .document import Document
 
@@ -163,14 +163,11 @@ class Replicator(object):
             Retrieves the replication state.
             """
             try:
-                repl_doc = self.database[repl_id]
-                repl_doc.fetch()
-                state = repl_doc.get('_replication_state')
+                arepl_doc = self.database[repl_id]
+                arepl_doc.fetch()
+                return arepl_doc, arepl_doc.get('_replication_state')
             except KeyError:
-                repl_doc = None
-                state = None
-
-            return repl_doc, state
+                return None, None
 
         while True:
             # Make sure we fetch the state up front, just in case it moves

--- a/src/cloudant/result.py
+++ b/src/cloudant/result.py
@@ -18,7 +18,7 @@ API module for interacting with result collections.
 import json
 from collections import Sequence
 
-from ._py2to3 import STRTYPE, UNITYPE, NONETYPE, iteritems_
+from ._2to3 import STRTYPE, UNITYPE, NONETYPE, iteritems_
 from .errors import CloudantArgumentError
 
 ARG_TYPES = {

--- a/src/cloudant/result.py
+++ b/src/cloudant/result.py
@@ -18,38 +18,38 @@ API module for interacting with result collections.
 import json
 from collections import Sequence
 
-from . import _STRTYPE, _UNITYPE, _NONETYPE, _iteritems
+from ._py2to3 import STRTYPE, UNITYPE, NONETYPE, iteritems_
 from .errors import CloudantArgumentError
 
 ARG_TYPES = {
     'descending': bool,
-    'endkey': (_STRTYPE, Sequence),
-    'endkey_docid': _STRTYPE,
+    'endkey': (STRTYPE, Sequence),
+    'endkey_docid': STRTYPE,
     'group': bool,
-    'group_level': (int, _NONETYPE),
+    'group_level': (int, NONETYPE),
     'include_docs': bool,
     'inclusive_end': bool,
-    'key': (int, _STRTYPE, Sequence),
+    'key': (int, STRTYPE, Sequence),
     'keys': list,
-    'limit': (int, _NONETYPE),
+    'limit': (int, NONETYPE),
     'reduce': bool,
-    'skip': (int, _NONETYPE),
-    'stale': _STRTYPE,
-    'startkey': (_STRTYPE, Sequence),
-    'startkey_docid': _STRTYPE,
+    'skip': (int, NONETYPE),
+    'stale': STRTYPE,
+    'startkey': (STRTYPE, Sequence),
+    'startkey_docid': STRTYPE,
 }
 
 # pylint: disable=unnecessary-lambda
 TYPE_CONVERTERS = {
-    _STRTYPE: lambda x: json.dumps(x),
+    STRTYPE: lambda x: json.dumps(x),
     str: lambda x: json.dumps(x),
-    _UNITYPE: lambda x: json.dumps(x),
+    UNITYPE: lambda x: json.dumps(x),
     Sequence: lambda x: json.dumps(list(x)),
     list: lambda x: json.dumps(x),
     tuple: lambda x: json.dumps(list(x)),
     int: lambda x: x,
     bool: lambda x: 'true' if x else 'false',
-    _NONETYPE: lambda x: x
+    NONETYPE: lambda x: x
 }
 
 def python_to_couch(options):
@@ -67,7 +67,7 @@ def python_to_couch(options):
     :returns: Dictionary of translated CouchDB/Cloudant query parameters
     """
     translation = dict()
-    for key, val in _iteritems(options):
+    for key, val in iteritems_(options):
         if key not in ARG_TYPES:
             msg = 'Invalid argument {0}'.format(key)
             raise CloudantArgumentError(msg)
@@ -77,7 +77,7 @@ def python_to_couch(options):
         if (
                 not isinstance(val, ARG_TYPES[key]) or
                 (
-                    ARG_TYPES[key] == (int, _NONETYPE) and
+                    ARG_TYPES[key] == (int, NONETYPE) and
                     type(val) is bool
                 )
         ):
@@ -193,7 +193,7 @@ class Result(object):
 
         :returns: Rows data in JSON format
         """
-        if isinstance(key, _STRTYPE):
+        if isinstance(key, STRTYPE):
             data = self._ref(key=key, **self.options)
             return self._parse_data(data)
 
@@ -203,8 +203,8 @@ class Result(object):
 
         if isinstance(key, slice):
             # slice is startkey and endkey if str or array
-            str_or_none_start = type_or_none((_STRTYPE, list), key.start)
-            str_or_none_stop = type_or_none((_STRTYPE, list), key.stop)
+            str_or_none_start = type_or_none((STRTYPE, list), key.start)
+            str_or_none_stop = type_or_none((STRTYPE, list), key.stop)
             if str_or_none_start and str_or_none_stop:
                 # startkey/endkey
                 if key.start is not None and key.stop is not None:

--- a/src/cloudant/result.py
+++ b/src/cloudant/result.py
@@ -16,40 +16,40 @@
 API module for interacting with result collections.
 """
 import json
-import types
-
 from collections import Sequence
+
+from . import _STRTYPE, _UNITYPE, _NONETYPE, _iteritems
 from .errors import CloudantArgumentError
 
 ARG_TYPES = {
     'descending': bool,
-    'endkey': (basestring, Sequence),
-    'endkey_docid': basestring,
+    'endkey': (_STRTYPE, Sequence),
+    'endkey_docid': _STRTYPE,
     'group': bool,
-    'group_level': (int, types.NoneType),
+    'group_level': (int, _NONETYPE),
     'include_docs': bool,
     'inclusive_end': bool,
-    'key': (int, basestring, Sequence),
+    'key': (int, _STRTYPE, Sequence),
     'keys': list,
-    'limit': (int, types.NoneType),
+    'limit': (int, _NONETYPE),
     'reduce': bool,
-    'skip': (int, types.NoneType),
-    'stale': basestring,
-    'startkey': (basestring, Sequence),
-    'startkey_docid': basestring,
+    'skip': (int, _NONETYPE),
+    'stale': _STRTYPE,
+    'startkey': (_STRTYPE, Sequence),
+    'startkey_docid': _STRTYPE,
 }
 
 # pylint: disable=unnecessary-lambda
 TYPE_CONVERTERS = {
-    basestring: lambda x: json.dumps(x),
+    _STRTYPE: lambda x: json.dumps(x),
     str: lambda x: json.dumps(x),
-    unicode: lambda x: json.dumps(x),
+    _UNITYPE: lambda x: json.dumps(x),
     Sequence: lambda x: json.dumps(list(x)),
     list: lambda x: json.dumps(x),
     tuple: lambda x: json.dumps(list(x)),
     int: lambda x: x,
     bool: lambda x: 'true' if x else 'false',
-    types.NoneType: lambda x: x
+    _NONETYPE: lambda x: x
 }
 
 def python_to_couch(options):
@@ -66,8 +66,8 @@ def python_to_couch(options):
 
     :returns: Dictionary of translated CouchDB/Cloudant query parameters
     """
-    translation = {}
-    for key, val in options.iteritems():
+    translation = dict()
+    for key, val in _iteritems(options):
         if key not in ARG_TYPES:
             msg = 'Invalid argument {0}'.format(key)
             raise CloudantArgumentError(msg)
@@ -77,7 +77,7 @@ def python_to_couch(options):
         if (
                 not isinstance(val, ARG_TYPES[key]) or
                 (
-                    cmp(ARG_TYPES[key], (int, types.NoneType)) == 0 and
+                    ARG_TYPES[key] == (int, _NONETYPE) and
                     type(val) is bool
                 )
         ):
@@ -193,7 +193,7 @@ class Result(object):
 
         :returns: Rows data in JSON format
         """
-        if isinstance(key, basestring):
+        if isinstance(key, _STRTYPE):
             data = self._ref(key=key, **self.options)
             return self._parse_data(data)
 
@@ -203,8 +203,8 @@ class Result(object):
 
         if isinstance(key, slice):
             # slice is startkey and endkey if str or array
-            str_or_none_start = type_or_none((basestring, list), key.start)
-            str_or_none_stop = type_or_none((basestring, list), key.stop)
+            str_or_none_start = type_or_none((_STRTYPE, list), key.start)
+            str_or_none_stop = type_or_none((_STRTYPE, list), key.stop)
             if str_or_none_start and str_or_none_stop:
                 # startkey/endkey
                 if key.start is not None and key.stop is not None:
@@ -278,7 +278,7 @@ class Result(object):
                 **self.options
             )
             result = self._parse_data(response)
-            skip = skip + self._page_size
+            skip += self._page_size
             if len(result) > 0:
                 for row in result:
                     yield row
@@ -360,10 +360,11 @@ class QueryResult(Result):
 
         :returns: Rows data in JSON format
         """
-        if 'skip' in self.options or 'skip' in self._ref.keys():
+        refkeys = set(self._ref.keys())
+        if 'skip' in self.options or 'skip' in refkeys:
             msg = 'Cannot use skip parameter with QueryResult slicing.'
             raise CloudantArgumentError(msg)
-        if 'limit' in self.options or 'limit' in self._ref.keys():
+        if 'limit' in self.options or 'limit' in refkeys:
             msg = 'Cannot use limit parameter with QueryResult slicing.'
             raise CloudantArgumentError(msg)
         if (

--- a/src/cloudant/views.py
+++ b/src/cloudant/views.py
@@ -18,7 +18,7 @@ API module for interacting with a view in a design document.
 import contextlib
 import posixpath
 
-from ._py2to3 import STRTYPE
+from ._2to3 import STRTYPE
 from .result import Result, python_to_couch
 from .errors import CloudantArgumentError, CloudantException
 

--- a/src/cloudant/views.py
+++ b/src/cloudant/views.py
@@ -18,6 +18,7 @@ API module for interacting with a view in a design document.
 import contextlib
 import posixpath
 
+from . import _STRTYPE
 from .result import Result, python_to_couch
 from .errors import CloudantArgumentError, CloudantException
 
@@ -346,7 +347,7 @@ class QueryIndexView(View):
     def __init__(self, ddoc, view_name, map_fields, reduce_func, **kwargs):
         if not isinstance(map_fields, dict):
             raise CloudantArgumentError('The map property must be a dictionary')
-        if not isinstance(reduce_func, basestring):
+        if not isinstance(reduce_func, _STRTYPE):
             raise CloudantArgumentError('The reduce property must be a string.')
         super(QueryIndexView, self).__init__(
             ddoc,
@@ -397,7 +398,7 @@ class QueryIndexView(View):
         """
         Provides a reduce property setter.
         """
-        if isinstance(reduce_func, basestring):
+        if isinstance(reduce_func, _STRTYPE):
             self['reduce'] = reduce_func
         else:
             raise CloudantArgumentError('The reduce property must be a string')

--- a/src/cloudant/views.py
+++ b/src/cloudant/views.py
@@ -18,7 +18,7 @@ API module for interacting with a view in a design document.
 import contextlib
 import posixpath
 
-from . import _STRTYPE
+from ._py2to3 import STRTYPE
 from .result import Result, python_to_couch
 from .errors import CloudantArgumentError, CloudantException
 
@@ -28,8 +28,8 @@ class Code(str):
     Javascript blob content.  Used internally by the View object when
     codifying map and reduce Javascript content.
     """
-    def __init__(self, code):
-        super(Code, self).__init__(code)
+    def __new__(cls, code):
+        return str.__new__(cls, code)
 
 def _codify(code_or_str):
     """
@@ -347,7 +347,7 @@ class QueryIndexView(View):
     def __init__(self, ddoc, view_name, map_fields, reduce_func, **kwargs):
         if not isinstance(map_fields, dict):
             raise CloudantArgumentError('The map property must be a dictionary')
-        if not isinstance(reduce_func, _STRTYPE):
+        if not isinstance(reduce_func, STRTYPE):
             raise CloudantArgumentError('The reduce property must be a string.')
         super(QueryIndexView, self).__init__(
             ddoc,
@@ -398,7 +398,7 @@ class QueryIndexView(View):
         """
         Provides a reduce property setter.
         """
-        if isinstance(reduce_func, _STRTYPE):
+        if isinstance(reduce_func, STRTYPE):
             self['reduce'] = reduce_func
         else:
             raise CloudantArgumentError('The reduce property must be a string')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -18,3 +18,12 @@ _tests_
 Test coverage for package
 
 """
+import sys
+
+PY2 = sys.version_info[0] < 3
+
+def _unicode(s):
+    return unicode(s) if PY2 else s
+
+def _iteritems(d):
+    return d.iteritems() if PY2 else d.items()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -22,8 +22,15 @@ import sys
 
 PY2 = sys.version_info[0] < 3
 
-def _unicode(s):
+def unicode_(s):
     return unicode(s) if PY2 else s
 
-def _iteritems(d):
+def iteritems_(d):
     return d.iteritems() if PY2 else d.items()
+
+def bytes_(astr):
+    return astr.encode('utf-8') if hasattr(astr, 'encode') else astr
+
+def str_(astr):
+    return astr.decode('utf-8') if hasattr(astr, 'decode') else astr
+

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -34,3 +34,7 @@ def bytes_(astr):
 def str_(astr):
     return astr.decode('utf-8') if hasattr(astr, 'decode') else astr
 
+if PY2:
+    from StringIO import StringIO
+else:
+    from io import StringIO

--- a/tests/integration/changes_test.py
+++ b/tests/integration/changes_test.py
@@ -27,7 +27,7 @@ import uuid
 from cloudant import cloudant
 from cloudant.credentials import read_dot_cloudant
 
-from .. import _unicode
+from .. import unicode_
 
 
 def setup_logging():
@@ -68,7 +68,7 @@ class ChangesTest(unittest.TestCase):
         creating new docs while reading from the _changes feed.
 
         """
-        dbname = "cloudant-changes-test-{0}".format(_unicode(uuid.uuid4()))
+        dbname = "cloudant-changes-test-{0}".format(unicode_(uuid.uuid4()))
         self.last_db = dbname
 
         with cloudant(self.user, self.password, account=self.user) as c:
@@ -87,7 +87,7 @@ class ChangesTest(unittest.TestCase):
             doc = make_doc(n)
 
             for change in db.changes():
-                LOG.debug(_unicode(change))
+                LOG.debug(unicode_(change))
                 if change is not None:
                     self.assertEqual(change['id'], doc['_id'])
                     n += 1
@@ -106,7 +106,7 @@ class ChangesTest(unittest.TestCase):
 
         """
         dbname = "cloudant-changes-test-with-docs{0}".format(
-            _unicode(uuid.uuid4()))
+            unicode_(uuid.uuid4()))
         self.last_db = dbname
 
         with cloudant(self.user, self.password, account=self.user) as c:
@@ -125,7 +125,7 @@ class ChangesTest(unittest.TestCase):
             doc = make_doc(n)
 
             for change in db.changes(include_docs=True):
-                LOG.debug(_unicode(change))
+                LOG.debug(unicode_(change))
                 if change is not None:
                     self.assertEqual(change['id'], doc['_id'])
                     self.assertEqual(

--- a/tests/integration/changes_test.py
+++ b/tests/integration/changes_test.py
@@ -27,6 +27,9 @@ import uuid
 from cloudant import cloudant
 from cloudant.credentials import read_dot_cloudant
 
+from .. import _unicode
+
+
 def setup_logging():
     log = logging.getLogger()
     log.setLevel(logging.DEBUG)
@@ -65,7 +68,7 @@ class ChangesTest(unittest.TestCase):
         creating new docs while reading from the _changes feed.
 
         """
-        dbname = "cloudant-changes-test-{0}".format(unicode(uuid.uuid4()))
+        dbname = "cloudant-changes-test-{0}".format(_unicode(uuid.uuid4()))
         self.last_db = dbname
 
         with cloudant(self.user, self.password, account=self.user) as c:
@@ -84,7 +87,7 @@ class ChangesTest(unittest.TestCase):
             doc = make_doc(n)
 
             for change in db.changes():
-                LOG.debug(unicode(change))
+                LOG.debug(_unicode(change))
                 if change is not None:
                     self.assertEqual(change['id'], doc['_id'])
                     n += 1
@@ -103,7 +106,7 @@ class ChangesTest(unittest.TestCase):
 
         """
         dbname = "cloudant-changes-test-with-docs{0}".format(
-            unicode(uuid.uuid4()))
+            _unicode(uuid.uuid4()))
         self.last_db = dbname
 
         with cloudant(self.user, self.password, account=self.user) as c:
@@ -122,7 +125,7 @@ class ChangesTest(unittest.TestCase):
             doc = make_doc(n)
 
             for change in db.changes(include_docs=True):
-                LOG.debug(unicode(change))
+                LOG.debug(_unicode(change))
                 if change is not None:
                     self.assertEqual(change['id'], doc['_id'])
                     self.assertEqual(

--- a/tests/integration/changes_test.py
+++ b/tests/integration/changes_test.py
@@ -29,7 +29,6 @@ from cloudant.credentials import read_dot_cloudant
 
 from .. import unicode_
 
-
 def setup_logging():
     log = logging.getLogger()
     log.setLevel(logging.DEBUG)

--- a/tests/integration/document_test.py
+++ b/tests/integration/document_test.py
@@ -19,14 +19,14 @@ document module integration tests
 
 """
 
-import posixpath
 import requests
-import time
 import unittest
 import uuid
 
 from cloudant import cloudant
 from cloudant.credentials import read_dot_cloudant
+
+from .. import _unicode
 
 class DocumentTest(unittest.TestCase):
     """
@@ -36,9 +36,9 @@ class DocumentTest(unittest.TestCase):
 
     def setUp(self):
         self.user, self.passwd = read_dot_cloudant(filename="~/.clou")
-        self.dbname = u"cloudant-document-tests-{0}".format(
-            unicode(uuid.uuid4())
-        )
+        self.dbname = _unicode("cloudant-document-tests-{0}".format(
+            _unicode(uuid.uuid4())
+        ))
 
     def tearDown(self):
         with cloudant(self.user, self.passwd, account=self.user) as c:

--- a/tests/integration/document_test.py
+++ b/tests/integration/document_test.py
@@ -26,7 +26,7 @@ import uuid
 from cloudant import cloudant
 from cloudant.credentials import read_dot_cloudant
 
-from .. import _unicode
+from .. import unicode_
 
 class DocumentTest(unittest.TestCase):
     """
@@ -36,8 +36,8 @@ class DocumentTest(unittest.TestCase):
 
     def setUp(self):
         self.user, self.passwd = read_dot_cloudant(filename="~/.clou")
-        self.dbname = _unicode("cloudant-document-tests-{0}".format(
-            _unicode(uuid.uuid4())
+        self.dbname = unicode_("cloudant-document-tests-{0}".format(
+            unicode_(uuid.uuid4())
         ))
 
     def tearDown(self):

--- a/tests/integration/end_to_end_example_test.py
+++ b/tests/integration/end_to_end_example_test.py
@@ -44,7 +44,7 @@ class E2ECouchTest(unittest.TestCase):
             db = c.create_database(self.dbname)
 
             try:
-                self.assertTrue(self.dbname in c)
+                self.assertIn(self.dbname, c)
                 self.assertTrue(db.exists())
 
                 # creating docs
@@ -53,21 +53,21 @@ class E2ECouchTest(unittest.TestCase):
                     "testing": "document2"})
                 doc3 = db.create_document({"testing": "document3"})
 
-                self.assertTrue('_id' in doc1)
-                self.assertTrue('_rev' in doc1)
-                self.assertTrue('_id' in doc2)
-                self.assertTrue('_rev' in doc2)
-                self.assertTrue('_id' in doc3)
-                self.assertTrue('_rev' in doc3)
+                self.assertIn('_id', doc1)
+                self.assertIn('_rev', doc1)
+                self.assertIn('_id', doc2)
+                self.assertIn('_rev', doc2)
+                self.assertIn('_id', doc3)
+                self.assertIn('_rev', doc3)
 
                 # verifying access via dict api
-                self.assertTrue(doc1['_id'] in db)
-                self.assertTrue(doc2['_id'] in db)
-                self.assertTrue(doc3['_id'] in db)
+                self.assertIn(doc1['_id'], db)
+                self.assertIn(doc2['_id'], db)
+                self.assertIn(doc3['_id'], db)
 
-                self.assertTrue(db[doc1['_id']] == doc1)
-                self.assertTrue(db[doc2['_id']] == doc2)
-                self.assertTrue(db[doc3['_id']] == doc3)
+                self.assertEqual(db[doc1['_id']], doc1)
+                self.assertEqual(db[doc2['_id']], doc2)
+                self.assertEqual(db[doc3['_id']], doc3)
                 # test working context for updating docs
                 with doc2 as working_doc:
                     working_doc['field1'] = [1, 2, 3]
@@ -106,7 +106,7 @@ class E2ECloudantTest(unittest.TestCase):
 
             try:
 
-                self.assertTrue(self.dbname in c)
+                self.assertIn(self.dbname, c)
                 self.assertTrue(db.exists())
 
                 # creating docs
@@ -115,21 +115,21 @@ class E2ECloudantTest(unittest.TestCase):
                     "testing": "document2"})
                 doc3 = db.create_document({"testing": "document3"})
 
-                self.assertTrue('_id' in doc1)
-                self.assertTrue('_rev' in doc1)
-                self.assertTrue('_id' in doc2)
-                self.assertTrue('_rev' in doc2)
-                self.assertTrue('_id' in doc3)
-                self.assertTrue('_rev' in doc3)
+                self.assertIn('_id', doc1)
+                self.assertIn('_rev', doc1)
+                self.assertIn('_id', doc2)
+                self.assertIn('_rev', doc2)
+                self.assertIn('_id', doc3)
+                self.assertIn('_rev', doc3)
 
                 # verifying access via dict api
-                self.assertTrue(doc1['_id'] in db)
-                self.assertTrue(doc2['_id'] in db)
-                self.assertTrue(doc3['_id'] in db)
+                self.assertIn(doc1['_id'], db)
+                self.assertIn(doc2['_id'], db)
+                self.assertIn(doc3['_id'], db)
 
-                self.assertTrue(db[doc1['_id']] == doc1)
-                self.assertTrue(db[doc2['_id']] == doc2)
-                self.assertTrue(db[doc3['_id']] == doc3)
+                self.assertEqual(db[doc1['_id']], doc1)
+                self.assertEqual(db[doc2['_id']], doc2)
+                self.assertEqual(db[doc3['_id']], doc3)
 
                 # test working context for updating docs
                 with doc2 as working_doc:

--- a/tests/integration/iter_test.py
+++ b/tests/integration/iter_test.py
@@ -25,6 +25,9 @@ import uuid
 from cloudant import cloudant
 from cloudant.credentials import read_dot_cloudant
 
+from .. import _unicode
+
+
 class IterTest(unittest.TestCase):
     """
     Verify that our database iterator works, and does the caching that
@@ -32,7 +35,6 @@ class IterTest(unittest.TestCase):
 
     """
 
-    @classmethod
     def setUp(self):
         self.user, self.password = read_dot_cloudant(filename="~/.clou")
         self.last_db = None
@@ -51,7 +53,7 @@ class IterTest(unittest.TestCase):
         chunk.
 
         """
-        dbname = "cloudant-itertest-twodocs-{0}".format(unicode(uuid.uuid4()))
+        dbname = "cloudant-itertest-twodocs-{0}".format(_unicode(uuid.uuid4()))
         self.last_db = dbname
 
         with cloudant(self.user, self.password, account=self.user) as c:
@@ -80,7 +82,7 @@ class IterTest(unittest.TestCase):
         Test to make sure that we can iterator through stuff
 
         """
-        dbname = "cloudant-itertest-manydocs-{0}".format(unicode(uuid.uuid4()))
+        dbname = "cloudant-itertest-manydocs-{0}".format(_unicode(uuid.uuid4()))
         self.last_db = dbname
 
         with cloudant(self.user, self.password, account=self.user) as c:
@@ -98,10 +100,10 @@ class IterTest(unittest.TestCase):
             for doc in db:
                 docs.append(doc)
 
-            self.assertTrue(len(docs) == 300)
+            self.assertEqual(len(docs), 300)
 
             unique_ids = set([doc['id'] for doc in docs])
-            self.assertTrue(len(unique_ids) == 300)
+            self.assertEqual(len(unique_ids), 300)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/integration/iter_test.py
+++ b/tests/integration/iter_test.py
@@ -27,7 +27,6 @@ from cloudant.credentials import read_dot_cloudant
 
 from .. import unicode_
 
-
 class IterTest(unittest.TestCase):
     """
     Verify that our database iterator works, and does the caching that

--- a/tests/integration/iter_test.py
+++ b/tests/integration/iter_test.py
@@ -25,7 +25,7 @@ import uuid
 from cloudant import cloudant
 from cloudant.credentials import read_dot_cloudant
 
-from .. import _unicode
+from .. import unicode_
 
 
 class IterTest(unittest.TestCase):
@@ -53,7 +53,7 @@ class IterTest(unittest.TestCase):
         chunk.
 
         """
-        dbname = "cloudant-itertest-twodocs-{0}".format(_unicode(uuid.uuid4()))
+        dbname = "cloudant-itertest-twodocs-{0}".format(unicode_(uuid.uuid4()))
         self.last_db = dbname
 
         with cloudant(self.user, self.password, account=self.user) as c:
@@ -82,7 +82,7 @@ class IterTest(unittest.TestCase):
         Test to make sure that we can iterator through stuff
 
         """
-        dbname = "cloudant-itertest-manydocs-{0}".format(_unicode(uuid.uuid4()))
+        dbname = "cloudant-itertest-manydocs-{0}".format(unicode_(uuid.uuid4()))
         self.last_db = dbname
 
         with cloudant(self.user, self.password, account=self.user) as c:

--- a/tests/integration/replicator_test.py
+++ b/tests/integration/replicator_test.py
@@ -20,7 +20,6 @@ replicator integration tests
 """
 
 import logging
-import posixpath
 import sys
 import time
 import uuid
@@ -29,6 +28,9 @@ import unittest
 from cloudant import cloudant
 from cloudant.credentials import read_dot_cloudant
 from cloudant.replicator import Replicator
+
+from .. import _unicode
+
 
 def setup_logging():
     log = logging.getLogger()
@@ -82,10 +84,10 @@ class ReplicatorTest(unittest.TestCase):
         one get transferred to t'other.
 
         """
-        dbsource = u"test_create_replication_source_{}".format(
-            unicode(uuid.uuid4()))
-        dbtarget = u"test_create_replication_target_{}".format(
-            unicode(uuid.uuid4()))
+        dbsource = _unicode("test_create_replication_source_{}".format(
+            _unicode(uuid.uuid4())))
+        dbtarget = _unicode("test_create_replication_target_{}".format(
+            _unicode(uuid.uuid4())))
 
         self.dbs = [dbsource, dbtarget]
 
@@ -104,8 +106,8 @@ class ReplicatorTest(unittest.TestCase):
             )
 
             replicator = Replicator(c)
-            repl_id = u"test_create_replication_{}".format(
-                unicode(uuid.uuid4()))
+            repl_id = _unicode("test_create_replication_{}".format(
+                _unicode(uuid.uuid4())))
             self.replication_ids.append(repl_id)
 
             ret = replicator.create_replication(
@@ -134,8 +136,8 @@ class ReplicatorTest(unittest.TestCase):
                             break
                         else:
                             LOG.debug(
-                                u"Waiting for replication to complete "
-                                u"(repl_doc: {})".format(repl_doc)
+                                _unicode("Waiting for replication to complete "
+                                         "(repl_doc: {})".format(repl_doc))
                             )
 
             self.assertTrue(repl_doc)
@@ -151,10 +153,10 @@ class ReplicatorTest(unittest.TestCase):
         Test to make sure that we can follow a replication.
 
         """
-        dbsource = u"test_follow_replication_source_{}".format(
-            unicode(uuid.uuid4()))
-        dbtarget = u"test_follow_replication_target_{}".format(
-            unicode(uuid.uuid4()))
+        dbsource = _unicode("test_follow_replication_source_{}".format(
+            _unicode(uuid.uuid4())))
+        dbtarget = _unicode("test_follow_replication_target_{}".format(
+            _unicode(uuid.uuid4())))
 
         self.dbs = [dbsource, dbtarget]
 
@@ -173,8 +175,8 @@ class ReplicatorTest(unittest.TestCase):
             )
 
             replicator = Replicator(c)
-            repl_id = u"test_follow_replication_{}".format(
-                unicode(uuid.uuid4()))
+            repl_id = _unicode("test_follow_replication_{}".format(
+                _unicode(uuid.uuid4())))
             self.replication_ids.append(repl_id)
 
             ret = replicator.create_replication(
@@ -198,10 +200,10 @@ class ReplicatorTest(unittest.TestCase):
         a bad replication.
 
         """
-        dbsource = u"test_follow_replication_source_error_{}".format(
-            unicode(uuid.uuid4()))
-        dbtarget = u"test_follow_replication_target_error_{}".format(
-            unicode(uuid.uuid4()))
+        dbsource = _unicode("test_follow_replication_source_error_{}".format(
+            _unicode(uuid.uuid4())))
+        dbtarget = _unicode("test_follow_replication_target_error_{}".format(
+            _unicode(uuid.uuid4())))
 
         self.dbs = [dbsource, dbtarget]
 
@@ -220,8 +222,8 @@ class ReplicatorTest(unittest.TestCase):
             )
 
             replicator = Replicator(c)
-            repl_id = u"test_follow_replication_{}".format(
-                unicode(uuid.uuid4()))
+            repl_id = _unicode("test_follow_replication_{}".format(
+                _unicode(uuid.uuid4())))
             self.replication_ids.append(repl_id)
 
             ret = replicator.create_replication(
@@ -247,10 +249,10 @@ class ReplicatorTest(unittest.TestCase):
         Verify that we can get the replication state.
 
         """
-        dbsource = u"test_replication_state_source_{}".format(
-            unicode(uuid.uuid4()))
-        dbtarget = u"test_replication_state_target_{}".format(
-            unicode(uuid.uuid4()))
+        dbsource = _unicode("test_replication_state_source_{}".format(
+            _unicode(uuid.uuid4())))
+        dbtarget = _unicode("test_replication_state_target_{}".format(
+            _unicode(uuid.uuid4())))
 
         self.dbs = [dbsource, dbtarget]
 
@@ -269,8 +271,8 @@ class ReplicatorTest(unittest.TestCase):
             )
 
             replicator = Replicator(c)
-            repl_id = u"test_replication_state_{}".format(
-                unicode(uuid.uuid4()))
+            repl_id = _unicode("test_replication_state_{}".format(
+                _unicode(uuid.uuid4())))
             self.replication_ids.append(repl_id)
 
             ret = replicator.create_replication(
@@ -314,9 +316,9 @@ class ReplicatorTest(unittest.TestCase):
             num_reps = 3
 
             for i in range(0, num_reps):
-                tag = "{0}_{1}".format(i, unicode(uuid.uuid4()))
-                dbsource = u"test_list_repl_src_{}".format(tag)
-                dbtarget = u"test_list_repl_tgt_{}".format(tag)
+                tag = "{0}_{1}".format(i, _unicode(uuid.uuid4()))
+                dbsource = _unicode("test_list_repl_src_{}".format(tag))
+                dbtarget = _unicode("test_list_repl_tgt_{}".format(tag))
 
                 self.dbs.append(dbsource)
                 self.dbs.append(dbtarget)
@@ -328,7 +330,7 @@ class ReplicatorTest(unittest.TestCase):
                     {"_id": "doc1", "testing": "document 1"}
                 )
 
-                repl_id = u"test_create_replication_{}".format(tag)
+                repl_id = _unicode("test_create_replication_{}".format(tag))
                 self.replication_ids.append(repl_id)
                 repl_ids.append(repl_id)
 

--- a/tests/integration/replicator_test.py
+++ b/tests/integration/replicator_test.py
@@ -31,7 +31,6 @@ from cloudant.replicator import Replicator
 
 from .. import unicode_
 
-
 def setup_logging():
     log = logging.getLogger()
     log.setLevel(logging.DEBUG)

--- a/tests/integration/replicator_test.py
+++ b/tests/integration/replicator_test.py
@@ -29,7 +29,7 @@ from cloudant import cloudant
 from cloudant.credentials import read_dot_cloudant
 from cloudant.replicator import Replicator
 
-from .. import _unicode
+from .. import unicode_
 
 
 def setup_logging():
@@ -84,10 +84,10 @@ class ReplicatorTest(unittest.TestCase):
         one get transferred to t'other.
 
         """
-        dbsource = _unicode("test_create_replication_source_{}".format(
-            _unicode(uuid.uuid4())))
-        dbtarget = _unicode("test_create_replication_target_{}".format(
-            _unicode(uuid.uuid4())))
+        dbsource = unicode_("test_create_replication_source_{}".format(
+            unicode_(uuid.uuid4())))
+        dbtarget = unicode_("test_create_replication_target_{}".format(
+            unicode_(uuid.uuid4())))
 
         self.dbs = [dbsource, dbtarget]
 
@@ -106,8 +106,8 @@ class ReplicatorTest(unittest.TestCase):
             )
 
             replicator = Replicator(c)
-            repl_id = _unicode("test_create_replication_{}".format(
-                _unicode(uuid.uuid4())))
+            repl_id = unicode_("test_create_replication_{}".format(
+                unicode_(uuid.uuid4())))
             self.replication_ids.append(repl_id)
 
             ret = replicator.create_replication(
@@ -136,7 +136,7 @@ class ReplicatorTest(unittest.TestCase):
                             break
                         else:
                             LOG.debug(
-                                _unicode("Waiting for replication to complete "
+                                unicode_("Waiting for replication to complete "
                                          "(repl_doc: {})".format(repl_doc))
                             )
 
@@ -153,10 +153,10 @@ class ReplicatorTest(unittest.TestCase):
         Test to make sure that we can follow a replication.
 
         """
-        dbsource = _unicode("test_follow_replication_source_{}".format(
-            _unicode(uuid.uuid4())))
-        dbtarget = _unicode("test_follow_replication_target_{}".format(
-            _unicode(uuid.uuid4())))
+        dbsource = unicode_("test_follow_replication_source_{}".format(
+            unicode_(uuid.uuid4())))
+        dbtarget = unicode_("test_follow_replication_target_{}".format(
+            unicode_(uuid.uuid4())))
 
         self.dbs = [dbsource, dbtarget]
 
@@ -175,8 +175,8 @@ class ReplicatorTest(unittest.TestCase):
             )
 
             replicator = Replicator(c)
-            repl_id = _unicode("test_follow_replication_{}".format(
-                _unicode(uuid.uuid4())))
+            repl_id = unicode_("test_follow_replication_{}".format(
+                unicode_(uuid.uuid4())))
             self.replication_ids.append(repl_id)
 
             ret = replicator.create_replication(
@@ -200,10 +200,10 @@ class ReplicatorTest(unittest.TestCase):
         a bad replication.
 
         """
-        dbsource = _unicode("test_follow_replication_source_error_{}".format(
-            _unicode(uuid.uuid4())))
-        dbtarget = _unicode("test_follow_replication_target_error_{}".format(
-            _unicode(uuid.uuid4())))
+        dbsource = unicode_("test_follow_replication_source_error_{}".format(
+            unicode_(uuid.uuid4())))
+        dbtarget = unicode_("test_follow_replication_target_error_{}".format(
+            unicode_(uuid.uuid4())))
 
         self.dbs = [dbsource, dbtarget]
 
@@ -222,8 +222,8 @@ class ReplicatorTest(unittest.TestCase):
             )
 
             replicator = Replicator(c)
-            repl_id = _unicode("test_follow_replication_{}".format(
-                _unicode(uuid.uuid4())))
+            repl_id = unicode_("test_follow_replication_{}".format(
+                unicode_(uuid.uuid4())))
             self.replication_ids.append(repl_id)
 
             ret = replicator.create_replication(
@@ -249,10 +249,10 @@ class ReplicatorTest(unittest.TestCase):
         Verify that we can get the replication state.
 
         """
-        dbsource = _unicode("test_replication_state_source_{}".format(
-            _unicode(uuid.uuid4())))
-        dbtarget = _unicode("test_replication_state_target_{}".format(
-            _unicode(uuid.uuid4())))
+        dbsource = unicode_("test_replication_state_source_{}".format(
+            unicode_(uuid.uuid4())))
+        dbtarget = unicode_("test_replication_state_target_{}".format(
+            unicode_(uuid.uuid4())))
 
         self.dbs = [dbsource, dbtarget]
 
@@ -271,8 +271,8 @@ class ReplicatorTest(unittest.TestCase):
             )
 
             replicator = Replicator(c)
-            repl_id = _unicode("test_replication_state_{}".format(
-                _unicode(uuid.uuid4())))
+            repl_id = unicode_("test_replication_state_{}".format(
+                unicode_(uuid.uuid4())))
             self.replication_ids.append(repl_id)
 
             ret = replicator.create_replication(
@@ -316,9 +316,9 @@ class ReplicatorTest(unittest.TestCase):
             num_reps = 3
 
             for i in range(0, num_reps):
-                tag = "{0}_{1}".format(i, _unicode(uuid.uuid4()))
-                dbsource = _unicode("test_list_repl_src_{}".format(tag))
-                dbtarget = _unicode("test_list_repl_tgt_{}".format(tag))
+                tag = "{0}_{1}".format(i, unicode_(uuid.uuid4()))
+                dbsource = unicode_("test_list_repl_src_{}".format(tag))
+                dbtarget = unicode_("test_list_repl_tgt_{}".format(tag))
 
                 self.dbs.append(dbsource)
                 self.dbs.append(dbtarget)
@@ -330,7 +330,7 @@ class ReplicatorTest(unittest.TestCase):
                     {"_id": "doc1", "testing": "document 1"}
                 )
 
-                repl_id = _unicode("test_create_replication_{}".format(tag))
+                repl_id = unicode_("test_create_replication_{}".format(tag))
                 self.replication_ids.append(repl_id)
                 repl_ids.append(repl_id)
 

--- a/tests/unit/db/account_tests.py
+++ b/tests/unit/db/account_tests.py
@@ -34,6 +34,8 @@ from cloudant.account import Cloudant
 from cloudant.errors import CloudantException
 
 from .unit_t_db_base import UnitTestDbBase
+from ... import bytes_, str_
+
 
 class AccountTests(UnitTestDbBase):
     """
@@ -91,7 +93,7 @@ class AccountTests(UnitTestDbBase):
         try:
             self.client.connect()
             expected = 'Basic {0}'.format(
-                base64.urlsafe_b64encode("{0}:{1}".format(self.user, self.pwd))
+                str_(base64.urlsafe_b64encode(bytes_("{0}:{1}".format(self.user, self.pwd))))
                 )
             self.assertEqual(
                 self.client.basic_auth_str(),

--- a/tests/unit/db/account_tests.py
+++ b/tests/unit/db/account_tests.py
@@ -21,7 +21,6 @@ See configuration options for environment variables in unit_t_db_base
 module docstring.
 
 """
-from __future__ import absolute_import
 
 import unittest
 import requests
@@ -185,7 +184,7 @@ class AccountTests(UnitTestDbBase):
         """
         try:
             self.client.connect()
-            self.client['no_such_db']
+            db = self.client['no_such_db']
             self.fail('Above statement should raise a KeyError')
         except KeyError:
             pass
@@ -234,14 +233,14 @@ class AccountTests(UnitTestDbBase):
         dbname = self.dbname()
         try:
             self.client.connect()
-            _ = self.client.create_database(dbname)
+            db = self.client.create_database(dbname)
             self.assertIsNotNone(self.client.get(dbname))
             self.client.__delitem__(dbname, remote=True)
             # Removed from local cache
             self.assertIsNone(self.client.get(dbname))
             # Database removed remotely as well
             try:
-                _ = self.client[dbname]
+                db = self.client[dbname]
                 self.fail('Above statement should raise a KeyError')
             except KeyError:
                 pass

--- a/tests/unit/db/account_tests.py
+++ b/tests/unit/db/account_tests.py
@@ -21,19 +21,19 @@ See configuration options for environment variables in unit_t_db_base
 module docstring.
 
 """
+from __future__ import absolute_import
 
 import unittest
 import requests
 import json
 import base64
 import os
-import uuid
 from datetime import datetime
 
 from cloudant.account import Cloudant
 from cloudant.errors import CloudantException
 
-from unit_t_db_base import UnitTestDbBase
+from .unit_t_db_base import UnitTestDbBase
 
 class AccountTests(UnitTestDbBase):
     """
@@ -104,7 +104,7 @@ class AccountTests(UnitTestDbBase):
         """
         Test getting a list of all of the databases in the account
         """
-        dbnames = [self.dbname() for _ in xrange(3)]
+        dbnames = [self.dbname() for _ in range(3)]
         try:
             self.client.connect()
             for dbname in dbnames:
@@ -141,7 +141,7 @@ class AccountTests(UnitTestDbBase):
             self.client.create_database(dbname)
             self.client.create_database(dbname, throw_on_exists=True)
             self.fail('Above statement should raise a CloudantException')
-        except CloudantException, err:
+        except CloudantException as err:
             self.assertEqual(
                 str(err),
                 'Database {0} already exists'.format(dbname)
@@ -158,7 +158,7 @@ class AccountTests(UnitTestDbBase):
             self.client.connect()
             self.client.delete_database('no_such_db')
             self.fail('Above statement should raise a CloudantException')
-        except CloudantException, err:
+        except CloudantException as err:
             self.assertEqual(str(err), 'Database no_such_db does not exist')
         finally:
             self.client.disconnect()
@@ -169,7 +169,7 @@ class AccountTests(UnitTestDbBase):
         """
         try:
             self.client.connect()
-            self.assertEqual(self.client.keys(), [])
+            self.assertEqual(list(self.client.keys()), [])
             self.assertEqual(
                 self.client.keys(remote=True),
                 self.client.all_dbs()
@@ -183,7 +183,7 @@ class AccountTests(UnitTestDbBase):
         """
         try:
             self.client.connect()
-            db = self.client['no_such_db']
+            self.client['no_such_db']
             self.fail('Above statement should raise a KeyError')
         except KeyError:
             pass
@@ -232,14 +232,14 @@ class AccountTests(UnitTestDbBase):
         dbname = self.dbname()
         try:
             self.client.connect()
-            db = self.client.create_database(dbname)
+            _ = self.client.create_database(dbname)
             self.assertIsNotNone(self.client.get(dbname))
             self.client.__delitem__(dbname, remote=True)
             # Removed from local cache
             self.assertIsNone(self.client.get(dbname))
             # Database removed remotely as well
             try:
-                db = self.client[dbname]
+                _ = self.client[dbname]
                 self.fail('Above statement should raise a KeyError')
             except KeyError:
                 pass
@@ -292,7 +292,7 @@ class AccountTests(UnitTestDbBase):
             self.client.connect()
             self.client['not-a-db'] = 'This is not a database object'
             self.fail('Above statement should raise a CloudantException')
-        except CloudantException, err:
+        except CloudantException as err:
             self.assertEqual(str(err), 'Value must be set to a Database object')
         finally:
             self.client.disconnect()

--- a/tests/unit/db/database_tests.py
+++ b/tests/unit/db/database_tests.py
@@ -21,6 +21,7 @@ See configuration options for environment variables in unit_t_db_base
 module docstring.
 
 """
+from __future__ import absolute_import
 
 import unittest
 import requests
@@ -28,14 +29,15 @@ import posixpath
 import os
 import uuid
 
-from cloudant.database import CouchDatabase, CloudantDatabase
 from cloudant.result import Result, QueryResult
 from cloudant.errors import CloudantException, CloudantArgumentError
 from cloudant.document import Document
 from cloudant.design_document import DesignDocument
 from cloudant.indexes import Index, SearchIndex, SpecialIndex
 
-from unit_t_db_base import UnitTestDbBase
+from .unit_t_db_base import UnitTestDbBase
+from ... import _unicode
+
 
 class DatabaseTests(UnitTestDbBase):
     """
@@ -104,7 +106,7 @@ class DatabaseTests(UnitTestDbBase):
             # No issue should arise if attempting to create existing database
             db_2 = db.create()
             self.assertEqual(db, db_2)
-        except Exception, err:
+        except Exception as err:
             self.fail('Exception {0} was raised.'.format(str(err)))
         finally:
             db.delete()
@@ -118,7 +120,7 @@ class DatabaseTests(UnitTestDbBase):
             fake_db = self.client._DATABASE_CLASS(self.client, 'no-such-db')
             fake_db.delete()
             self.fail('Above statement should raise an Exception')
-        except requests.HTTPError, err:
+        except requests.HTTPError as err:
             self.assertEqual(err.response.status_code, 404)
 
     def test_retrieve_db_metadata(self):
@@ -133,7 +135,7 @@ class DatabaseTests(UnitTestDbBase):
             )
         expected = resp.json()
         actual = self.db.metadata()
-        self.assertEqual(actual.keys(), expected.keys())
+        self.assertListEqual(list(actual.keys()), list(expected.keys()))
 
     def test_retrieve_document_count(self):
         """
@@ -156,7 +158,7 @@ class DatabaseTests(UnitTestDbBase):
         try:
             self.db.create_document(data, throw_on_exists=True)
             self.fail('Above statement should raise a CloudantException')
-        except CloudantException, err:
+        except CloudantException as err:
             self.assertEqual(
                 str(err),
                 'Error - Document with id julia06 already exists.'
@@ -303,7 +305,7 @@ class DatabaseTests(UnitTestDbBase):
         """
         Test retrieving the document keys from the database
         """
-        self.assertEqual(self.db.keys(), [])
+        self.assertEqual(list(self.db.keys()), [])
         self.populate_db_with_documents(3)
         self.assertEqual(
             self.db.keys(remote=True),
@@ -315,7 +317,7 @@ class DatabaseTests(UnitTestDbBase):
         Test __getitem__ when retrieving a non-existing document
         """
         try:
-            doc = self.db['no_such_doc']
+            _ = self.db['no_such_doc']
             self.fail('Above statement should raise a KeyError')
         except KeyError:
             pass
@@ -371,7 +373,7 @@ class DatabaseTests(UnitTestDbBase):
         self.assertEqual(len(docs), 3)
         # Check that the local database object has been populated
         # with the appropriate documents
-        expected_keys = ['julia{0:03d}'.format(i) for i in xrange(3)]
+        expected_keys = ['julia{0:03d}'.format(i) for i in range(3)]
         self.assertTrue(all(x in self.db.keys()for x in expected_keys))
         for id in self.db.keys():
             doc = self.db.get(id)
@@ -404,7 +406,7 @@ class DatabaseTests(UnitTestDbBase):
         self.assertEqual(len(docs), 103)
         # Check that the local database object has been populated
         # with the appropriate documents
-        expected_keys = ['julia{0:03d}'.format(i) for i in xrange(103)]
+        expected_keys = ['julia{0:03d}'.format(i) for i in range(103)]
         self.assertTrue(all(x in self.db.keys()for x in expected_keys))
         for id in self.db.keys():
             doc = self.db.get(id)
@@ -412,7 +414,7 @@ class DatabaseTests(UnitTestDbBase):
             self.assertEqual(doc['_id'], id)
             self.assertTrue(doc['_rev'].startswith('1-'))
             self.assertEqual(doc['name'], 'julia')
-            self.assertEqual(doc['age'], int(id[len(id) - 3 : len(id)]))
+            self.assertEqual(doc['age'], int(id[len(id) - 3: len(id)]))
 
     def test_document_iteration_returns_valid_documents(self):
         """
@@ -444,7 +446,7 @@ class DatabaseTests(UnitTestDbBase):
             doc.delete()
 
         # Confirm successful deletions
-        for doc in self.db:
+        for _ in self.db:
             self.fail('All documents should have been deleted!!!')
 
         # Confirm that the correct number of Document (3) and DesignDocument (1)
@@ -455,7 +457,7 @@ class DatabaseTests(UnitTestDbBase):
     def test_bulk_docs_creation(self):
         docs = [
             {'_id': 'julia{0:03d}'.format(i), 'name': 'julia', 'age': i}
-            for i in xrange(3)
+            for i in range(3)
         ]
         results = self.db.bulk_docs(docs)
         self.assertEqual(len(results), 3)
@@ -612,13 +614,13 @@ class CloudantDatabaseTests(UnitTestDbBase):
 
     def test_get_security_document(self):
         self.assertEqual(self.db.security_document(), {})
-        share = 'unit-test-share-user-{0}'.format(unicode(uuid.uuid4()))
+        share = 'unit-test-share-user-{0}'.format(_unicode(uuid.uuid4()))
         self.db.share_database(share)
         expected = {'cloudant': {share: ['_reader']}}
         self.assertEqual(self.db.security_document(), expected)
 
     def test_share_unshare_database(self):
-        share = 'unit-test-share-user-{0}'.format(unicode(uuid.uuid4()))
+        share = 'unit-test-share-user-{0}'.format(_unicode(uuid.uuid4()))
         self.assertEqual(self.db.security_document(), {})
         self.assertEqual(self.db.share_database(share), {'ok': True})
         expected = {'cloudant': {share: ['_reader']}}
@@ -713,7 +715,7 @@ class CloudantDatabaseTests(UnitTestDbBase):
         )
         self.assertIsInstance(result, QueryResult)
         for doc in result:
-            doc_fields = doc.keys()
+            doc_fields = list(doc.keys())
             doc_fields.sort()
             self.assertEqual(doc_fields, expected_fields)
         self.assertEqual(
@@ -739,7 +741,7 @@ class CloudantDatabaseTests(UnitTestDbBase):
         )
         self.assertIsInstance(result, QueryResult)
         for doc in result:
-            doc_fields = doc.keys()
+            doc_fields = list(doc.keys())
             doc_fields.sort()
             self.assertEqual(doc_fields, expected_fields)
         self.assertEqual(

--- a/tests/unit/db/database_tests.py
+++ b/tests/unit/db/database_tests.py
@@ -36,7 +36,7 @@ from cloudant.design_document import DesignDocument
 from cloudant.indexes import Index, SearchIndex, SpecialIndex
 
 from .unit_t_db_base import UnitTestDbBase
-from ... import _unicode
+from ... import unicode_
 
 
 class DatabaseTests(UnitTestDbBase):
@@ -614,13 +614,13 @@ class CloudantDatabaseTests(UnitTestDbBase):
 
     def test_get_security_document(self):
         self.assertEqual(self.db.security_document(), {})
-        share = 'unit-test-share-user-{0}'.format(_unicode(uuid.uuid4()))
+        share = 'unit-test-share-user-{0}'.format(unicode_(uuid.uuid4()))
         self.db.share_database(share)
         expected = {'cloudant': {share: ['_reader']}}
         self.assertEqual(self.db.security_document(), expected)
 
     def test_share_unshare_database(self):
-        share = 'unit-test-share-user-{0}'.format(_unicode(uuid.uuid4()))
+        share = 'unit-test-share-user-{0}'.format(unicode_(uuid.uuid4()))
         self.assertEqual(self.db.security_document(), {})
         self.assertEqual(self.db.share_database(share), {'ok': True})
         expected = {'cloudant': {share: ['_reader']}}

--- a/tests/unit/db/database_tests.py
+++ b/tests/unit/db/database_tests.py
@@ -21,7 +21,6 @@ See configuration options for environment variables in unit_t_db_base
 module docstring.
 
 """
-from __future__ import absolute_import
 
 import unittest
 import requests
@@ -37,7 +36,6 @@ from cloudant.indexes import Index, SearchIndex, SpecialIndex
 
 from .unit_t_db_base import UnitTestDbBase
 from ... import unicode_
-
 
 class DatabaseTests(UnitTestDbBase):
     """
@@ -317,7 +315,7 @@ class DatabaseTests(UnitTestDbBase):
         Test __getitem__ when retrieving a non-existing document
         """
         try:
-            _ = self.db['no_such_doc']
+            doc = self.db['no_such_doc']
             self.fail('Above statement should raise a KeyError')
         except KeyError:
             pass
@@ -446,7 +444,7 @@ class DatabaseTests(UnitTestDbBase):
             doc.delete()
 
         # Confirm successful deletions
-        for _ in self.db:
+        for doc in self.db:
             self.fail('All documents should have been deleted!!!')
 
         # Confirm that the correct number of Document (3) and DesignDocument (1)
@@ -613,26 +611,26 @@ class CloudantDatabaseTests(UnitTestDbBase):
         super(CloudantDatabaseTests, self).tearDown()
 
     def test_get_security_document(self):
-        self.assertEqual(self.db.security_document(), {})
+        self.assertDictEqual(self.db.security_document(), dict())
         share = 'unit-test-share-user-{0}'.format(unicode_(uuid.uuid4()))
         self.db.share_database(share)
         expected = {'cloudant': {share: ['_reader']}}
-        self.assertEqual(self.db.security_document(), expected)
+        self.assertDictEqual(self.db.security_document(), expected)
 
     def test_share_unshare_database(self):
         share = 'unit-test-share-user-{0}'.format(unicode_(uuid.uuid4()))
-        self.assertEqual(self.db.security_document(), {})
-        self.assertEqual(self.db.share_database(share), {'ok': True})
+        self.assertDictEqual(self.db.security_document(), dict())
+        self.assertDictEqual(self.db.share_database(share), {'ok': True})
         expected = {'cloudant': {share: ['_reader']}}
-        self.assertEqual(self.db.security_document(), expected)
-        self.assertEqual(
+        self.assertDictEqual(self.db.security_document(), expected)
+        self.assertDictEqual(
             self.db.share_database(share, True, True, True),
             {'ok': True}
         )
         expected = {'cloudant': {share: ['_reader', '_writer', '_admin']}}
-        self.assertEqual(self.db.security_document(), expected)
-        self.assertEqual(self.db.unshare_database(share), {'ok': True})
-        self.assertEqual(self.db.security_document(), {'cloudant':{}})
+        self.assertDictEqual(self.db.security_document(), expected)
+        self.assertDictEqual(self.db.unshare_database(share), {'ok': True})
+        self.assertDictEqual(self.db.security_document(), {'cloudant': dict()})
 
     def test_retrieve_shards(self):
         shards = self.db.shards()

--- a/tests/unit/db/design_document_tests.py
+++ b/tests/unit/db/design_document_tests.py
@@ -21,6 +21,7 @@ See configuration options for environment variables in unit_t_db_base
 module docstring.
 
 """
+from __future__ import absolute_import
 
 import unittest
 
@@ -29,7 +30,7 @@ from cloudant.design_document import DesignDocument
 from cloudant.views import View, QueryIndexView
 from cloudant.errors import CloudantArgumentError, CloudantException
 
-from unit_t_db_base import UnitTestDbBase
+from .unit_t_db_base import UnitTestDbBase
 
 class DesignDocumentTests(UnitTestDbBase):
     """
@@ -139,7 +140,7 @@ class DesignDocumentTests(UnitTestDbBase):
             'view001',
             'function (doc) {\n  emit(doc._id, 1);\n}'
         )
-        self.assertEqual(ddoc.get('views').keys(), ['view001'])
+        self.assertListEqual(list(ddoc.get('views').keys()), ['view001'])
         self.assertIsInstance(ddoc.get('views')['view001'], View)
         self.assertEqual(
             ddoc.get('views')['view001'],
@@ -158,7 +159,7 @@ class DesignDocumentTests(UnitTestDbBase):
         try:
             ddoc.add_view('view001', 'function (doc) {\n  emit(doc._id, 2);\n}')
             self.fail('Above statement should raise an Exception')
-        except CloudantArgumentError, err:
+        except CloudantArgumentError as err:
             self.assertEqual(
                 str(err),
                 'View view001 already exists in this design doc'
@@ -210,7 +211,7 @@ class DesignDocumentTests(UnitTestDbBase):
                 'function (doc) {\n  emit(doc._id, 1);\n}'
             )
             self.fail('Above statement should raise an Exception')
-        except CloudantArgumentError, err:
+        except CloudantArgumentError as err:
             self.assertEqual(
                 str(err),
                 'View view001 does not exist in this design doc'
@@ -583,7 +584,7 @@ class DesignDocumentTests(UnitTestDbBase):
         try:
             ddoc.info()
             self.fail('Above statement should raise an Exception')
-        except NotImplementedError, err:
+        except NotImplementedError as err:
             self.assertEqual(str(err), '_info not yet implemented')
 
 if __name__ == '__main__':

--- a/tests/unit/db/design_document_tests.py
+++ b/tests/unit/db/design_document_tests.py
@@ -21,7 +21,6 @@ See configuration options for environment variables in unit_t_db_base
 module docstring.
 
 """
-from __future__ import absolute_import
 
 import unittest
 

--- a/tests/unit/db/document_tests.py
+++ b/tests/unit/db/document_tests.py
@@ -518,7 +518,7 @@ class DocumentTests(UnitTestDbBase):
             expected.fetch()
             # Test retrieving an attachment
             self.assertEqual(
-                doc.get_attachment('attachment.txt',attachment_type='text'),
+                doc.get_attachment('attachment.txt', attachment_type='text'),
                 attachment.getvalue()
             )
             # Test update an attachment
@@ -549,7 +549,7 @@ class DocumentTests(UnitTestDbBase):
             self.assertTrue(updated_size > orig_size)
             self.assertEqual(updated_size, len(attachment.getvalue()))
             self.assertEqual(
-                doc.get_attachment('attachment.txt',attachment_type='text'),
+                doc.get_attachment('attachment.txt', attachment_type='text'),
                 attachment.getvalue()
             )
             # Confirm that the local document dictionary matches 

--- a/tests/unit/db/document_tests.py
+++ b/tests/unit/db/document_tests.py
@@ -21,22 +21,16 @@ See configuration options for environment variables in unit_t_db_base
 module docstring.
 
 """
-from __future__ import absolute_import
 
 import unittest
 import posixpath
 import json
 import requests
 
-from ... import PY2
-if PY2:
-    from StringIO import StringIO
-else:
-    from io import StringIO
-
 from cloudant.document import Document
 from cloudant.errors import CloudantException
 
+from ... import StringIO
 from .unit_t_db_base import UnitTestDbBase
 
 class DocumentTests(UnitTestDbBase):

--- a/tests/unit/db/document_tests.py
+++ b/tests/unit/db/document_tests.py
@@ -21,17 +21,23 @@ See configuration options for environment variables in unit_t_db_base
 module docstring.
 
 """
+from __future__ import absolute_import
 
 import unittest
 import posixpath
 import json
 import requests
-import StringIO
+
+from ... import PY2
+if PY2:
+    from StringIO import StringIO
+else:
+    from io import StringIO
 
 from cloudant.document import Document
 from cloudant.errors import CloudantException
 
-from unit_t_db_base import UnitTestDbBase
+from .unit_t_db_base import UnitTestDbBase
 
 class DocumentTests(UnitTestDbBase):
     """
@@ -190,7 +196,7 @@ class DocumentTests(UnitTestDbBase):
         try:
             doc.create()
             self.fail('Above statement should raise an Exception')
-        except requests.HTTPError, err:
+        except requests.HTTPError as err:
             self.assertEqual(err.response.status_code, 409)
 
     def test_fetch_document_without_docid(self):
@@ -201,7 +207,7 @@ class DocumentTests(UnitTestDbBase):
         try:
             doc.fetch()
             self.fail('Above statement should raise an Exception')
-        except CloudantException, err:
+        except CloudantException as err:
             self.assertEqual(
                 str(err),
                 'A document id is required to fetch document contents.  '
@@ -216,7 +222,7 @@ class DocumentTests(UnitTestDbBase):
         try:
             doc.fetch()
             self.fail('Above statement should raise an Exception')
-        except requests.HTTPError, err:
+        except requests.HTTPError as err:
             self.assertEqual(err.response.status_code, 404)
 
     def test_fetch_existing_document_with_docid(self):
@@ -321,7 +327,7 @@ class DocumentTests(UnitTestDbBase):
         try:
             doc.list_field_append(doc, 'name', 'isabel')
             self.fail('Above statement should raise an Exception')
-        except CloudantException, err:
+        except CloudantException as err:
             self.assertEqual(str(err), 'The field name is not a list.')
         self.assertEqual(doc, {'name': 'julia'})
 
@@ -347,7 +353,7 @@ class DocumentTests(UnitTestDbBase):
         try:
             doc.list_field_remove(doc, 'name', 'julia')
             self.fail('Above statement should raise an Exception')
-        except CloudantException, err:
+        except CloudantException as err:
             self.assertEqual(str(err), 'The field name is not a list.')
         self.assertEqual(doc, {'name': 'julia'})
 
@@ -394,7 +400,7 @@ class DocumentTests(UnitTestDbBase):
         try:
             doc.delete()
             self.fail('Above statement should raise an Exception')
-        except CloudantException, err:
+        except CloudantException as err:
             self.assertEqual(
                 str(err), 
                 'Attempting to delete a doc with no _rev. '
@@ -441,7 +447,7 @@ class DocumentTests(UnitTestDbBase):
         self.assertTrue(new_doc.exists())
         del new_doc
         with Document(self.db, 'julia006') as doc:
-            self.assertTrue(all(x in doc.keys() for x in ['_id', '_rev']))
+            self.assertTrue(all(x in list(doc.keys()) for x in ['_id', '_rev']))
             self.assertTrue(doc['_rev'].startswith('1-'))
             doc['name'] = 'julia'
             doc['age'] = 6
@@ -476,7 +482,7 @@ class DocumentTests(UnitTestDbBase):
         doc = self.db.create_document(
             {'_id': 'julia006', 'name': 'julia', 'age': 6}
         )
-        attachment = StringIO.StringIO()
+        attachment = StringIO()
         try:
             attachment.write('This is line one of the attachment.\n')
             attachment.write('This is line two of the attachment.\n')
@@ -491,7 +497,7 @@ class DocumentTests(UnitTestDbBase):
             self.assertTrue(resp['rev'].startswith('2-'))
             self.assertEqual(doc['_rev'], resp['rev'])
             self.assertTrue(
-                all(x in doc.keys() for x in [
+                all(x in list(doc.keys()) for x in [
                     '_id',
                     '_rev',
                     'name',
@@ -500,7 +506,7 @@ class DocumentTests(UnitTestDbBase):
                 ])
             )
             self.assertTrue(
-                all(x in doc['_attachments'].keys() for x in [
+                all(x in list(doc['_attachments'].keys()) for x in [
                     'attachment.txt'
                 ])
             )
@@ -526,7 +532,7 @@ class DocumentTests(UnitTestDbBase):
             self.assertTrue(resp['rev'].startswith('3-'))
             self.assertEqual(doc['_rev'], resp['rev'])
             self.assertTrue(
-                all(x in doc.keys() for x in [
+                all(x in list(doc.keys()) for x in [
                     '_id',
                     '_rev',
                     'name',
@@ -535,7 +541,7 @@ class DocumentTests(UnitTestDbBase):
                 ])
             )
             self.assertTrue(
-                all(x in doc['_attachments'].keys() for x in [
+                all(x in list(doc['_attachments'].keys()) for x in [
                     'attachment.txt'
                 ])
             )
@@ -565,7 +571,7 @@ class DocumentTests(UnitTestDbBase):
             self.assertTrue(resp['rev'].startswith('5-'))
             self.assertEqual(doc['_rev'], resp['rev'])
             self.assertTrue(
-                all(x in doc.keys() for x in [
+                all(x in list(doc.keys()) for x in [
                     '_id',
                     '_rev',
                     'name',
@@ -585,7 +591,7 @@ class DocumentTests(UnitTestDbBase):
             self.assertTrue(resp['rev'].startswith('6-'))
             self.assertEqual(doc['_rev'], resp['rev'])
             self.assertTrue(
-                all(x in doc.keys() for x in [
+                all(x in list(doc.keys()) for x in [
                     '_id',
                     '_rev',
                     'name',

--- a/tests/unit/db/index_tests.py
+++ b/tests/unit/db/index_tests.py
@@ -20,6 +20,7 @@ See configuration options for environment variables in unit_t_db_base
 module docstring.
 
 """
+from __future__ import absolute_import
 
 import unittest
 import mock
@@ -34,7 +35,7 @@ from cloudant.design_document import DesignDocument
 from cloudant.document import Document
 from cloudant.errors import CloudantArgumentError, CloudantException
 
-from unit_t_db_base import UnitTestDbBase
+from .unit_t_db_base import UnitTestDbBase
 
 @unittest.skipUnless(
     os.environ.get('RUN_CLOUDANT_TESTS') is not None,
@@ -130,7 +131,7 @@ class IndexTests(UnitTestDbBase):
         self.assertEqual(index.name, 'index001')
         with DesignDocument(self.db, index.design_document_id) as ddoc:
             self.assertEqual(ddoc['language'], 'query')
-            self.assertEqual(ddoc['views'].keys(), ['index001'])
+            self.assertListEqual(list(ddoc['views'].keys()), ['index001'])
             self.assertIsInstance(ddoc.get_view('index001'), QueryIndexView)
             self.assertTrue(ddoc['_rev'].startswith('1-'))
             self.assertEqual(ddoc,
@@ -156,7 +157,7 @@ class IndexTests(UnitTestDbBase):
         self.assertIsNotNone(index.name)
         with DesignDocument(self.db, index.design_document_id) as ddoc:
             self.assertEqual(ddoc['language'], 'query')
-            self.assertEqual(ddoc['views'].keys(), [index.name])
+            self.assertListEqual(list(ddoc['views'].keys()), [index.name])
             self.assertIsInstance(ddoc.get_view(index.name), QueryIndexView)
             self.assertTrue(ddoc['_rev'].startswith('1-'))
             self.assertEqual(ddoc,
@@ -182,7 +183,7 @@ class IndexTests(UnitTestDbBase):
         self.assertIsNotNone(index.name)
         with DesignDocument(self.db, index.design_document_id) as ddoc:
             self.assertEqual(ddoc['language'], 'query')
-            self.assertEqual(ddoc['views'].keys(), [index.name])
+            self.assertListEqual(list(ddoc['views'].keys()), [index.name])
             self.assertIsInstance(ddoc.get_view(index.name), QueryIndexView)
             self.assertTrue(ddoc['_rev'].startswith('1-'))
             self.assertEqual(ddoc,
@@ -208,7 +209,7 @@ class IndexTests(UnitTestDbBase):
         self.assertEqual(index.name, 'index001')
         with DesignDocument(self.db, index.design_document_id) as ddoc:
             self.assertEqual(ddoc['language'], 'query')
-            self.assertEqual(ddoc['views'].keys(), ['index001'])
+            self.assertListEqual(list(ddoc['views'].keys()), ['index001'])
             self.assertIsInstance(ddoc.get_view('index001'), QueryIndexView)
             self.assertTrue(ddoc['_rev'].startswith('1-'))
             self.assertEqual(ddoc,
@@ -410,7 +411,7 @@ class SearchIndexTests(UnitTestDbBase):
         self.assertEqual(index.name, 'index001')
         with DesignDocument(self.db, index.design_document_id) as ddoc:
             self.assertEqual(ddoc['language'], 'query')
-            self.assertEqual(ddoc['indexes'].keys(), ['index001'])
+            self.assertListEqual(list(ddoc['indexes'].keys()), ['index001'])
             self.assertTrue(ddoc['_rev'].startswith('1-'))
             self.assertEqual(ddoc,
                 {'_id': '_design/ddoc001',
@@ -444,7 +445,7 @@ class SearchIndexTests(UnitTestDbBase):
         self.assertEqual(index.name, 'index001')
         with DesignDocument(self.db, index.design_document_id) as ddoc:
             self.assertEqual(ddoc['language'], 'query')
-            self.assertEqual(ddoc['indexes'].keys(), ['index001'])
+            self.assertListEqual(list(ddoc['indexes'].keys()), ['index001'])
             self.assertTrue(ddoc['_rev'].startswith('1-'))
             self.assertEqual(ddoc,
                 {'_id': '_design/ddoc001',

--- a/tests/unit/db/index_tests.py
+++ b/tests/unit/db/index_tests.py
@@ -35,6 +35,7 @@ from cloudant.design_document import DesignDocument
 from cloudant.document import Document
 from cloudant.errors import CloudantArgumentError, CloudantException
 
+from ... import PY2
 from .unit_t_db_base import UnitTestDbBase
 
 @unittest.skipUnless(
@@ -486,7 +487,7 @@ class SearchIndexTests(UnitTestDbBase):
         self.assertEqual(
             str(err),
             'Argument fields is not an instance of expected type: '
-            '<type \'list\'>'
+            '<{} \'list\'>'.format('type' if PY2 else 'class')
         )
 
     def test_create_a_search_index_invalid_default_field_value(self):
@@ -501,7 +502,7 @@ class SearchIndexTests(UnitTestDbBase):
         self.assertEqual(
             str(err),
             'Argument default_field is not an instance of expected type: '
-            '<type \'dict\'>'
+            '<{} \'dict\'>'.format('type' if PY2 else 'class')
         )
 
     def test_create_a_search_index_invalid_selector_value(self):
@@ -516,7 +517,7 @@ class SearchIndexTests(UnitTestDbBase):
         self.assertEqual(
             str(err),
             'Argument selector is not an instance of expected type: '
-            '<type \'dict\'>'
+            '<{} \'dict\'>'.format('type' if PY2 else 'class')
         )
 
     def test_search_index_via_query(self):

--- a/tests/unit/db/query_result_tests.py
+++ b/tests/unit/db/query_result_tests.py
@@ -19,7 +19,6 @@ See configuration options for environment variables in unit_t_db_base
 module docstring.
 
 """
-from __future__ import absolute_import
 
 import unittest
 import os

--- a/tests/unit/db/query_result_tests.py
+++ b/tests/unit/db/query_result_tests.py
@@ -19,17 +19,17 @@ See configuration options for environment variables in unit_t_db_base
 module docstring.
 
 """
+from __future__ import absolute_import
 
 import unittest
 import os
-import posixpath
 import requests
 
 from cloudant.query import Query
 from cloudant.result import QueryResult
 from cloudant.errors import CloudantArgumentError
 
-from unit_t_db_base import UnitTestDbBase
+from .unit_t_db_base import UnitTestDbBase
 
 @unittest.skipUnless(
     os.environ.get('RUN_CLOUDANT_TESTS') is not None,
@@ -90,7 +90,7 @@ class QueryResultTests(UnitTestDbBase):
         try:
             docs = result[:]
             self.fail('Above statement should raise an Exception')
-        except CloudantArgumentError, err:
+        except CloudantArgumentError as err:
             self.assertEqual(
                 str(err),
                 'Cannot use skip parameter with QueryResult slicing.'
@@ -110,7 +110,7 @@ class QueryResultTests(UnitTestDbBase):
         try:
             docs = result[:]
             self.fail('Above statement should raise an Exception')
-        except CloudantArgumentError, err:
+        except CloudantArgumentError as err:
             self.assertEqual(
                 str(err),
                 'Cannot use limit parameter with QueryResult slicing.'
@@ -208,7 +208,7 @@ class QueryResultTests(UnitTestDbBase):
         try:
             docs = result[10:5]
             self.fail('Above statement should raise an Exception')
-        except requests.HTTPError, err:
+        except requests.HTTPError as err:
             self.assertEqual(err.response.status_code, 400)
 
     def test_key_access_is_not_supported(self):
@@ -224,7 +224,7 @@ class QueryResultTests(UnitTestDbBase):
         try:
             docs = result['julia006']
             self.fail('Above statement should raise an Exception')
-        except CloudantArgumentError, err:
+        except CloudantArgumentError as err:
             self.assertEqual(
                 str(err),
                 'Failed to interpret the argument julia006 as an element slice.'
@@ -246,7 +246,7 @@ class QueryResultTests(UnitTestDbBase):
         try:
             docs = result['julia006': 'julia010']
             self.fail('Above statement should raise an Exception')
-        except CloudantArgumentError, err:
+        except CloudantArgumentError as err:
             self.assertEqual(
                 str(err),
                 'Failed to interpret the argument '
@@ -269,7 +269,7 @@ class QueryResultTests(UnitTestDbBase):
         try:
             for doc in result:
                 self.fail('Above statement should raise an Exception')
-        except CloudantArgumentError, err:
+        except CloudantArgumentError as err:
             self.assertEqual(
                 str(err),
                 'Cannot use skip for iteration'
@@ -289,7 +289,7 @@ class QueryResultTests(UnitTestDbBase):
         try:
             for doc in result:
                 self.fail('Above statement should raise an Exception')
-        except CloudantArgumentError, err:
+        except CloudantArgumentError as err:
             self.assertEqual(
                 str(err),
                 'Cannot use limit for iteration'
@@ -309,7 +309,7 @@ class QueryResultTests(UnitTestDbBase):
         try:
             for doc in result:
                 self.fail('Above statement should raise an Exception')
-        except CloudantArgumentError, err:
+        except CloudantArgumentError as err:
             self.assertEqual(str(err), 'Invalid page_size: 0')
 
     def test_iteration_result_eq_page_size(self):

--- a/tests/unit/db/query_tests.py
+++ b/tests/unit/db/query_tests.py
@@ -19,7 +19,6 @@ See configuration options for environment variables in unit_t_db_base
 module docstring.
 
 """
-from __future__ import absolute_import
 
 import unittest
 import os

--- a/tests/unit/db/query_tests.py
+++ b/tests/unit/db/query_tests.py
@@ -19,6 +19,7 @@ See configuration options for environment variables in unit_t_db_base
 module docstring.
 
 """
+from __future__ import absolute_import
 
 import unittest
 import os
@@ -28,7 +29,7 @@ from cloudant.query import Query
 from cloudant.result import QueryResult
 from cloudant.errors import CloudantArgumentError
 
-from unit_t_db_base import UnitTestDbBase
+from .unit_t_db_base import UnitTestDbBase
 
 @unittest.skipUnless(
     os.environ.get('RUN_CLOUDANT_TESTS') is not None,
@@ -89,7 +90,7 @@ class QueryTests(UnitTestDbBase):
         try:
             query(foo={'bar': 'baz'})
             self.fail('Above statement should raise an Exception')
-        except CloudantArgumentError, err:
+        except CloudantArgumentError as err:
             self.assertEqual(str(err), 'Invalid argument: foo')
 
     def test_callable_with_invalid_value_types(self):
@@ -112,10 +113,10 @@ class QueryTests(UnitTestDbBase):
             try:
                 query(**argument)
                 self.fail('Above statement should raise an Exception')
-            except CloudantArgumentError, err:
+            except CloudantArgumentError as err:
                 self.assertTrue(str(err).startswith(
                     'Argument {0} is not an instance of expected type:'.format(
-                        argument.keys()[0]
+                        list(argument.keys())[0]
                     )
                 ))
 
@@ -127,7 +128,7 @@ class QueryTests(UnitTestDbBase):
         try:
             query(fields=['_id', '_rev'])
             self.fail('Above statement should raise an Exception')
-        except CloudantArgumentError, err:
+        except CloudantArgumentError as err:
             self.assertEqual(
                 str(err),
                 'No selector in the query or the selector was empty.  '
@@ -142,7 +143,7 @@ class QueryTests(UnitTestDbBase):
         try:
             query(selector={}, fields=['_id', '_rev'])
             self.fail('Above statement should raise an Exception')
-        except CloudantArgumentError, err:
+        except CloudantArgumentError as err:
             self.assertEqual(
                 str(err),
                 'No selector in the query or the selector was empty.  '

--- a/tests/unit/db/replicator_tests.py
+++ b/tests/unit/db/replicator_tests.py
@@ -33,7 +33,7 @@ from cloudant.document import Document
 from cloudant.errors import CloudantException
 
 from .unit_t_db_base import UnitTestDbBase
-from ... import _unicode
+from ... import unicode_
 
 
 class ReplicatorTests(UnitTestDbBase):
@@ -64,7 +64,7 @@ class ReplicatorTests(UnitTestDbBase):
         del self.test_target_dbname
         del self.target_db
         while self.replication_ids:
-                self.replicator.stop_replication(self.replication_ids.pop())
+            self.replicator.stop_replication(self.replication_ids.pop())
         del self.replicator
         self.db_tear_down()
         super(ReplicatorTests, self).tearDown()
@@ -106,7 +106,7 @@ class ReplicatorTests(UnitTestDbBase):
         replication is successful.
         """
         self.populate_db_with_documents(3)
-        repl_id = 'test-repl-{}'.format(_unicode(uuid.uuid4()))
+        repl_id = 'test-repl-{}'.format(unicode_(uuid.uuid4()))
 
         repl_doc = self.replicator.create_replication(
             self.db,
@@ -115,7 +115,7 @@ class ReplicatorTests(UnitTestDbBase):
         )
         self.replication_ids.append(repl_id)
         # Test that the replication document was created
-        expected_keys = ['_id', '_rev', 'source', 'target', 'user_ctx']
+        expected_keys = ('_id', '_rev', 'source', 'target', 'user_ctx')
         self.assertTrue(all(x in list(repl_doc.keys()) for x in expected_keys))
         self.assertEqual(repl_doc['_id'], repl_id)
         self.assertTrue(repl_doc['_rev'].startswith('1-'))
@@ -123,14 +123,13 @@ class ReplicatorTests(UnitTestDbBase):
         # check that the replication occurred.
         repl_doc = Document(self.replicator.database, repl_id)
         repl_doc.fetch()
-        if not (repl_doc.get('_replication_state')
-            in ('completed', 'error')):
+        if repl_doc.get('_replication_state') not in ('completed', 'error'):
             for change in self.replicator.database.changes():
                 if change.get('id') == repl_id:
                     repl_doc = Document(self.replicator.database, repl_id)
                     repl_doc.fetch()
-                    if (repl_doc.get('_replication_state')
-                        in ('completed', 'error')):
+                    if (repl_doc.get('_replication_state') in
+                            ('completed', 'error')):
                         break
         self.assertEqual(repl_doc['_replication_state'], 'completed')
         self.assertEqual(self.db.all_docs(), self.target_db.all_docs())
@@ -178,7 +177,7 @@ class ReplicatorTests(UnitTestDbBase):
         """
         self.populate_db_with_documents(3)
         repl_ids = ['test-repl-{}'.format(
-            _unicode(uuid.uuid4())
+            unicode_(uuid.uuid4())
         ) for _ in range(3)]
         repl_docs = [self.replicator.create_replication(
             self.db,
@@ -196,7 +195,7 @@ class ReplicatorTests(UnitTestDbBase):
         Test that the replication state can be retrieved for a replication
         """
         self.populate_db_with_documents(3)
-        repl_id = "test-repl-{}".format(_unicode(uuid.uuid4()))
+        repl_id = "test-repl-{}".format(unicode_(uuid.uuid4()))
         repl_doc = self.replicator.create_replication(
             self.db,
             self.target_db,
@@ -220,7 +219,7 @@ class ReplicatorTests(UnitTestDbBase):
         Test that replication_state(...) raises an exception as expected
         when an invalid replication id is provided.
         """
-        repl_id = 'fake-repl-id-{}'.format(_unicode(uuid.uuid4()))
+        repl_id = 'fake-repl-id-{}'.format(unicode_(uuid.uuid4()))
         repl_state = None
         try:
             self.replicator.replication_state(repl_id)
@@ -237,7 +236,7 @@ class ReplicatorTests(UnitTestDbBase):
         Test that a replication can be stopped.
         """
         self.populate_db_with_documents(3)
-        repl_id = "test-repl-{}".format(_unicode(uuid.uuid4()))
+        repl_id = "test-repl-{}".format(unicode_(uuid.uuid4()))
         repl_doc = self.replicator.create_replication(
             self.db,
             self.target_db,
@@ -257,7 +256,7 @@ class ReplicatorTests(UnitTestDbBase):
         Test that stop_replication(...) raises an exception as expected
         when an invalid replication id is provided.
         """
-        repl_id = 'fake-repl-id-{}'.format(_unicode(uuid.uuid4()))
+        repl_id = 'fake-repl-id-{}'.format(unicode_(uuid.uuid4()))
         try:
             self.replicator.stop_replication(repl_id)
             self.fail('Above statement should raise a CloudantException')
@@ -273,21 +272,22 @@ class ReplicatorTests(UnitTestDbBase):
         replication documents while the replication is executing.
         """
         self.populate_db_with_documents(3)
-        repl_id = "test-repl-{}".format(_unicode(uuid.uuid4()))
+        repl_id = "test-repl-{}".format(unicode_(uuid.uuid4()))
         repl_doc = self.replicator.create_replication(
             self.db,
             self.target_db,
             repl_id
         )
         self.replication_ids.append(repl_id)
-        valid_states = ['completed', 'error', 'triggered', None]
+        valid_states = ('completed', 'error', 'triggered', None)
         repl_states = []
         for doc in self.replicator.follow_replication(repl_id):
-            self.assertTrue(doc.get('_replication_state') in valid_states)
+            self.assertIn(doc.get('_replication_state'), valid_states)
             repl_states.append(doc.get('_replication_state'))
         self.assertTrue(len(repl_states) > 0)
+        print(repl_states)
         self.assertEqual(repl_states[-1], 'completed')
-        self.assertTrue('error' not in repl_states)
+        self.assertNotIn('error', repl_states)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/db/replicator_tests.py
+++ b/tests/unit/db/replicator_tests.py
@@ -21,7 +21,6 @@ See configuration options for environment variables in unit_t_db_base
 module docstring.
 
 """
-from __future__ import absolute_import
 
 import unittest
 import uuid
@@ -34,7 +33,6 @@ from cloudant.errors import CloudantException
 
 from .unit_t_db_base import UnitTestDbBase
 from ... import unicode_
-
 
 class ReplicatorTests(UnitTestDbBase):
     """
@@ -128,8 +126,8 @@ class ReplicatorTests(UnitTestDbBase):
                 if change.get('id') == repl_id:
                     repl_doc = Document(self.replicator.database, repl_id)
                     repl_doc.fetch()
-                    if (repl_doc.get('_replication_state') in
-                            ('completed', 'error')):
+                    if (repl_doc.get('_replication_state')
+                        in ('completed', 'error')):
                         break
         self.assertEqual(repl_doc['_replication_state'], 'completed')
         self.assertEqual(self.db.all_docs(), self.target_db.all_docs())
@@ -285,7 +283,6 @@ class ReplicatorTests(UnitTestDbBase):
             self.assertIn(doc.get('_replication_state'), valid_states)
             repl_states.append(doc.get('_replication_state'))
         self.assertTrue(len(repl_states) > 0)
-        print(repl_states)
         self.assertEqual(repl_states[-1], 'completed')
         self.assertNotIn('error', repl_states)
 

--- a/tests/unit/db/replicator_tests.py
+++ b/tests/unit/db/replicator_tests.py
@@ -21,6 +21,7 @@ See configuration options for environment variables in unit_t_db_base
 module docstring.
 
 """
+from __future__ import absolute_import
 
 import unittest
 import uuid
@@ -31,7 +32,9 @@ from cloudant.replicator import Replicator
 from cloudant.document import Document
 from cloudant.errors import CloudantException
 
-from unit_t_db_base import UnitTestDbBase
+from .unit_t_db_base import UnitTestDbBase
+from ... import _unicode
+
 
 class ReplicatorTests(UnitTestDbBase):
     """
@@ -87,7 +90,7 @@ class ReplicatorTests(UnitTestDbBase):
             self.client.disconnect()
             repl = Replicator(self.client)
             self.fail('Above statement should raise a CloudantException')
-        except CloudantException, err:
+        except CloudantException as err:
             self.assertEqual(
                 str(err),
                 'Unable to acquire _replicator database.  '
@@ -103,7 +106,7 @@ class ReplicatorTests(UnitTestDbBase):
         replication is successful.
         """
         self.populate_db_with_documents(3)
-        repl_id = 'test-repl-{}'.format(unicode(uuid.uuid4()))
+        repl_id = 'test-repl-{}'.format(_unicode(uuid.uuid4()))
 
         repl_doc = self.replicator.create_replication(
             self.db,
@@ -113,7 +116,7 @@ class ReplicatorTests(UnitTestDbBase):
         self.replication_ids.append(repl_id)
         # Test that the replication document was created
         expected_keys = ['_id', '_rev', 'source', 'target', 'user_ctx']
-        self.assertTrue(all(x in repl_doc.keys() for x in expected_keys))
+        self.assertTrue(all(x in list(repl_doc.keys()) for x in expected_keys))
         self.assertEqual(repl_doc['_id'], repl_id)
         self.assertTrue(repl_doc['_rev'].startswith('1-'))
         # Now that we know that the replication document was created,
@@ -147,7 +150,7 @@ class ReplicatorTests(UnitTestDbBase):
         try:
             repl_doc = self.replicator.create_replication()
             self.fail('Above statement should raise a CloudantException')
-        except CloudantException, err:
+        except CloudantException as err:
             self.assertEqual(
                 str(err),
                 'You must specify either a source_db Database '
@@ -162,7 +165,7 @@ class ReplicatorTests(UnitTestDbBase):
         try:
             repl_doc = self.replicator.create_replication(self.db)
             self.fail('Above statement should raise a CloudantException')
-        except CloudantException, err:
+        except CloudantException as err:
             self.assertEqual(
                 str(err),
                 'You must specify either a target_db Database '
@@ -175,8 +178,8 @@ class ReplicatorTests(UnitTestDbBase):
         """
         self.populate_db_with_documents(3)
         repl_ids = ['test-repl-{}'.format(
-            unicode(uuid.uuid4())
-        ) for _ in xrange(3)]
+            _unicode(uuid.uuid4())
+        ) for _ in range(3)]
         repl_docs = [self.replicator.create_replication(
             self.db,
             self.target_db,
@@ -193,7 +196,7 @@ class ReplicatorTests(UnitTestDbBase):
         Test that the replication state can be retrieved for a replication
         """
         self.populate_db_with_documents(3)
-        repl_id = "test-repl-{}".format(unicode(uuid.uuid4()))
+        repl_id = "test-repl-{}".format(_unicode(uuid.uuid4()))
         repl_doc = self.replicator.create_replication(
             self.db,
             self.target_db,
@@ -203,7 +206,7 @@ class ReplicatorTests(UnitTestDbBase):
         repl_state = None
         valid_states = ['completed', 'error', 'triggered', None]
         finished = False
-        for _ in xrange(300):
+        for _ in range(300):
             repl_state = self.replicator.replication_state(repl_id)
             self.assertTrue(repl_state in valid_states)
             if repl_state in ('error', 'completed'):
@@ -217,12 +220,12 @@ class ReplicatorTests(UnitTestDbBase):
         Test that replication_state(...) raises an exception as expected
         when an invalid replication id is provided.
         """
-        repl_id = 'fake-repl-id-{}'.format(unicode(uuid.uuid4()))
+        repl_id = 'fake-repl-id-{}'.format(_unicode(uuid.uuid4()))
         repl_state = None
         try:
             self.replicator.replication_state(repl_id)
             self.fail('Above statement should raise a CloudantException')
-        except CloudantException, err:
+        except CloudantException as err:
             self.assertEqual(
                 str(err),
                 'Replication {} not found'.format(repl_id)
@@ -234,7 +237,7 @@ class ReplicatorTests(UnitTestDbBase):
         Test that a replication can be stopped.
         """
         self.populate_db_with_documents(3)
-        repl_id = "test-repl-{}".format(unicode(uuid.uuid4()))
+        repl_id = "test-repl-{}".format(_unicode(uuid.uuid4()))
         repl_doc = self.replicator.create_replication(
             self.db,
             self.target_db,
@@ -246,7 +249,7 @@ class ReplicatorTests(UnitTestDbBase):
             # and the replication document has been removed from the db.
             repl_doc.fetch()
             self.fail('Above statement should raise a CloudantException')
-        except requests.HTTPError, err:
+        except requests.HTTPError as err:
             self.assertEqual(err.response.status_code, 404)
 
     def test_stop_replication_using_invalid_id(self):
@@ -254,11 +257,11 @@ class ReplicatorTests(UnitTestDbBase):
         Test that stop_replication(...) raises an exception as expected
         when an invalid replication id is provided.
         """
-        repl_id = 'fake-repl-id-{}'.format(unicode(uuid.uuid4()))
+        repl_id = 'fake-repl-id-{}'.format(_unicode(uuid.uuid4()))
         try:
             self.replicator.stop_replication(repl_id)
             self.fail('Above statement should raise a CloudantException')
-        except CloudantException, err:
+        except CloudantException as err:
             self.assertEqual(
                 str(err),
                 'Could not find replication with id {}'.format(repl_id)
@@ -270,7 +273,7 @@ class ReplicatorTests(UnitTestDbBase):
         replication documents while the replication is executing.
         """
         self.populate_db_with_documents(3)
-        repl_id = "test-repl-{}".format(unicode(uuid.uuid4()))
+        repl_id = "test-repl-{}".format(_unicode(uuid.uuid4()))
         repl_doc = self.replicator.create_replication(
             self.db,
             self.target_db,

--- a/tests/unit/db/result_tests.py
+++ b/tests/unit/db/result_tests.py
@@ -15,12 +15,15 @@
 """
 result module - Unit tests for Result class
 """
+from __future__ import absolute_import
+
 import unittest
 
 from cloudant.design_document import DesignDocument
 from cloudant.errors import CloudantArgumentError
 from cloudant.result import python_to_couch, Result
-from tests.unit.db.unit_t_db_base import UnitTestDbBase
+
+from .unit_t_db_base import UnitTestDbBase
 
 class PythonToCouchTests(unittest.TestCase):
     """
@@ -85,7 +88,7 @@ class ResultTests(UnitTestDbBase):
             page_size=1000
         )
         self.assertIsInstance(result, Result)
-        self.assertEquals(result.options, {'startkey': '1', 'endkey': '9'})
+        self.assertDictEqual(result.options, {'startkey': '1', 'endkey': '9'})
 
     def test_group_level(self):
         """
@@ -94,7 +97,7 @@ class ResultTests(UnitTestDbBase):
         self.populate_db_with_documents(10)
         result_set = Result(self.ddoc.get_view('view001'), group_level=1)
         self.assertIsInstance(result_set, Result)
-        self.assertEquals(result_set.options, {'group_level': 1})
+        self.assertDictEqual(result_set.options, {'group_level': 1})
         # Test Result iteration
         i = 0
         for result in result_set:

--- a/tests/unit/db/result_tests.py
+++ b/tests/unit/db/result_tests.py
@@ -15,8 +15,6 @@
 """
 result module - Unit tests for Result class
 """
-from __future__ import absolute_import
-
 import unittest
 
 from cloudant.design_document import DesignDocument

--- a/tests/unit/db/unit_t_db_base.py
+++ b/tests/unit/db/unit_t_db_base.py
@@ -47,6 +47,7 @@ DB_URL: Optionally set this to override the construction of the database URL.
   example: export CLOUDANT_URL=https://account.cloudant.com
 
 """
+from __future__ import absolute_import
 
 import unittest
 import requests
@@ -55,13 +56,16 @@ import uuid
 
 from cloudant.account import CouchDB, Cloudant
 
+from ... import _unicode
+
+
 class UnitTestDbBase(unittest.TestCase):
     """
     The base class for all unit tests targeting a database
     """
 
     @classmethod
-    def setUpClass(self):
+    def setUpClass(cls):
         """
         If targeting CouchDB, Set up a CouchDB instance otherwise do nothing.
           
@@ -76,7 +80,7 @@ class UnitTestDbBase(unittest.TestCase):
             if os.environ.get('DB_USER') is None:
                 os.environ['DB_USER_CREATED'] = '1'
                 os.environ['DB_USER'] = 'unit-test-user-{0}'.format(
-                    unicode(uuid.uuid4())
+                    _unicode(uuid.uuid4())
                     )
                 os.environ['DB_PASSWORD'] = 'unit-test-password'
                 resp = requests.put(
@@ -89,7 +93,7 @@ class UnitTestDbBase(unittest.TestCase):
                 resp.raise_for_status()
 
     @classmethod
-    def tearDownClass(self):
+    def tearDownClass(cls):
         """
         If necessary, clean up CouchDB instance once all tests are complete.
         """
@@ -113,24 +117,22 @@ class UnitTestDbBase(unittest.TestCase):
         Set up test attributes for unit tests targeting a database
         """
         if os.environ.get('RUN_CLOUDANT_TESTS') is None:
-        	self.user = os.environ['DB_USER']
-        	self.pwd = os.environ['DB_PASSWORD']
-        	self.url = os.environ['DB_URL']
-        	self.client = CouchDB(self.user, self.pwd, url=self.url)
+            self.user = os.environ['DB_USER']
+            self.pwd = os.environ['DB_PASSWORD']
+            self.url = os.environ['DB_URL']
+            self.client = CouchDB(self.user, self.pwd, url=self.url)
         else:
-        	self.account = os.environ.get('CLOUDANT_ACCOUNT')
-        	self.user = os.environ.get('DB_USER')
-        	self.pwd = os.environ.get('DB_PASSWORD')
-        	self.url = os.environ.get(
-        		'DB_URL',
-        		'https://{0}.cloudant.com'.format(self.account)
-        		)
-        	self.client = Cloudant(
-        		self.user,
-        		self.pwd,
-        		url=self.url,
-        		x_cloudant_user=self.account
-        		)
+            self.account = os.environ.get('CLOUDANT_ACCOUNT')
+            self.user = os.environ.get('DB_USER')
+            self.pwd = os.environ.get('DB_PASSWORD')
+            self.url = os.environ.get(
+                    'DB_URL',
+                    'https://{0}.cloudant.com'.format(self.account))
+            self.client = Cloudant(
+                    self.user,
+                    self.pwd,
+                    url=self.url,
+                    x_cloudant_user=self.account)
 
     def tearDown(self):
         """
@@ -157,11 +159,11 @@ class UnitTestDbBase(unittest.TestCase):
         del self.db
 
     def dbname(self, database_name='unit-test-db'):
-        return '{0}-{1}'.format(database_name, unicode(uuid.uuid4()))
+        return '{0}-{1}'.format(database_name, _unicode(uuid.uuid4()))
 
     def populate_db_with_documents(self, doc_count=100):
         docs = [
             {'_id': 'julia{0:03d}'.format(i), 'name': 'julia', 'age': i}
-            for i in xrange(doc_count)
+            for i in range(doc_count)
         ]
         return self.db.bulk_docs(docs)

--- a/tests/unit/db/unit_t_db_base.py
+++ b/tests/unit/db/unit_t_db_base.py
@@ -77,10 +77,10 @@ class UnitTestDbBase(unittest.TestCase):
 
             if os.environ.get('DB_USER') is None:
                 os.environ['DB_USER_CREATED'] = '1'
-                os.environ['DB_USER'] = 'unit-test-user-{0}'.format(
+                os.environ['DB_USER'] = 'user-{0}'.format(
                     unicode_(uuid.uuid4())
                     )
-                os.environ['DB_PASSWORD'] = 'unit-test-password'
+                os.environ['DB_PASSWORD'] = 'password'
                 resp = requests.put(
                     '{0}/_config/admins/{1}'.format(
                         os.environ['DB_URL'],
@@ -156,7 +156,7 @@ class UnitTestDbBase(unittest.TestCase):
         del self.test_dbname
         del self.db
 
-    def dbname(self, database_name='unit-test-db'):
+    def dbname(self, database_name='db'):
         return '{0}-{1}'.format(database_name, unicode_(uuid.uuid4()))
 
     def populate_db_with_documents(self, doc_count=100):

--- a/tests/unit/db/unit_t_db_base.py
+++ b/tests/unit/db/unit_t_db_base.py
@@ -40,14 +40,13 @@ DB_USER: Set this to the username to connect with.
 
 DB_PASSWORD: Set this to the password for the user specified.
 
-  example: export CLOUDANT_PASSWORD=password
+  example: export DB_PASSWORD=password
 
 DB_URL: Optionally set this to override the construction of the database URL.
 
-  example: export CLOUDANT_URL=https://account.cloudant.com
+  example: export DB_URL=https://account.cloudant.com
 
 """
-from __future__ import absolute_import
 
 import unittest
 import requests
@@ -57,7 +56,6 @@ import uuid
 from cloudant.account import CouchDB, Cloudant
 
 from ... import unicode_
-
 
 class UnitTestDbBase(unittest.TestCase):
     """
@@ -126,13 +124,13 @@ class UnitTestDbBase(unittest.TestCase):
             self.user = os.environ.get('DB_USER')
             self.pwd = os.environ.get('DB_PASSWORD')
             self.url = os.environ.get(
-                    'DB_URL',
-                    'https://{0}.cloudant.com'.format(self.account))
+                'DB_URL',
+                'https://{0}.cloudant.com'.format(self.account))
             self.client = Cloudant(
-                    self.user,
-                    self.pwd,
-                    url=self.url,
-                    x_cloudant_user=self.account)
+                self.user,
+                self.pwd,
+                url=self.url,
+                x_cloudant_user=self.account)
 
     def tearDown(self):
         """

--- a/tests/unit/db/unit_t_db_base.py
+++ b/tests/unit/db/unit_t_db_base.py
@@ -56,7 +56,7 @@ import uuid
 
 from cloudant.account import CouchDB, Cloudant
 
-from ... import _unicode
+from ... import unicode_
 
 
 class UnitTestDbBase(unittest.TestCase):
@@ -80,7 +80,7 @@ class UnitTestDbBase(unittest.TestCase):
             if os.environ.get('DB_USER') is None:
                 os.environ['DB_USER_CREATED'] = '1'
                 os.environ['DB_USER'] = 'unit-test-user-{0}'.format(
-                    _unicode(uuid.uuid4())
+                    unicode_(uuid.uuid4())
                     )
                 os.environ['DB_PASSWORD'] = 'unit-test-password'
                 resp = requests.put(
@@ -159,7 +159,7 @@ class UnitTestDbBase(unittest.TestCase):
         del self.db
 
     def dbname(self, database_name='unit-test-db'):
-        return '{0}-{1}'.format(database_name, _unicode(uuid.uuid4()))
+        return '{0}-{1}'.format(database_name, unicode_(uuid.uuid4()))
 
     def populate_db_with_documents(self, doc_count=100):
         docs = [

--- a/tests/unit/db/views_tests.py
+++ b/tests/unit/db/views_tests.py
@@ -21,7 +21,6 @@ See configuration options for environment variables in unit_t_db_base
 module docstring.
 
 """
-from __future__ import absolute_import
 
 import unittest
 import mock
@@ -37,7 +36,6 @@ from cloudant.errors import CloudantArgumentError, CloudantException
 
 from .unit_t_db_base import UnitTestDbBase
 
-
 class CodeTests(unittest.TestCase):
     """
     Code class unit test
@@ -51,7 +49,6 @@ class CodeTests(unittest.TestCase):
         code = Code('this is code.')
         self.assertIsInstance(code, Code)
         self.assertEqual(code, 'this is code.')
-
 
 class ViewTests(UnitTestDbBase):
     """
@@ -214,7 +211,7 @@ class ViewTests(UnitTestDbBase):
         )
         self.assertIsInstance(view, View)
         try:
-            for _ in view.result:
+            for row in view.result:
                 self.fail('Above statement should raise an Exception')
         except requests.HTTPError as err:
             self.assertEqual(err.response.status_code, 404)
@@ -244,7 +241,7 @@ class ViewTests(UnitTestDbBase):
         view = ddoc.get_view('view001')
         self.assertEqual(view.map, 'This is not valid Javascript')
         try:
-            for _ in view.result:
+            for row in view.result:
                 self.fail('Above statement should raise an Exception')
         except requests.HTTPError as err:
             self.assertEqual(err.response.status_code, 500)
@@ -287,7 +284,6 @@ class ViewTests(UnitTestDbBase):
                 i += 1
             self.assertEqual(i, 100)
 
-
 class QueryIndexViewTests(unittest.TestCase):
     """
     QueryIndexView class unit tests.  These tests use a mocked DesignDocument
@@ -308,7 +304,7 @@ class QueryIndexViewTests(unittest.TestCase):
             'view001',
             {'fields': {'name': 'asc', 'age': 'asc'}},
             '_count',
-            options={'def': {'fields': ['name', 'age']}, 'w': 2}
+            options = {'def': {'fields': ['name', 'age']}, 'w': 2}
         )
 
     def test_constructor(self):

--- a/tests/unit/db/views_tests.py
+++ b/tests/unit/db/views_tests.py
@@ -21,6 +21,7 @@ See configuration options for environment variables in unit_t_db_base
 module docstring.
 
 """
+from __future__ import absolute_import
 
 import unittest
 import mock
@@ -34,7 +35,8 @@ from cloudant.views import Code
 from cloudant.result import Result
 from cloudant.errors import CloudantArgumentError, CloudantException
 
-from unit_t_db_base import UnitTestDbBase
+from .unit_t_db_base import UnitTestDbBase
+
 
 class CodeTests(unittest.TestCase):
     """
@@ -49,6 +51,7 @@ class CodeTests(unittest.TestCase):
         code = Code('this is code.')
         self.assertIsInstance(code, Code)
         self.assertEqual(code, 'this is code.')
+
 
 class ViewTests(UnitTestDbBase):
     """
@@ -211,14 +214,14 @@ class ViewTests(UnitTestDbBase):
         )
         self.assertIsInstance(view, View)
         try:
-            for row in view.result:
+            for _ in view.result:
                 self.fail('Above statement should raise an Exception')
-        except requests.HTTPError, err:
+        except requests.HTTPError as err:
             self.assertEqual(err.response.status_code, 404)
 
     @unittest.skipUnless(
     os.environ.get('RUN_CLOUDANT_TESTS') is None,
-    'Only execute as part of CouchDB tests')
+            'Only execute as part of CouchDB tests')
     def test_view_callable_with_invalid_javascript(self):
         """
         Test error condition when Javascript errors exist.  This test is only
@@ -241,9 +244,9 @@ class ViewTests(UnitTestDbBase):
         view = ddoc.get_view('view001')
         self.assertEqual(view.map, 'This is not valid Javascript')
         try:
-            for row in view.result:
+            for _ in view.result:
                 self.fail('Above statement should raise an Exception')
-        except requests.HTTPError, err:
+        except requests.HTTPError as err:
             self.assertEqual(err.response.status_code, 500)
 
     def test_make_result(self):
@@ -284,6 +287,7 @@ class ViewTests(UnitTestDbBase):
                 i += 1
             self.assertEqual(i, 100)
 
+
 class QueryIndexViewTests(unittest.TestCase):
     """
     QueryIndexView class unit tests.  These tests use a mocked DesignDocument
@@ -304,7 +308,7 @@ class QueryIndexViewTests(unittest.TestCase):
             'view001',
             {'fields': {'name': 'asc', 'age': 'asc'}},
             '_count',
-            options = {'def': {'fields': ['name', 'age']}, 'w': 2}
+            options={'def': {'fields': ['name', 'age']}, 'w': 2}
         )
 
     def test_constructor(self):
@@ -349,7 +353,7 @@ class QueryIndexViewTests(unittest.TestCase):
         try:
             self.view.map = 'function (doc) {\n  emit(doc._id, 1);\n}'
             self.fail('Above statement should raise an Exception')
-        except CloudantArgumentError, err:
+        except CloudantArgumentError as err:
             self.assertEqual(
                 str(err),
                 'The map property must be a dictionary'

--- a/tests/unit/mocked/account_test.py
+++ b/tests/unit/mocked/account_test.py
@@ -182,7 +182,7 @@ class CouchDBAccountTests(unittest.TestCase):
         c.connect()
         c.all_dbs = mock.Mock()
         c.all_dbs.return_value = ['db1', 'db2']
-        self.assertEqual(c.keys(), [])
+        self.assertListEqual(list(c.keys()), [])
         self.assertEqual(c.keys(remote=True), c.all_dbs.return_value)
 
     def test_getitem(self):

--- a/tests/unit/mocked/design_doc_test.py
+++ b/tests/unit/mocked/design_doc_test.py
@@ -36,25 +36,25 @@ class DesignDocTests(unittest.TestCase):
         mock_database = mock.Mock()
         ddoc = DesignDocument(mock_database, '_design/unittest')
         ddoc['views'] = {
-            'view1' : {'map': "MAP", 'reduce': 'REDUCE'}
+            'view1': {'map': "MAP", 'reduce': 'REDUCE'}
         }
         ddoc.fetch()
 
         self.assertTrue(mock_fetch.called)
-        views = [ x for x in ddoc.iterviews() ]
+        views = [x for x in ddoc.iterviews()]
         self.assertEqual(len(views), 1)
         view = views[0]
-        self.assertTrue('view1' in view)
+        self.assertIn('view1', view)
         funcs = view[1]
         self.assertEqual(funcs['map'], 'MAP')
         self.assertEqual(funcs['reduce'], 'REDUCE')
-        self.assertTrue('view1' in ddoc.views)
+        self.assertIn('view1', ddoc.views)
 
     def test_new_ddoc_add_view(self):
         mock_database = mock.Mock()
         ddoc = DesignDocument(mock_database, '_design/unittest')
         ddoc.add_view('view1', "MAP")
-        self.assertTrue('view1' in ddoc['views'])
+        self.assertIn('view1', ddoc['views'])
         self.assertEqual(ddoc['views']['view1'].map, 'MAP')
         self.assertEqual(ddoc['views']['view1'].reduce, None)
 
@@ -65,8 +65,8 @@ class DesignDocTests(unittest.TestCase):
            'view1': {'map': "MAP", 'reduce': 'REDUCE'}
         }
         ddoc.add_view('view2', "MAP2")
-        self.assertTrue('view1' in ddoc['views'])
-        self.assertTrue('view2' in ddoc['views'])
+        self.assertIn('view1', ddoc['views'])
+        self.assertIn('view2', ddoc['views'])
         self.assertEqual(ddoc['views']['view2'].map, 'MAP2')
         self.assertEqual(ddoc['views']['view2'].reduce, None)
 
@@ -85,12 +85,12 @@ class DesignDocTests(unittest.TestCase):
         ddoc = DesignDocument(mock_database, '_design/unittest')
         ddoc.add_view('view1', "MAP", "REDUCE")
         ddoc.add_view('view2', "MAP", "REDUCE")
-        self.assertTrue('view1' in ddoc['views'])
-        self.assertTrue('view2' in ddoc['views'])
+        self.assertIn('view1', ddoc['views'])
+        self.assertIn('view2', ddoc['views'])
         
         ddoc.delete_view('view2')
-        self.assertTrue('view1' in ddoc['views'])
-        self.assertTrue('view2' not in ddoc['views'])
+        self.assertIn('view1', ddoc['views'])
+        self.assertNotIn('view2', ddoc['views'])
         self.assertEqual(ddoc['views']['view1'].map, 'MAP')
         self.assertEqual(ddoc['views']['view1'].reduce, 'REDUCE')
 
@@ -101,7 +101,7 @@ class DesignDocTests(unittest.TestCase):
             'view1': {'map': "MAP", 'reduce': 'REDUCE'},
             'view2': {'map': "MAP", 'reduce': 'REDUCE'},
         }
-        self.assertEqual(ddoc.list_views(), ['view1', 'view2'])
+        self.assertListEqual(sorted(ddoc.list_views()), ['view1', 'view2'])
 
 
 if __name__ == '__main__':

--- a/tests/unit/mocked/document_test.py
+++ b/tests/unit/mocked/document_test.py
@@ -18,7 +18,6 @@ _document_test_
 document module unit tests
 
 """
-from __future__ import absolute_import
 
 import mock
 import requests
@@ -29,7 +28,6 @@ from cloudant.errors import CloudantException
 from cloudant.document import Document
 
 from ... import iteritems_
-
 
 class DocumentTest(unittest.TestCase):
 

--- a/tests/unit/mocked/document_test.py
+++ b/tests/unit/mocked/document_test.py
@@ -18,6 +18,7 @@ _document_test_
 document module unit tests
 
 """
+from __future__ import absolute_import
 
 import mock
 import requests
@@ -26,6 +27,8 @@ import json
 
 from cloudant.errors import CloudantException
 from cloudant.document import Document
+
+from ... import _iteritems
 
 
 class DocumentTest(unittest.TestCase):
@@ -200,7 +203,7 @@ class DocumentTest(unittest.TestCase):
         self.assertTrue(mock_encode.encode.called)
         payload = mock_encode.encode.call_args[0][0]
 
-        for k, v in payload.iteritems():
+        for k, v in _iteritems(payload):
             self.assertTrue(k in doc)
             self.assertEqual(doc[k], v)
 

--- a/tests/unit/mocked/document_test.py
+++ b/tests/unit/mocked/document_test.py
@@ -28,7 +28,7 @@ import json
 from cloudant.errors import CloudantException
 from cloudant.document import Document
 
-from ... import _iteritems
+from ... import iteritems_
 
 
 class DocumentTest(unittest.TestCase):
@@ -203,7 +203,7 @@ class DocumentTest(unittest.TestCase):
         self.assertTrue(mock_encode.encode.called)
         payload = mock_encode.encode.call_args[0][0]
 
-        for k, v in _iteritems(payload):
+        for k, v in iteritems_(payload):
             self.assertTrue(k in doc)
             self.assertEqual(doc[k], v)
 


### PR DESCRIPTION
## What

This is a rebased copy of PR #91.

## How

- PR #91 was thoroughly reviewed and given two +1s.
- Added the commits from that PR to an updated version of this repo.
- Fixed a small issue with tests running in Python 3.5.1.
- Added line item for Python 3 support in CHANGES.rst.
- Added content in documentation for Python 3 support.

## Testing

- Tests have been set to run in Travis CI for both Python 2.7 and Python 3.5 against a CouchDB instance.
- Tests were executed manually against a Cloudant instance with successful completion confirmed for Python 2.7.11 and Python 3.5.1.

## Issues

- #23 
