### PR TITLE
Refactor Cloudant Query index class and DB methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@
 - [FIX] Fixed the handling of empty views in the DesignDocument.
 - [BREAKING] Fixed CloudantDatabase.share_database to accept all valid permission roles.  Changed the method signature to accept roles as a list argument.
 - [FIX] The CouchDatabase.create_document method now will handle both documents and design documents correctly.  If the document created is a design document then the locally cached object will be a DesignDocument otherwise it will be a Document.
-- [BREAKING] Refactored the SearchIndex class to now be the TextIndex class.  Also renamed the CloudantDatabase convenience methods of get_all_indexes, create_index, and delete_index as get_cq_indexes, create_cq_index, and delete_cq_index respectively.  These changes were made to clarify that the changed class and the changed methods were specific to Cloudant Query index processing only.
+- [BREAKING] Refactored the SearchIndex class to now be the TextIndex class.  Also renamed the CloudantDatabase convenience methods of get_all_indexes, create_index, and delete_index as get_query_indexes, create_query_index, and delete_query_index respectively.  These changes were made to clarify that the changed class and the changed methods were specific to query index processing only.
 
 2.0.0b2 (2016-02-24)
 ====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 - [FIX] Fixed the handling of empty views in the DesignDocument.
 - [BREAKING] Fixed CloudantDatabase.share_database to accept all valid permission roles.  Changed the method signature to accept roles as a list argument.
 - [FIX] The CouchDatabase.create_document method now will handle both documents and design documents correctly.  If the document created is a design document then the locally cached object will be a DesignDocument otherwise it will be a Document.
+- [BREAKING] Refactored the SearchIndex class to now be the TextIndex class.  Also renamed the CloudantDatabase convenience methods of get_all_indexes, create_index, and delete_index as get_cq_indexes, create_cq_index, and delete_cq_index respectively.  These changes were made to clarify that the changed class and the changed methods were specific to Cloudant Query index processing only.
 
 2.0.0b2 (2016-02-24)
 ====================

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -816,9 +816,9 @@ class CloudantDatabase(CouchDatabase):
 
         return resp.json()
 
-    def get_cq_indexes(self, raw_result=False):
+    def get_query_indexes(self, raw_result=False):
         """
-        Retrieves Cloudant Query indexes from the remote database.
+        Retrieves query indexes from the remote database.
 
         :param bool raw_result: If set to True then the raw JSON content for
             the request is returned.  Default is to return a list containing
@@ -826,7 +826,7 @@ class CloudantDatabase(CouchDatabase):
             :class:`~cloudant.indexes.TextIndex`, and
             :class:`~cloudant.indexes.SpecialIndex` wrapped objects.
 
-        :returns: The Cloudant Query indexes in the database
+        :returns: The query indexes in the database
         """
 
         url = posixpath.join(self.database_url, '_index')
@@ -863,7 +863,7 @@ class CloudantDatabase(CouchDatabase):
                 raise CloudantException('Unexpected index content: {0} found.')
         return indexes
 
-    def create_cq_index(
+    def create_query_index(
             self,
             design_document_id=None,
             index_name=None,
@@ -871,8 +871,7 @@ class CloudantDatabase(CouchDatabase):
             **kwargs
     ):
         """
-        Creates either a JSON or a text Cloudant Query index in the remote
-        database.
+        Creates either a JSON or a text query index in the remote database.
 
         :param str index_type: The type of the index to create.  Can
             be either 'text' or 'json'.  Defaults to 'json'.
@@ -918,9 +917,9 @@ class CloudantDatabase(CouchDatabase):
         index.create()
         return index
 
-    def delete_cq_index(self, design_document_id, index_type, index_name):
+    def delete_query_index(self, design_document_id, index_type, index_name):
         """
-        Deletes the Cloudant Query index identified by the design document id,
+        Deletes the query index identified by the design document id,
         index type and index name from the remote database.
 
         :param str design_document_id: The design document id that the index

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -25,7 +25,7 @@ from ._2to3 import url_quote_plus
 from .document import Document
 from .design_document import DesignDocument
 from .views import View
-from .indexes import Index, SearchIndex, SpecialIndex
+from .indexes import Index, TextIndex, SpecialIndex
 from .index_constants import JSON_INDEX_TYPE
 from .index_constants import TEXT_INDEX_TYPE
 from .index_constants import SPECIAL_INDEX_TYPE
@@ -816,17 +816,17 @@ class CloudantDatabase(CouchDatabase):
 
         return resp.json()
 
-    def get_all_indexes(self, raw_result=False):
+    def get_cq_indexes(self, raw_result=False):
         """
-        Retrieves indexes from the remote database.
+        Retrieves Cloudant Query indexes from the remote database.
 
         :param bool raw_result: If set to True then the raw JSON content for
             the request is returned.  Default is to return a list containing
             :class:`~cloudant.indexes.Index`,
-            :class:`~cloudant.indexes.SearchIndex`, and
+            :class:`~cloudant.indexes.TextIndex`, and
             :class:`~cloudant.indexes.SpecialIndex` wrapped objects.
 
-        :returns: The indexes in the database
+        :returns: The Cloudant Query indexes in the database
         """
 
         url = posixpath.join(self.database_url, '_index')
@@ -846,7 +846,7 @@ class CloudantDatabase(CouchDatabase):
                     **data.get('def', {})
                 ))
             elif data.get('type') == TEXT_INDEX_TYPE:
