### PR TITLE
Add support for CouchDB Admin Party mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ python:
   - "2.7"
   - "3.5"
 
+env:
+  - ADMIN_PARTY=true
+  - ADMIN_PARTY=false
+
 services:
   - couchdb
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@
 - [FIX] The CouchDatabase.create_document method now will handle both documents and design documents correctly.  If the document created is a design document then the locally cached object will be a DesignDocument otherwise it will be a Document.
 - [BREAKING] Refactored the SearchIndex class to now be the TextIndex class.  Also renamed the CloudantDatabase convenience methods of get_all_indexes, create_index, and delete_index as get_query_indexes, create_query_index, and delete_query_index respectively.  These changes were made to clarify that the changed class and the changed methods were specific to query index processing only.
 - [FIX] Fixed Document.get_attachment method to successfully create text and binary files based on http response Content-Type.  The method also returns text, binary, and json content based on http response Content-Type.
+- [NEW] Added support for CouchDB Admin Party mode.  This library can now be used with CouchDB instances where everyone is Admin.
 
 2.0.0b2 (2016-02-24)
 ====================

--- a/src/cloudant/__init__.py
+++ b/src/cloudant/__init__.py
@@ -90,3 +90,31 @@ def couchdb(user, passwd, **kwargs):
     couchdb_session.connect()
     yield couchdb_session
     couchdb_session.disconnect()
+
+@contextlib.contextmanager
+def couchdb_admin_party(**kwargs):
+    """
+    Provides a context manager to create a CouchDB session in Admin Party mode
+    and provide access to databases, docs etc.
+
+    :param str url: URL for CouchDB server.
+    :param str encoder: Optional json Encoder object used to encode
+        documents for storage.  Defaults to json.JSONEncoder.
+
+    For example:
+
+    .. code-block:: python
+
+        # couchdb_admin_party context manager
+        from cloudant import couchdb_admin_party
+
+        with couchdb_admin_party(url=COUCHDB_URL) as client:
+            # Context handles connect() and disconnect() for you.
+            # Perform library operations within this context.  Such as:
+            print client.all_dbs()
+            # ...
+    """
+    couchdb_session = CouchDB(None, None, True, **kwargs)
+    couchdb_session.connect()
+    yield couchdb_session
+    couchdb_session.disconnect()

--- a/src/cloudant/account.py
+++ b/src/cloudant/account.py
@@ -46,33 +46,23 @@ class CouchDB(dict):
     :param str user: Username used to connect to CouchDB.
     :param str auth_token: Authentication token used to connect to CouchDB.
     :param str url: URL for CouchDB server.
+    :param bool admin_party: Setting to allow the use of Admin Party mode in
+        CouchDB.  Defaults to ``False``.
     :param str encoder: Optional json Encoder object used to encode
         documents for storage.  Defaults to json.JSONEncoder.
     """
     _DATABASE_CLASS = CouchDatabase
 
-    def __init__(self, user=None, auth_token=None, **kwargs):
+    def __init__(self, user, auth_token, admin_party=False, **kwargs):
         super(CouchDB, self).__init__()
         self._cloudant_user = user
         self._cloudant_token = auth_token
         self._cloudant_session = None
         self.cloudant_url = kwargs.get('url')
         self._cloudant_user_header = None
+        self.admin_party = admin_party
         self.encoder = kwargs.get('encoder') or json.JSONEncoder
         self.r_session = None
-
-    @property
-    def admin_party(self):
-        """
-        If neither a username or a password have been provided during object
-        construction then CouchDB Admin Party mode is assumed.
-
-        :returns: Boolean value showing whether a username and password have
-            been provided
-        """
-        if self._cloudant_user is None and self._cloudant_token is None:
-            return True
-        return False
 
     def connect(self):
         """

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -56,6 +56,16 @@ class CouchDatabase(dict):
         self.result = Result(self.all_docs)
 
     @property
+    def admin_party(self):
+        """
+        Returns the CouchDB Admin Party status.  ``True`` if using Admin Party
+        ``False`` otherwise.
+
+        :returns: CouchDB Admin Party mode status
+        """
+        return self.cloudant_account.admin_party
+
+    @property
     def database_url(self):
         """
         Constructs and returns the database URL.
@@ -75,7 +85,7 @@ class CouchDatabase(dict):
 
         :returns: Dictionary containing authentication information
         """
