### PR TITLE
Fix CloudantDatabase.share_database method to accept all valid roles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 2.0.0 (Unreleased)
 ==================
 - [FIX] Fixed the handling of empty views in the DesignDocument.
+- [BREAKING] Fixed CloudantDatabase.share_database to accept all valid permission roles.  Changed the method signature to accept roles as a list argument.
 
 2.0.0b2 (2016-02-24)
 ====================

--- a/tests/unit/mocked/database_test.py
+++ b/tests/unit/mocked/database_test.py
@@ -275,8 +275,7 @@ class CloudantDBTest(unittest.TestCase):
 
         shared_resp = self.cl.share_database(
             'someotheruser',
-            reader=True,
-            writer=True
+            ['_reader', '_writer']
         )
 
         self.assertTrue(self.mock_session.get.called)


### PR DESCRIPTION
## What

Fix the CloudantDatabase.share_database method to accept all valid roles when sharing a database.

## How

- Change the method signature to accept roles as a list argument.
- Validate the roles provided against a list of valid roles.

## Testing

- Updated tests to use the new method signature for shared_database
- Added new tests to validate new functionality introduced as part of this bug fix.

reviewer: @emlaver 
reviewer: @rhyshort

## Issues

- #98 