-                indexes.append(SearchIndex(
+                indexes.append(TextIndex(
                     self,
                     data.get('ddoc'),
                     data.get('name'),
@@ -863,7 +863,7 @@ class CloudantDatabase(CouchDatabase):
                 raise CloudantException('Unexpected index content: {0} found.')
         return indexes
 
-    def create_index(
+    def create_cq_index(
             self,
             design_document_id=None,
             index_name=None,
@@ -871,7 +871,8 @@ class CloudantDatabase(CouchDatabase):
             **kwargs
     ):
         """
-        Creates either a JSON or a text index in the remote database.
+        Creates either a JSON or a text Cloudant Query index in the remote
+        database.
 
         :param str index_type: The type of the index to create.  Can
             be either 'text' or 'json'.  Defaults to 'json'.
@@ -907,7 +908,7 @@ class CloudantDatabase(CouchDatabase):
         if index_type == JSON_INDEX_TYPE:
             index = Index(self, design_document_id, index_name, **kwargs)
         elif index_type == TEXT_INDEX_TYPE:
-            index = SearchIndex(self, design_document_id, index_name, **kwargs)
+            index = TextIndex(self, design_document_id, index_name, **kwargs)
         else:
             msg = (
                 'Invalid index type: {0}.  '
@@ -917,10 +918,10 @@ class CloudantDatabase(CouchDatabase):
         index.create()
         return index
 
-    def delete_index(self, design_document_id, index_type, index_name):
+    def delete_cq_index(self, design_document_id, index_type, index_name):
         """
-        Deletes the index identified by the design document id, index type and
-        index name from the remote database.
+        Deletes the Cloudant Query index identified by the design document id,
+        index type and index name from the remote database.
 
         :param str design_document_id: The design document id that the index
             exists in.
@@ -931,7 +932,7 @@ class CloudantDatabase(CouchDatabase):
         if index_type == JSON_INDEX_TYPE:
             index = Index(self, design_document_id, index_name)
         elif index_type == TEXT_INDEX_TYPE:
-            index = SearchIndex(self, design_document_id, index_name)
+            index = TextIndex(self, design_document_id, index_name)
         else:
             msg = (
                 'Invalid index type: {0}.  '

--- a/src/cloudant/design_document.py
+++ b/src/cloudant/design_document.py
@@ -60,10 +60,10 @@ class DesignDocument(Document):
     def add_view(self, view_name, map_func, reduce_func=None, **kwargs):
         """
         Appends a MapReduce view to the locally cached DesignDocument View
-        dictionary.  To create a query index use
-        :func:`~cloudant.database.CloudantDatabase.create_index` instead.  A
+        dictionary.  To create a Cloudant Query JSON index use
+        :func:`~cloudant.database.CloudantDatabase.create_cq_index` instead.  A
         CloudantException is raised if an attempt to add a QueryIndexView
-        (query index) using this method is made.
+        (Cloudant Query JSON index) using this method is made.
 
         :param str view_name: Name used to identify the View.
         :param str map_func: Javascript map function.  Can also be a
@@ -85,11 +85,12 @@ class DesignDocument(Document):
     def update_view(self, view_name, map_func, reduce_func=None, **kwargs):
         """
         Modifies/overwrites an existing MapReduce view definition in the
-        locally cached DesignDocument View dictionary.  To update a query index
-        use :func:`~cloudant.database.CloudantDatabase.delete_index` followed by
-        :func:`~cloudant.database.CloudantDatabase.create_index` instead.  A
+        locally cached DesignDocument View dictionary.  To update a Cloudant
+        Query JSON index use
+        :func:`~cloudant.database.CloudantDatabase.delete_cq_index` followed by
+        :func:`~cloudant.database.CloudantDatabase.create_cq_index` instead.  A
         CloudantException is raised if an attempt to update a QueryIndexView
-        (query index) using this method is made.
+        (Cloudant Query JSON index) using this method is made.
 
         :param str view_name: Name used to identify the View.
         :param str map_func: Javascript map function.  Can also be a
@@ -111,10 +112,10 @@ class DesignDocument(Document):
     def delete_view(self, view_name):
         """
         Removes an existing MapReduce view definition from the locally cached
-        DesignDocument View dictionary.  To delete a query index use
-        :func:`~cloudant.database.CloudantDatabase.delete_index` instead.  A
-        CloudantException is raised if an attempt to delete a QueryIndexView
-        (query index) using this method is made.
+        DesignDocument View dictionary.  To delete a Cloudant Query JSON index
+        use :func:`~cloudant.database.CloudantDatabase.delete_cq_index` instead.
+        A CloudantException is raised if an attempt to delete a QueryIndexView
+        (Cloudant Query JSON index) using this method is made.
 
         :param str view_name: Name used to identify the View.
         """

--- a/src/cloudant/design_document.py
+++ b/src/cloudant/design_document.py
@@ -60,10 +60,10 @@ class DesignDocument(Document):
     def add_view(self, view_name, map_func, reduce_func=None, **kwargs):
         """
         Appends a MapReduce view to the locally cached DesignDocument View
-        dictionary.  To create a Cloudant Query JSON index use
-        :func:`~cloudant.database.CloudantDatabase.create_cq_index` instead.  A
-        CloudantException is raised if an attempt to add a QueryIndexView
-        (Cloudant Query JSON index) using this method is made.
+        dictionary.  To create a JSON query index use
+        :func:`~cloudant.database.CloudantDatabase.create_query_index` instead.
+        A CloudantException is raised if an attempt to add a QueryIndexView
+        (JSON query index) using this method is made.
 
         :param str view_name: Name used to identify the View.
         :param str map_func: Javascript map function.  Can also be a
@@ -85,12 +85,12 @@ class DesignDocument(Document):
     def update_view(self, view_name, map_func, reduce_func=None, **kwargs):
         """
         Modifies/overwrites an existing MapReduce view definition in the
-        locally cached DesignDocument View dictionary.  To update a Cloudant
-        Query JSON index use
-        :func:`~cloudant.database.CloudantDatabase.delete_cq_index` followed by
-        :func:`~cloudant.database.CloudantDatabase.create_cq_index` instead.  A
-        CloudantException is raised if an attempt to update a QueryIndexView
-        (Cloudant Query JSON index) using this method is made.
+        locally cached DesignDocument View dictionary.  To update a JSON
+        query index use
+        :func:`~cloudant.database.CloudantDatabase.delete_query_index` followed
+        by :func:`~cloudant.database.CloudantDatabase.create_query_index`
+        instead.  A CloudantException is raised if an attempt to update a
+        QueryIndexView (JSON query index) using this method is made.
 
         :param str view_name: Name used to identify the View.
         :param str map_func: Javascript map function.  Can also be a
@@ -112,10 +112,10 @@ class DesignDocument(Document):
     def delete_view(self, view_name):
         """
         Removes an existing MapReduce view definition from the locally cached
-        DesignDocument View dictionary.  To delete a Cloudant Query JSON index
-        use :func:`~cloudant.database.CloudantDatabase.delete_cq_index` instead.
-        A CloudantException is raised if an attempt to delete a QueryIndexView
-        (Cloudant Query JSON index) using this method is made.
+        DesignDocument View dictionary.  To delete a JSON query index
+        use :func:`~cloudant.database.CloudantDatabase.delete_query_index`
+        instead.  A CloudantException is raised if an attempt to delete a
+        QueryIndexView (JSON query index) using this method is made.
 
         :param str view_name: Name used to identify the View.
         """

--- a/src/cloudant/indexes.py
+++ b/src/cloudant/indexes.py
@@ -28,11 +28,11 @@ from .errors import CloudantArgumentError, CloudantException
 
 class Index(object):
     """
-    Provides an interface for managing a Cloudan Query JSON index.  Primarily
+    Provides an interface for managing a JSON query index.  Primarily
     meant to be used by the database convenience methods
-    :func:`~cloudant.database.CloudantDatabase.create_cq_index`,
-    :func:`~cloudant.database.CloudantDatabase.delete_cq_index`, and
-    :func:`~cloudant.database.CloudantDatabase.get_cq_indexes`.  It is
+    :func:`~cloudant.database.CloudantDatabase.create_query_index`,
+    :func:`~cloudant.database.CloudantDatabase.delete_query_index`, and
+    :func:`~cloudant.database.CloudantDatabase.get_query_indexes`.  It is
     recommended that you use those methods to manage an index rather than
     directly interfacing with Index objects.
 
@@ -42,7 +42,7 @@ class Index(object):
     :param str name: Optional name of the index.
     :param kwargs: Options used to construct the index definition for the
         purposes of index creation.  For more details on valid options See
-        :func:`~cloudant.database.CloudantDatabase.create_cq_index`.
+        :func:`~cloudant.database.CloudantDatabase.create_query_index`.
     """
 
     def __init__(self, database, design_document_id=None, name=None, **kwargs):
@@ -183,11 +183,11 @@ class Index(object):
 
 class TextIndex(Index):
     """
-    Provides an interface for managing a Cloudant Query text index.  Primarily
+    Provides an interface for managing a text query index.  Primarily
     meant to be used by the database convenience methods
-    :func:`~cloudant.database.CloudantDatabase.create_cq_index`,
-    :func:`~cloudant.database.CloudantDatabase.delete_cq_index`, and
-    :func:`~cloudant.database.CloudantDatabase.get_cq_indexes`.  It is
+    :func:`~cloudant.database.CloudantDatabase.create_query_index`,
+    :func:`~cloudant.database.CloudantDatabase.delete_query_index`, and
+    :func:`~cloudant.database.CloudantDatabase.get_query_indexes`.  It is
     recommended that you use those methods to manage an index rather than
     directly interfacing with TextIndex objects.
 
@@ -197,7 +197,7 @@ class TextIndex(Index):
     :param str name: Optional name of the index.
     :param kwargs: Options used to construct the index definition for the
         purposes of index creation.  For more details on valid options See
-        :func:`~cloudant.database.CloudantDatabase.create_cq_index`.
+        :func:`~cloudant.database.CloudantDatabase.create_query_index`.
     """
     def __init__(self, database, design_document_id=None, name=None, **kwargs):
         super(TextIndex, self).__init__(
@@ -228,7 +228,7 @@ class SpecialIndex(Index):
     """
     Provides an interface for viewing the "special" primary index of a database.
     Primarily meant to be used by the database convenience method
-    :func:`~cloudant.database.CloudantDatabase.get_cq_indexes`.  It is
+    :func:`~cloudant.database.CloudantDatabase.get_query_indexes`.  It is
     recommended that you use that method to view the "special" index rather than
     directly interfacing with the SpecialIndex object.
     """

--- a/src/cloudant/indexes.py
+++ b/src/cloudant/indexes.py
@@ -28,11 +28,11 @@ from .errors import CloudantArgumentError, CloudantException
 
 class Index(object):
     """
-    Provides an interface for managing a query JSON index.  Primarily meant to
-    be used by the database convenience methods
-    :func:`~cloudant.database.CloudantDatabase.create_index`,
-    :func:`~cloudant.database.CloudantDatabase.delete_index`, and
-    :func:`~cloudant.database.CloudantDatabase.get_all_indexes`.  It is
+    Provides an interface for managing a Cloudan Query JSON index.  Primarily
+    meant to be used by the database convenience methods
+    :func:`~cloudant.database.CloudantDatabase.create_cq_index`,
+    :func:`~cloudant.database.CloudantDatabase.delete_cq_index`, and
+    :func:`~cloudant.database.CloudantDatabase.get_cq_indexes`.  It is
     recommended that you use those methods to manage an index rather than
     directly interfacing with Index objects.
 
@@ -42,7 +42,7 @@ class Index(object):
     :param str name: Optional name of the index.
     :param kwargs: Options used to construct the index definition for the
         purposes of index creation.  For more details on valid options See
-        :func:`~cloudant.database.CloudantDatabase.create_index`.
+        :func:`~cloudant.database.CloudantDatabase.create_cq_index`.
     """
 
     def __init__(self, database, design_document_id=None, name=None, **kwargs):
@@ -181,26 +181,26 @@ class Index(object):
         resp.raise_for_status()
         return
 
-class SearchIndex(Index):
+class TextIndex(Index):
     """
-    Provides an interface for managing a query text index.  Primarily meant to
-    be used by the database convenience methods
-    :func:`~cloudant.database.CloudantDatabase.create_index`,
-    :func:`~cloudant.database.CloudantDatabase.delete_index`, and
-    :func:`~cloudant.database.CloudantDatabase.get_all_indexes`.  It is
+    Provides an interface for managing a Cloudant Query text index.  Primarily
+    meant to be used by the database convenience methods
+    :func:`~cloudant.database.CloudantDatabase.create_cq_index`,
+    :func:`~cloudant.database.CloudantDatabase.delete_cq_index`, and
+    :func:`~cloudant.database.CloudantDatabase.get_cq_indexes`.  It is
     recommended that you use those methods to manage an index rather than
-    directly interfacing with SearchIndex objects.
+    directly interfacing with TextIndex objects.
 
     :param CloudantDatabase database: A Cloudant database instance used by the
-        SearchIndex.
+        TextIndex.
     :param str design_document_id: Optional identifier of the design document.
     :param str name: Optional name of the index.
     :param kwargs: Options used to construct the index definition for the
         purposes of index creation.  For more details on valid options See
-        :func:`~cloudant.database.CloudantDatabase.create_index`.
+        :func:`~cloudant.database.CloudantDatabase.create_cq_index`.
     """
     def __init__(self, database, design_document_id=None, name=None, **kwargs):
-        super(SearchIndex, self).__init__(
+        super(TextIndex, self).__init__(
             database,
             design_document_id,
             name,
@@ -228,7 +228,7 @@ class SpecialIndex(Index):
     """
     Provides an interface for viewing the "special" primary index of a database.
     Primarily meant to be used by the database convenience method
-    :func:`~cloudant.database.CloudantDatabase.get_all_indexes`.  It is
+    :func:`~cloudant.database.CloudantDatabase.get_cq_indexes`.  It is
     recommended that you use that method to view the "special" index rather than
     directly interfacing with the SpecialIndex object.
     """

--- a/src/cloudant/views.py
+++ b/src/cloudant/views.py
@@ -338,11 +338,12 @@ class View(dict):
 
 class QueryIndexView(View):
     """
-    A view that defines a JSON index in a design document.
+    A view that defines a Cloudant Query JSON index in a design document.
 
-    If you wish to manage a view that represents a query index it is strongly
-    recommended that :func:`~cloudant.database.CloudantDatabase.create_index`
-    and :func:`~cloudant.database.CloudantDatabase.delete_index` are used.
+    If you wish to manage a view that represents a Cloudant Query JSON index it
+    is strongly recommended that
+    :func:`~cloudant.database.CloudantDatabase.create_cq_index`
+    and :func:`~cloudant.database.CloudantDatabase.delete_cq_index` are used.
     """
     def __init__(self, ddoc, view_name, map_fields, reduce_func, **kwargs):
         if not isinstance(map_fields, dict):

--- a/src/cloudant/views.py
+++ b/src/cloudant/views.py
@@ -338,12 +338,12 @@ class View(dict):
 
 class QueryIndexView(View):
     """
-    A view that defines a Cloudant Query JSON index in a design document.
+    A view that defines a JSON query index in a design document.
 
-    If you wish to manage a view that represents a Cloudant Query JSON index it
+    If you wish to manage a view that represents a JSON query index it
     is strongly recommended that
-    :func:`~cloudant.database.CloudantDatabase.create_cq_index`
-    and :func:`~cloudant.database.CloudantDatabase.delete_cq_index` are used.
+    :func:`~cloudant.database.CloudantDatabase.create_query_index`
+    and :func:`~cloudant.database.CloudantDatabase.delete_query_index` are used.
     """
     def __init__(self, ddoc, view_name, map_fields, reduce_func, **kwargs):
         if not isinstance(map_fields, dict):

--- a/tests/unit/db/database_tests.py
+++ b/tests/unit/db/database_tests.py
@@ -32,7 +32,7 @@ from cloudant.result import Result, QueryResult
 from cloudant.errors import CloudantException, CloudantArgumentError
 from cloudant.document import Document
 from cloudant.design_document import DesignDocument
-from cloudant.indexes import Index, SearchIndex, SpecialIndex
+from cloudant.indexes import Index, TextIndex, SpecialIndex
 
 from .unit_t_db_base import UnitTestDbBase
 from ... import unicode_
@@ -830,7 +830,7 @@ class CloudantDatabaseTests(UnitTestDbBase):
         """
         Ensure that a JSON index is created as expected.
         """
-        index = self.db.create_index(fields=['name', 'age'])
+        index = self.db.create_cq_index(fields=['name', 'age'])
         self.assertIsInstance(index, Index)
         ddoc = self.db[index.design_document_id]
         self.assertTrue(ddoc['_rev'].startswith('1-'))
@@ -850,12 +850,12 @@ class CloudantDatabaseTests(UnitTestDbBase):
         """
         Ensure that a text index is created as expected.
         """
-        index = self.db.create_index(
+        index = self.db.create_cq_index(
             index_type='text',
             fields=[{'name': 'name', 'type':'string'},
                     {'name': 'age', 'type':'number'}]
         )
-        self.assertIsInstance(index, SearchIndex)
+        self.assertIsInstance(index, TextIndex)
         ddoc = self.db[index.design_document_id]
         self.assertTrue(ddoc['_rev'].startswith('1-'))
         self.assertEqual(ddoc,
@@ -878,8 +878,8 @@ class CloudantDatabaseTests(UnitTestDbBase):
         """
         Ensure that a text index is created for all fields as expected.
         """
-        index = self.db.create_index(index_type='text')
-        self.assertIsInstance(index, SearchIndex)
+        index = self.db.create_cq_index(index_type='text')
+        self.assertIsInstance(index, TextIndex)
         ddoc = self.db[index.design_document_id]
         self.assertTrue(ddoc['_rev'].startswith('1-'))
         self.assertEqual(ddoc,
@@ -902,20 +902,20 @@ class CloudantDatabaseTests(UnitTestDbBase):
         Tests that multiple indexes of different types can be stored in one
         design document.
         """
-        json_index = self.db.create_index(
+        json_index = self.db.create_cq_index(
             'ddoc001',
             'json-index-001',
             fields=['name', 'age']
         )
         self.assertIsInstance(json_index, Index)
-        search_index = self.db.create_index(
+        search_index = self.db.create_cq_index(
             'ddoc001',
             'text-index-001',
             'text',
             fields=[{'name': 'name', 'type':'string'},
                     {'name': 'age', 'type':'number'}]
         )
-        self.assertIsInstance(search_index, SearchIndex)
+        self.assertIsInstance(search_index, TextIndex)
         ddoc = self.db['_design/ddoc001']
         self.assertTrue(ddoc['_rev'].startswith('2-'))
         self.assertEqual(ddoc,
@@ -941,13 +941,13 @@ class CloudantDatabaseTests(UnitTestDbBase):
                                    'fields': {'$default': 'standard'}}}}}
             )
     
-    def test_create_index_failure(self):
+    def test_create_cq_index_failure(self):
         """
         Tests that a type of something other than 'json' or 'text' will cause
         failure.
         """
         with self.assertRaises(CloudantArgumentError) as cm:
-            self.db.create_index(
+            self.db.create_cq_index(
                 None,
                 '_all_docs',
                 'special',
@@ -964,34 +964,34 @@ class CloudantDatabaseTests(UnitTestDbBase):
         """
         Ensure that a JSON index is deleted as expected.
         """
-        index = self.db.create_index(
+        index = self.db.create_cq_index(
             'ddoc001',
             'index001',
             fields=['name', 'age'])
         self.assertIsInstance(index, Index)
         ddoc = self.db['_design/ddoc001']
         self.assertTrue(ddoc.exists())
-        self.db.delete_index('ddoc001', 'json', 'index001')
+        self.db.delete_cq_index('ddoc001', 'json', 'index001')
         self.assertFalse(ddoc.exists())
 
     def test_delete_text_index(self):
         """
         Ensure that a text index is deleted as expected.
         """
-        index = self.db.create_index('ddoc001', 'index001', 'text')
-        self.assertIsInstance(index, SearchIndex)
+        index = self.db.create_cq_index('ddoc001', 'index001', 'text')
+        self.assertIsInstance(index, TextIndex)
         ddoc = self.db['_design/ddoc001']
         self.assertTrue(ddoc.exists())
-        self.db.delete_index('ddoc001', 'text', 'index001')
+        self.db.delete_cq_index('ddoc001', 'text', 'index001')
         self.assertFalse(ddoc.exists())
 
-    def test_delete_index_failure(self):
+    def test_delete_cq_index_failure(self):
         """
         Tests that a type of something other than 'json' or 'text' will cause
         failure.
         """
         with self.assertRaises(CloudantArgumentError) as cm:
-            self.db.delete_index(None, 'special', '_all_docs')
+            self.db.delete_cq_index(None, 'special', '_all_docs')
         err = cm.exception
         self.assertEqual(
             str(err),
@@ -999,14 +999,15 @@ class CloudantDatabaseTests(UnitTestDbBase):
             'Index type must be either \"json\" or \"text\"'
         )
 
-    def test_get_all_indexes_raw(self):
+    def test_get_cq_indexes_raw(self):
         """
-        Tests getting all indexes from the _index endpoint in JSON format.
+        Tests getting all Cloudant Query indexes from the _index endpoint in
+        JSON format.
         """
-        self.db.create_index('ddoc001', 'json-idx-001', fields=['name', 'age'])
-        self.db.create_index('ddoc001', 'text-idx-001', 'text')
+        self.db.create_cq_index('ddoc001', 'json-idx-001', fields=['name', 'age'])
+        self.db.create_cq_index('ddoc001', 'text-idx-001', 'text')
         self.assertEqual(
-            self.db.get_all_indexes(raw_result=True),
+            self.db.get_cq_indexes(raw_result=True),
             {'indexes': [
                 {'ddoc': None,
                  'name': '_all_docs',
@@ -1027,20 +1028,21 @@ class CloudantDatabaseTests(UnitTestDbBase):
             ]}
         )
 
-    def test_get_all_indexes(self):
+    def test_get_cq_indexes(self):
         """
-        Tests getting all indexes from the _index endpoint wrapped as Index.
+        Tests getting all Cloudant Query indexes from the _index endpoint
+        wrapped as Index, TextIndex, and SpecialIndex.
         """
-        self.db.create_index('ddoc001', 'json-idx-001', fields=['name', 'age'])
-        self.db.create_index('ddoc001', 'text-idx-001', 'text')
-        indexes = self.db.get_all_indexes()
+        self.db.create_cq_index('ddoc001', 'json-idx-001', fields=['name', 'age'])
+        self.db.create_cq_index('ddoc001', 'text-idx-001', 'text')
+        indexes = self.db.get_cq_indexes()
         self.assertIsInstance(indexes[0], SpecialIndex)
         self.assertIsNone(indexes[0].design_document_id)
         self.assertEqual(indexes[0].name, '_all_docs')
         self.assertIsInstance(indexes[1], Index)
         self.assertEqual(indexes[1].design_document_id, '_design/ddoc001')
         self.assertEqual(indexes[1].name, 'json-idx-001')
-        self.assertIsInstance(indexes[2], SearchIndex)
+        self.assertIsInstance(indexes[2], TextIndex)
         self.assertEqual(indexes[2].design_document_id, '_design/ddoc001')
         self.assertEqual(indexes[2].name, 'text-idx-001')
 

--- a/tests/unit/db/database_tests.py
+++ b/tests/unit/db/database_tests.py
@@ -830,7 +830,7 @@ class CloudantDatabaseTests(UnitTestDbBase):
         """
         Ensure that a JSON index is created as expected.
         """
-        index = self.db.create_cq_index(fields=['name', 'age'])
+        index = self.db.create_query_index(fields=['name', 'age'])
         self.assertIsInstance(index, Index)
         ddoc = self.db[index.design_document_id]
         self.assertTrue(ddoc['_rev'].startswith('1-'))
@@ -850,7 +850,7 @@ class CloudantDatabaseTests(UnitTestDbBase):
         """
         Ensure that a text index is created as expected.
         """
-        index = self.db.create_cq_index(
+        index = self.db.create_query_index(
             index_type='text',
             fields=[{'name': 'name', 'type':'string'},
                     {'name': 'age', 'type':'number'}]
@@ -878,7 +878,7 @@ class CloudantDatabaseTests(UnitTestDbBase):
         """
         Ensure that a text index is created for all fields as expected.
         """
-        index = self.db.create_cq_index(index_type='text')
+        index = self.db.create_query_index(index_type='text')
         self.assertIsInstance(index, TextIndex)
         ddoc = self.db[index.design_document_id]
         self.assertTrue(ddoc['_rev'].startswith('1-'))
@@ -902,13 +902,13 @@ class CloudantDatabaseTests(UnitTestDbBase):
         Tests that multiple indexes of different types can be stored in one
         design document.
         """
-        json_index = self.db.create_cq_index(
+        json_index = self.db.create_query_index(
             'ddoc001',
             'json-index-001',
             fields=['name', 'age']
         )
         self.assertIsInstance(json_index, Index)
-        search_index = self.db.create_cq_index(
+        search_index = self.db.create_query_index(
             'ddoc001',
             'text-index-001',
             'text',
@@ -941,13 +941,13 @@ class CloudantDatabaseTests(UnitTestDbBase):
                                    'fields': {'$default': 'standard'}}}}}
             )
     
-    def test_create_cq_index_failure(self):
+    def test_create_query_index_failure(self):
         """
         Tests that a type of something other than 'json' or 'text' will cause
         failure.
         """
         with self.assertRaises(CloudantArgumentError) as cm:
-            self.db.create_cq_index(
+            self.db.create_query_index(
                 None,
                 '_all_docs',
                 'special',
@@ -964,34 +964,34 @@ class CloudantDatabaseTests(UnitTestDbBase):
         """
         Ensure that a JSON index is deleted as expected.
         """
-        index = self.db.create_cq_index(
+        index = self.db.create_query_index(
             'ddoc001',
             'index001',
             fields=['name', 'age'])
         self.assertIsInstance(index, Index)
         ddoc = self.db['_design/ddoc001']
         self.assertTrue(ddoc.exists())
-        self.db.delete_cq_index('ddoc001', 'json', 'index001')
+        self.db.delete_query_index('ddoc001', 'json', 'index001')
         self.assertFalse(ddoc.exists())
 
     def test_delete_text_index(self):
         """
         Ensure that a text index is deleted as expected.
         """
-        index = self.db.create_cq_index('ddoc001', 'index001', 'text')
+        index = self.db.create_query_index('ddoc001', 'index001', 'text')
         self.assertIsInstance(index, TextIndex)
         ddoc = self.db['_design/ddoc001']
         self.assertTrue(ddoc.exists())
-        self.db.delete_cq_index('ddoc001', 'text', 'index001')
+        self.db.delete_query_index('ddoc001', 'text', 'index001')
         self.assertFalse(ddoc.exists())
 
-    def test_delete_cq_index_failure(self):
+    def test_delete_query_index_failure(self):
         """
         Tests that a type of something other than 'json' or 'text' will cause
         failure.
         """
         with self.assertRaises(CloudantArgumentError) as cm:
-            self.db.delete_cq_index(None, 'special', '_all_docs')
+            self.db.delete_query_index(None, 'special', '_all_docs')
         err = cm.exception
         self.assertEqual(
             str(err),
@@ -999,15 +999,15 @@ class CloudantDatabaseTests(UnitTestDbBase):
             'Index type must be either \"json\" or \"text\"'
         )
 
-    def test_get_cq_indexes_raw(self):
+    def test_get_query_indexes_raw(self):
         """
-        Tests getting all Cloudant Query indexes from the _index endpoint in
+        Tests getting all query indexes from the _index endpoint in
         JSON format.
         """
-        self.db.create_cq_index('ddoc001', 'json-idx-001', fields=['name', 'age'])
-        self.db.create_cq_index('ddoc001', 'text-idx-001', 'text')
+        self.db.create_query_index('ddoc001', 'json-idx-001', fields=['name', 'age'])
+        self.db.create_query_index('ddoc001', 'text-idx-001', 'text')
         self.assertEqual(
-            self.db.get_cq_indexes(raw_result=True),
+            self.db.get_query_indexes(raw_result=True),
             {'indexes': [
                 {'ddoc': None,
                  'name': '_all_docs',
@@ -1028,14 +1028,14 @@ class CloudantDatabaseTests(UnitTestDbBase):
             ]}
         )
 
-    def test_get_cq_indexes(self):
+    def test_get_query_indexes(self):
         """
-        Tests getting all Cloudant Query indexes from the _index endpoint
+        Tests getting all query indexes from the _index endpoint
         wrapped as Index, TextIndex, and SpecialIndex.
         """
-        self.db.create_cq_index('ddoc001', 'json-idx-001', fields=['name', 'age'])
-        self.db.create_cq_index('ddoc001', 'text-idx-001', 'text')
-        indexes = self.db.get_cq_indexes()
+        self.db.create_query_index('ddoc001', 'json-idx-001', fields=['name', 'age'])
+        self.db.create_query_index('ddoc001', 'text-idx-001', 'text')
+        indexes = self.db.get_query_indexes()
         self.assertIsInstance(indexes[0], SpecialIndex)
         self.assertIsNone(indexes[0].design_document_id)
         self.assertEqual(indexes[0].name, '_all_docs')

--- a/tests/unit/db/design_document_tests.py
+++ b/tests/unit/db/design_document_tests.py
@@ -467,7 +467,7 @@ class DesignDocumentTests(UnitTestDbBase):
         ddoc.save()
         self.assertTrue(ddoc['_rev'].startswith('1-'))
 
-    def test_cq_view_save_fails_when_lang_is_not_query(self):
+    def test_query_view_save_fails_when_lang_is_not_query(self):
         """
         Tests that save fails when language is not query but views are query
         index views.
@@ -500,7 +500,7 @@ class DesignDocumentTests(UnitTestDbBase):
         err = cm.exception
         self.assertEqual(str(err), 'View view001 must be of type View.')
 
-    def test_cq_view_save_succeeds(self):
+    def test_query_view_save_succeeds(self):
         """
         Tests that save succeeds when language is query and views are query
         index views.

--- a/tests/unit/db/index_tests.py
+++ b/tests/unit/db/index_tests.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Unit tests for the Index module.  IndexTests and SearchIndexTests are tested
+Unit tests for the Index module.  IndexTests and TextIndexTests are tested
 against Cloudant only.
 
 See configuration options for environment variables in unit_t_db_base
@@ -28,7 +28,7 @@ import os
 import posixpath
 import requests
 
-from cloudant.indexes import Index, SearchIndex, SpecialIndex
+from cloudant.indexes import Index, TextIndex, SpecialIndex
 from cloudant.query import Query
 from cloudant.views import QueryIndexView
 from cloudant.design_document import DesignDocument
@@ -358,7 +358,7 @@ class IndexTests(UnitTestDbBase):
     os.environ.get('RUN_CLOUDANT_TESTS') is not None,
     'Skipping Cloudant Search Index tests'
     )
-class SearchIndexTests(UnitTestDbBase):
+class TextIndexTests(UnitTestDbBase):
     """
     Search Index unit tests
     """
@@ -366,7 +366,7 @@ class SearchIndexTests(UnitTestDbBase):
         """
         Set up test attributes
         """
-        super(SearchIndexTests, self).setUp()
+        super(TextIndexTests, self).setUp()
         self.db_set_up()
 
     def tearDown(self):
@@ -374,16 +374,16 @@ class SearchIndexTests(UnitTestDbBase):
         Reset test attributes
         """
         self.db_tear_down()
-        super(SearchIndexTests, self).tearDown()
+        super(TextIndexTests, self).tearDown()
 
     def test_constructor_with_args(self):
         """
-        Test instantiating a SearchIndex by passing in arguments.  As a side effect
+        Test instantiating a TextIndex by passing in arguments.  As a side effect
         this test also tests the design_document_id, name, type, and definition
         property methods.
         """
-        index = SearchIndex(self.db, 'ddoc-id', 'index-name', foo={'bar': 'baz'})
-        self.assertIsInstance(index, SearchIndex)
+        index = TextIndex(self.db, 'ddoc-id', 'index-name', foo={'bar': 'baz'})
+        self.assertIsInstance(index, TextIndex)
         self.assertEqual(index.design_document_id, 'ddoc-id')
         self.assertEqual(index.name, 'index-name')
         self.assertEqual(index.type, 'text')
@@ -391,12 +391,12 @@ class SearchIndexTests(UnitTestDbBase):
 
     def test_constructor_with_only_a_db(self):
         """
-        Test instantiating an SearchIndex with a database only.  As a side effect
+        Test instantiating an TextIndex with a database only.  As a side effect
         this test also tests the design_document_id, name, type, and definition
         property methods.
         """
-        index = SearchIndex(self.db)
-        self.assertIsInstance(index, SearchIndex)
+        index = TextIndex(self.db)
+        self.assertIsInstance(index, TextIndex)
         self.assertIsNone(index.design_document_id)
         self.assertIsNone(index.name)
         self.assertEqual(index.type, 'text')
@@ -406,7 +406,7 @@ class SearchIndexTests(UnitTestDbBase):
         """
         Test that a TEXT index is created in the remote database.
         """
-        index = SearchIndex(self.db, 'ddoc001', 'index001')
+        index = TextIndex(self.db, 'ddoc001', 'index001')
         index.create()
         self.assertEqual(index.design_document_id, '_design/ddoc001')
         self.assertEqual(index.name, 'index001')
@@ -434,7 +434,7 @@ class SearchIndexTests(UnitTestDbBase):
         """
         Test that a TEXT index is created in the remote database.
         """
-        index = SearchIndex(
+        index = TextIndex(
             self.db,
             'ddoc001',
             'index001',
@@ -471,7 +471,7 @@ class SearchIndexTests(UnitTestDbBase):
         """
         Test that a TEXT index is not created when an invalid argument is given.
         """
-        index = SearchIndex(self.db, 'ddoc001', 'index001', foo='bar')
+        index = TextIndex(self.db, 'ddoc001', 'index001', foo='bar')
         with self.assertRaises(CloudantArgumentError) as cm:
             index.create()
         err = cm.exception
@@ -482,7 +482,7 @@ class SearchIndexTests(UnitTestDbBase):
         Test that a TEXT index is not created when an invalid fields value is
         given.
         """
-        index = SearchIndex(self.db, 'ddoc001', 'index001', fields=5)
+        index = TextIndex(self.db, 'ddoc001', 'index001', fields=5)
         with self.assertRaises(CloudantArgumentError) as cm:
             index.create()
         err = cm.exception
@@ -497,7 +497,7 @@ class SearchIndexTests(UnitTestDbBase):
         Test that a TEXT index is not created when an invalid default_field
         value is given.
         """
-        index = SearchIndex(self.db, 'ddoc001', 'index001', default_field=5)
+        index = TextIndex(self.db, 'ddoc001', 'index001', default_field=5)
         with self.assertRaises(CloudantArgumentError) as cm:
             index.create()
         err = cm.exception
@@ -512,7 +512,7 @@ class SearchIndexTests(UnitTestDbBase):
         Test that a TEXT index is not created when an invalid selector
         value is given.
         """
-        index = SearchIndex(self.db, 'ddoc001', 'index001', selector=5)
+        index = TextIndex(self.db, 'ddoc001', 'index001', selector=5)
         with self.assertRaises(CloudantArgumentError) as cm:
             index.create()
         err = cm.exception
@@ -526,7 +526,7 @@ class SearchIndexTests(UnitTestDbBase):
         """
         Test that a created TEXT index will produce expected query results.
         """
-        index = SearchIndex(self.db, 'ddoc001', 'index001')
+        index = TextIndex(self.db, 'ddoc001', 'index001')
         index.create()
         self.populate_db_with_documents(100)
         with Document(self.db, 'julia006') as doc:


### PR DESCRIPTION
## What

We need to refactor the current SearchIndex class to be named TextIndex since it really refers to Cloudant Query text index and not a Cloudant Search index.  Also, we need to provide clearer naming for the database convenience methods of get_all_indexes, create_index, and delete_index to specifically reference the fact that these methods are meant for Cloudant Query (CQ) index management only.

## Why

The current name of SearchIndex is inaccurate as it really handles Cloudant Query text indexes and not actual Cloudant Search indexes and the database convenience methods used to manage the Cloudant Query indexes need clearer naming for the same reason.

## How

- Rename SearchIndex to TextIndex and update all references to the class.
- Rename the get_all_indexes method of the CloudantDatabase class to be get_cq_indexes since the returned set of indexes are specific to Cloudant Query and do not necessarily include "all" indexes in the database.
- Rename the create_index method of the CloudantDatabase class to be create_cq_index since this method can only be used to create a Cloudant Query index.
- Rename the delete_index method of the CloudantDatabase class to be delete_cq_index since this method can only be used to delete a Cloudant Query index.

## Testing

- Renamed all references affected by the refactoring.  No new tests needed.

## Reviewers

reviewer: @emlaver 
reviewer @rhyshort
## Issues

- #103 