-        if self.cloudant_account.admin_party:
+        if self.admin_party:
             return None
         return {
             "basic_auth": self.cloudant_account.basic_auth_str(),

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -75,6 +75,8 @@ class CouchDatabase(dict):
 
         :returns: Dictionary containing authentication information
         """
+        if self.cloudant_account.admin_party:
+            return None
         return {
             "basic_auth": self.cloudant_account.basic_auth_str(),
             "user_ctx": self.cloudant_account.session()['userCtx']

--- a/src/cloudant/replicator.py
+++ b/src/cloudant/replicator.py
@@ -84,7 +84,7 @@ class Replicator(object):
                     'object or a manually composed \'source\' string/dict.'
                 )
             data['source'] = {'url': source_db.database_url}
-            if not source_db.cloudant_account.admin_party:
+            if not source_db.admin_party:
                 data['source'].update(
                     {'headers': {'Authorization': source_db.creds['basic_auth']}}
                 )
@@ -96,13 +96,13 @@ class Replicator(object):
                     'object or a manually composed \'target\' string/dict.'
                 )
             data['target'] = {'url': target_db.database_url}
-            if not target_db.cloudant_account.admin_party:
+            if not target_db.admin_party:
                 data['target'].update(
                     {'headers': {'Authorization': target_db.creds['basic_auth']}}
                 )
 
         if not data.get('user_ctx'):
-            if not target_db.cloudant_account.admin_party:
+            if not target_db.admin_party:
                 data['user_ctx'] = self.database.creds['user_ctx']
 
         return self.database.create_document(data, throw_on_exists=True)

--- a/tests/unit/db/account_tests.py
+++ b/tests/unit/db/account_tests.py
@@ -54,50 +54,67 @@ class AccountTests(UnitTestDbBase):
 
     def test_connect(self):
         """
-        Test connect and disconnect functionality
+        Test connect and disconnect functionality.
+        Client r_session_auth is not set in CouchDB Admin Party mode.
         """
         try:
             self.client.connect()
             self.assertIsInstance(self.client.r_session, requests.Session)
-            self.assertEqual(self.client.r_session.auth, (self.user, self.pwd))
+            if self.client.admin_party:
+                self.assertIsNone(self.client.r_session.auth)
+            else:
+                self.assertEqual(
+                    self.client.r_session.auth, (self.user, self.pwd)
+                )
         finally:
             self.client.disconnect()
             self.assertIsNone(self.client.r_session)
 
     def test_session(self):
         """
-        Test getting session information
+        Test getting session information.  
+        Session info is None if CouchDB Admin Party mode was selected.
         """
         try:
             self.client.connect()
             session = self.client.session()
-            self.assertEqual(session['userCtx']['name'], self.user)
+            if self.client.admin_party:
+                self.assertIsNone(session)
+            else:
+                self.assertEqual(session['userCtx']['name'], self.user)
         finally:
             self.client.disconnect()
 
     def test_session_cookie(self):
         """
-        Test getting the session cookie
+        Test getting the session cookie.
+        Session cookie is None if CouchDB Admin Party mode was selected.
         """
         try:
             self.client.connect()
-            self.assertIsNotNone(self.client.session_cookie())
+            if self.client.admin_party:
+                self.assertIsNone(self.client.session_cookie())
+            else:
+                self.assertIsNotNone(self.client.session_cookie())
         finally:
             self.client.disconnect()
 
     def test_basic_auth_str(self):
         """
-        Test getting the basic authentication string
+        Test getting the basic authentication string.
+        Basic auth string is None if CouchDB Admin Party mode was selected.
         """
         try:
             self.client.connect()
-            expected = 'Basic {0}'.format(
-                str_(base64.urlsafe_b64encode(bytes_("{0}:{1}".format(self.user, self.pwd))))
+            if self.client.admin_party:
+                self.assertIsNone(self.client.basic_auth_str())
+            else:
+                expected = 'Basic {0}'.format(
+                    str_(base64.urlsafe_b64encode(bytes_("{0}:{1}".format(
+                        self.user, self.pwd
+                    ))))
                 )
-            self.assertEqual(
-                self.client.basic_auth_str(),
-                expected
-                )
+                self.assertEqual(self.client.basic_auth_str(), expected)
         finally:
             self.client.disconnect()
 

--- a/tests/unit/db/database_tests.py
+++ b/tests/unit/db/database_tests.py
@@ -76,12 +76,18 @@ class DatabaseTests(UnitTestDbBase):
 
     def test_retrieve_creds(self):
         """
-        Test retrieving account credentials
+        Test retrieving account credentials.
+        Account credentials are None if CouchDB Admin Party mode was selected.
         """
-        expected_keys = ['basic_auth', 'user_ctx']
-        self.assertTrue(all(x in expected_keys for x in self.db.creds.keys()))
-        self.assertTrue(self.db.creds['basic_auth'].startswith('Basic'))
-        self.assertEqual(self.db.creds['user_ctx']['name'], self.user)
+        if self.client.admin_party:
+            self.assertIsNone(self.db.creds)
+        else:
+            expected_keys = ['basic_auth', 'user_ctx']
+            self.assertTrue(
+                all(x in expected_keys for x in self.db.creds.keys())
+            )
+            self.assertTrue(self.db.creds['basic_auth'].startswith('Basic'))
+            self.assertEqual(self.db.creds['user_ctx']['name'], self.user)
 
     def test_exists(self):
         """

--- a/tests/unit/db/database_tests.py
+++ b/tests/unit/db/database_tests.py
@@ -660,8 +660,8 @@ class CloudantDatabaseTests(UnitTestDbBase):
         """
         self.assertDictEqual(self.db.security_document(), dict())
         share = 'user-{0}'.format(unicode_(uuid.uuid4()))
-        self.db.share_database(share, ['_writer', '_replicator'])
-        expected = {'cloudant': {share: ['_writer', '_replicator']}}
+        self.db.share_database(share, ['_writer'])
+        expected = {'cloudant': {share: ['_writer']}}
         self.assertDictEqual(self.db.security_document(), expected)
 
     def test_share_database_with_redundant_role_entries(self):
@@ -671,8 +671,8 @@ class CloudantDatabaseTests(UnitTestDbBase):
         """
         self.assertDictEqual(self.db.security_document(), dict())
         share = 'user-{0}'.format(unicode_(uuid.uuid4()))
-        self.db.share_database(share, ['_writer', '_replicator', '_writer'])
-        expected = {'cloudant': {share: ['_writer', '_replicator']}}
+        self.db.share_database(share, ['_writer', '_writer'])
+        expected = {'cloudant': {share: ['_writer']}}
         self.assertDictEqual(self.db.security_document(), expected)
 
     def test_share_database_invalid_role(self):

--- a/tests/unit/db/replicator_tests.py
+++ b/tests/unit/db/replicator_tests.py
@@ -26,6 +26,7 @@ import unittest
 import uuid
 import time
 import requests
+import os
 
 from cloudant.replicator import Replicator
 from cloudant.document import Document
@@ -100,7 +101,7 @@ class ReplicatorTests(UnitTestDbBase):
 
     def test_create_replication(self):
         """
-        Test that the replication document gets created and that the 
+        Test that the replication document gets created and that the
         replication is successful.
         """
         self.populate_db_with_documents(3)
@@ -113,7 +114,10 @@ class ReplicatorTests(UnitTestDbBase):
         )
         self.replication_ids.append(repl_id)
         # Test that the replication document was created
