### PR TITLE
66 fix create doc to handle ddocs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 ==================
 - [FIX] Fixed the handling of empty views in the DesignDocument.
 - [BREAKING] Fixed CloudantDatabase.share_database to accept all valid permission roles.  Changed the method signature to accept roles as a list argument.
+- [FIX] The CouchDatabase.create_document method now will handle both documents and design documents correctly.  If the document created is a design document then the locally cached object will be a DesignDocument otherwise it will be a Document.
 
 2.0.0b2 (2016-02-24)
 ====================

--- a/tests/unit/db/database_tests.py
+++ b/tests/unit/db/database_tests.py
@@ -153,6 +153,8 @@ class DatabaseTests(UnitTestDbBase):
         self.assertTrue(doc['_rev'].startswith('1-'))
         self.assertEqual(doc['name'], data['name'])
         self.assertEqual(doc['age'], data['age'])
+        self.assertIsInstance(doc, Document)
+        self.assertIsInstance(self.db['julia06'], Document)
         try:
             self.db.create_document(data, throw_on_exists=True)
             self.fail('Above statement should raise a CloudantException')
@@ -172,6 +174,23 @@ class DatabaseTests(UnitTestDbBase):
         self.assertTrue(doc['_rev'].startswith('1-'))
         self.assertEqual(doc['name'], data['name'])
         self.assertEqual(doc['age'], data['age'])
+        self.assertIsInstance(doc, Document)
+        self.assertIsInstance(self.db[doc['_id']], Document)
+
+    def test_create_design_document(self):
+        """
+        Test creating a document using a supplied document id
+        """
+        data = {'_id': '_design/julia06', 'name': 'julia', 'age': 6}
+        doc = self.db.create_document(data)
+        self.assertEqual(self.db['_design/julia06'], doc)
+        self.assertEqual(doc['_id'], data['_id'])
+        self.assertTrue(doc['_rev'].startswith('1-'))
+        self.assertEqual(doc['name'], data['name'])
+        self.assertEqual(doc['age'], data['age'])
+        self.assertEqual(doc.views, dict())
+        self.assertIsInstance(doc, DesignDocument)
+        self.assertIsInstance(self.db['_design/julia06'], DesignDocument)
 
     def test_create_empty_document(self):
         """


### PR DESCRIPTION
## What

Fix the CouchDatabase.create_document method to handle design documents as well as documents.

## How

Add a check to see if the data being used to create the document contains an `_id` that begins with `_design/`.  If it does then a DesignDocument object is passed back by the method and is attached to the locally cached database object.  Otherwise a Document object will be passed back and cached.

## Testing

- Add assertions to existing tests to verify that a Document object is returned and locally cached when expected.
- Add a test to verify that a DesignDocument object is returned and locally cached when expected.

## Reviewers

reviewer @rhyshort
reviewer @emlaver 

## Issues

- #66 
