### PR TITLE
Use POST request with queries using the keys parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@
 - [BREAKING] Refactored the SearchIndex class to now be the TextIndex class.  Also renamed the CloudantDatabase convenience methods of get_all_indexes, create_index, and delete_index as get_query_indexes, create_query_index, and delete_query_index respectively.  These changes were made to clarify that the changed class and the changed methods were specific to query index processing only.
 - [FIX] Fixed Document.get_attachment method to successfully create text and binary files based on http response Content-Type.  The method also returns text, binary, and json content based on http response Content-Type.
 - [NEW] Added support for CouchDB Admin Party mode.  This library can now be used with CouchDB instances where everyone is Admin.
+- [IMPROVED] Changed the handling of queries using the keys argument to issue a http POST request instead of a http GET request so that the request is no longer bound by any URL length limitation.
 
 2.0.0b2 (2016-02-24)
 ====================

--- a/pylintrc
+++ b/pylintrc
@@ -235,7 +235,7 @@ notes=FIXME,XXX,TODO
 [SIMILARITIES]
 
 # Minimum lines number of a similarity.
-min-similarity-lines=4
+min-similarity-lines=5
 
 # Ignore comments when computing similarities.
 ignore-comments=yes

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -396,16 +396,17 @@ class CouchDatabase(dict):
         :returns: Raw JSON response content from ``_all_docs`` endpoint
 
         """
+        all_docs_url = posixpath.join(self.database_url, '_all_docs')
         params = python_to_couch(kwargs)
-        resp = self.r_session.get(
-            posixpath.join(
-                self.database_url,
-                '_all_docs'
-            ),
-            params=params
-        )
-        data = resp.json()
-        return data
+        keys_list = params.pop('keys', None)
+        resp = None
+        if keys_list:
+            keys = json.dumps({'keys': keys_list})
+            resp = self.r_session.post(all_docs_url, params=params, data=keys)
+        else:
+            resp = self.r_session.get(all_docs_url, params=params)
+        resp.raise_for_status()
+        return resp.json()
 
     @contextlib.contextmanager
     def custom_result(self, **options):

--- a/src/cloudant/result.py
+++ b/src/cloudant/result.py
@@ -86,6 +86,10 @@ def python_to_couch(options):
                 ARG_TYPES[key]
             )
             raise CloudantArgumentError(msg)
+
+        if key == 'keys':
+            translation[key] = val
+            continue
         arg_converter = TYPE_CONVERTERS.get(type(val))
         if key == 'stale':
             if val not in ('ok', 'update_after'):

--- a/src/cloudant/views.py
+++ b/src/cloudant/views.py
@@ -17,6 +17,7 @@ API module for interacting with a view in a design document.
 """
 import contextlib
 import posixpath
+import json
 
 from ._2to3 import STRTYPE
 from .result import Result, python_to_couch
@@ -244,7 +245,13 @@ class View(dict):
         :returns: View result data in JSON format
         """
         params = python_to_couch(kwargs)
-        resp = self._r_session.get(self.url, params=params)
+        keys_list = params.pop('keys', None)
+        resp = None
+        if keys_list:
+            keys = json.dumps({'keys': keys_list})
+            resp = self._r_session.post(self.url, params=params, data=keys)
+        else:
+            resp = self._r_session.get(self.url, params=params)
         resp.raise_for_status()
         return resp.json()
 

--- a/tests/unit/db/database_tests.py
+++ b/tests/unit/db/database_tests.py
@@ -299,19 +299,47 @@ class DatabaseTests(UnitTestDbBase):
         self.assertIsInstance(raw_rslt, dict)
         self.assertEqual(len(raw_rslt.get('rows')), 100)
 
-    def test_all_docs(self):
+    def test_all_docs_post(self):
         """
-        Test the all_docs functionality
+        Test the all_docs POST request functionality using keys param
+        """
+        # Create 200 documents with ids julia000, julia001, julia002, ..., julia199
+        self.populate_db_with_documents(200)
+        # Generate keys list for every other document created
+        # with ids julia000, julia002, julia004, ..., julia198
+        keys_list = ['julia{0:03d}'.format(i) for i in range(0, 200, 2)]
+        self.assertEqual(len(keys_list), 100)
+        rows = self.db.all_docs(keys=keys_list).get('rows')
+        self.assertEqual(len(rows), 100)
+        keys_returned = [row['key'] for row in rows]
+        self.assertTrue(all(x in keys_returned for x in keys_list))
+
+    def test_all_docs_post_multiple_params(self):
+        """
+        Test the all_docs POST request functionality using keys and other params
+        """
+        # Create 200 documents with ids julia000, julia001, julia002, ..., julia199
+        self.populate_db_with_documents(200)
+        # Generate keys list for every other document created
+        # with ids julia000, julia002, julia004, ..., julia198
+        keys_list = ['julia{0:03d}'.format(i) for i in range(0, 200, 2)]
+        self.assertEqual(len(keys_list), 100)
+        data = self.db.all_docs(limit=3, skip=10, keys=keys_list)
+        self.assertEqual(len(data.get('rows')), 3)
+        self.assertEqual(data['rows'][0]['key'], 'julia020')
+        self.assertEqual(data['rows'][1]['key'], 'julia022')
+        self.assertEqual(data['rows'][2]['key'], 'julia024')
+
+    def test_all_docs_get(self):
+        """
+        Test the all_docs GET request functionality
         """
         self.populate_db_with_documents()
-        data = self.db.all_docs(
-            limit=3,
-            keys=['julia006', 'julia024', 'julia045', 'julia099']
-        )
+        data = self.db.all_docs(limit=3, skip=10)
         self.assertEqual(len(data.get('rows')), 3)
-        self.assertEqual(data['rows'][0]['key'], 'julia006')
-        self.assertEqual(data['rows'][1]['key'], 'julia024')
-        self.assertEqual(data['rows'][2]['key'], 'julia045')
+        self.assertEqual(data['rows'][0]['key'], 'julia010')
+        self.assertEqual(data['rows'][1]['key'], 'julia011')
+        self.assertEqual(data['rows'][2]['key'], 'julia012')
 
     def test_custom_result_context_manager(self):
         """


### PR DESCRIPTION
## What

Add logic so that any query using the `keys` parameter is handled via a http POST request instead of a http GET request.

## How

- Update result module python_to_couch function so that it handles the keys argument separately.
- Update the CouchDatabase all_docs method logic to handle any call containing the keys argument as a http POST request.
- Update the Views \_\_call\_\_ method logic to handle any call containing the keys argument as a http POST request.

## Testing

- Add tests to both database_tests.py and view_tests.py to check that the POST request processing is working as expected.  Tests were added to include a list of keys that would normally cause a similar GET request to fail due to url size limitations.
- The current pylint min-similarity-lines setting was increased from 4 to 5 since the 4 setting was incorrectly causing the pylint test to fail due to the recent code commits.  4 similar lines is too few lines to check for so we are relaxing the check to 5 lines. 

## Reviewers

reviewer: @emlaver 
reviewer: @ricellis 

## Issues

#90 