-        expected_keys = ('_id', '_rev', 'source', 'target', 'user_ctx')
+        expected_keys = ['_id', '_rev', 'source', 'target', 'user_ctx']
+        # If Admin Party mode then user_ctx will not be in the key list
+        if self.client.admin_party:
+            expected_keys.pop()
         self.assertTrue(all(x in list(repl_doc.keys()) for x in expected_keys))
         self.assertEqual(repl_doc['_id'], repl_id)
         self.assertTrue(repl_doc['_rev'].startswith('1-'))

--- a/tests/unit/db/unit_t_db_base.py
+++ b/tests/unit/db/unit_t_db_base.py
@@ -128,10 +128,14 @@ class UnitTestDbBase(unittest.TestCase):
         Set up test attributes for unit tests targeting a database
         """
         if os.environ.get('RUN_CLOUDANT_TESTS') is None:
+            admin_party = False
+            if (os.environ.get('ADMIN_PARTY') and
+                os.environ.get('ADMIN_PARTY') == 'true'):
+                admin_party = True
             self.user = os.environ.get('DB_USER', None)
             self.pwd = os.environ.get('DB_PASSWORD', None)
             self.url = os.environ['DB_URL']
-            self.client = CouchDB(self.user, self.pwd, url=self.url)
+            self.client = CouchDB(self.user, self.pwd, admin_party, url=self.url)
         else:
             self.account = os.environ.get('CLOUDANT_ACCOUNT')
             self.user = os.environ.get('DB_USER')

--- a/tests/unit/db/unit_t_db_base.py
+++ b/tests/unit/db/unit_t_db_base.py
@@ -19,6 +19,11 @@ unit_t_db_base module - The base class for all unit tests that target a db
 
 The unit tests are set to execute by default against a CouchDB instance.
 
+To run the tests using Admin Party security mode in Couchdb, set the 
+ADMIN_PARTY environment variable to true.
+
+  example: export ADMIN_PARTY=true
+
 In order to run the unit tests against a Cloudant instance, set the
 RUN_CLOUDANT_TESTS environment variable to something.
 
@@ -32,8 +37,8 @@ CLOUDANT_ACCOUNT: Set this to the Cloudant account that you wish to connect to.
   example: export CLOUDANT_ACCOUNT=account
 
 DB_USER: Set this to the username to connect with.  
-  - Optional for CouchDB tests.  If omitted then a user will be created before
-    tests are executed in CouchDB.
+  - Optional for CouchDB tests.  If omitted and ADMIN_PARTY is not "true" then
+    a user will be created before tests are executed in CouchDB.
   - Mandatory for Cloudant tests.  
 
   example: export DB_USER=user
@@ -75,6 +80,14 @@ class UnitTestDbBase(unittest.TestCase):
             if os.environ.get('DB_URL') is None:
                 os.environ['DB_URL'] = 'http://127.0.0.1:5984'
 
+            if (os.environ.get('ADMIN_PARTY') and
+                os.environ.get('ADMIN_PARTY') == 'true'):
+                if os.environ.get('DB_USER'):
+                    del os.environ['DB_USER']
+                if os.environ.get('DB_PASSWORD'):
+                    del os.environ['DB_PASSWORD']
+                return
+
             if os.environ.get('DB_USER') is None:
                 os.environ['DB_USER_CREATED'] = '1'
                 os.environ['DB_USER'] = 'user-{0}'.format(
@@ -115,8 +128,8 @@ class UnitTestDbBase(unittest.TestCase):
         Set up test attributes for unit tests targeting a database
         """
         if os.environ.get('RUN_CLOUDANT_TESTS') is None:
-            self.user = os.environ['DB_USER']
-            self.pwd = os.environ['DB_PASSWORD']
+            self.user = os.environ.get('DB_USER', None)
+            self.pwd = os.environ.get('DB_PASSWORD', None)
             self.url = os.environ['DB_URL']
             self.client = CouchDB(self.user, self.pwd, url=self.url)
         else:

--- a/tests/unit/mocked/replicator_test.py
+++ b/tests/unit/mocked/replicator_test.py
@@ -73,10 +73,12 @@ class ReplicatorTests(unittest.TestCase):
             mock_target.database_url = "http://bob.cloudant.com/target"
             mock_target.creds = {'basic_auth': "target_auth"}
             mock_target.cloudant_account = self.mock_account
+            mock_target.admin_party = False
             mock_source = mock.Mock()
             mock_source.database_url = "http://bob.cloudant.com/source"
             mock_source.creds = {'basic_auth': "source_auth"}
             mock_source.cloudant_account = self.mock_account
+            mock_source.admin_party = False
 
             repl = Replicator(self.mock_account)
             repl.create_replication(mock_source, mock_target, "REPLID")

--- a/tests/unit/mocked/replicator_test.py
+++ b/tests/unit/mocked/replicator_test.py
@@ -61,6 +61,7 @@ class ReplicatorTests(unittest.TestCase):
         self.mock_account.session.return_value = {
             "userCtx": "user Context"
         }
+        self.mock_account.admin_party = False
 
     def tearDown(self):
         self.patcher.stop()
@@ -71,9 +72,11 @@ class ReplicatorTests(unittest.TestCase):
             mock_target = mock.Mock()
             mock_target.database_url = "http://bob.cloudant.com/target"
             mock_target.creds = {'basic_auth': "target_auth"}
+            mock_target.cloudant_account = self.mock_account
             mock_source = mock.Mock()
             mock_source.database_url = "http://bob.cloudant.com/source"
             mock_source.creds = {'basic_auth': "source_auth"}
+            mock_source.cloudant_account = self.mock_account
 
             repl = Replicator(self.mock_account)
             repl.create_replication(mock_source, mock_target, "REPLID")


### PR DESCRIPTION
## What

Add support for CouchDB Admin Party mode where everyone is an Admin.

## Why

The default install of CouchDB uses Admin Party mode where everyone is Admin.  We needed to enable this library to work in this mode.

## How

- Set CouchDB constructor user and auth_token arguments to default to None.
- Add an admin_party property to the CouchDB class that returns true if both user and auth_token are not defined. False otherwise.
- Add logic to handle processing differently for Admin Party in the CouchDB class. Methods include connect(), session(), session_cookie(), session_login(), session_logout(), and basic_auth_str().
- Add logic to handle processing differently for Admin Party in the CouchDatabase class, creds() method.
- Add logic to handle processing differently for Admin Party in the Replicator class, create_replication(...) method.

## Testing

- Update tests to handle both Admin Party and normal security.  No new tests added.
- Added the ADMIN_PARTY environment variable to the .travis.yml so that tests can now run against both Python 2.7 and Python 3.5 using CouchDB in Admin Party mode and CouchDB using standard security.

## Reviewers

reviewer: @emlaver 
reviewer: @evansde77 

## Issues

- #61 