### PR TITLE
Combine get_view_result and get_view_raw_result into one method

### DIFF
--- a/src/cloudant/views.py
+++ b/src/cloudant/views.py
@@ -212,8 +212,9 @@ class View(dict):
                 # Process view data (in JSON format).
 
         Note:  Rather than using the View callable directly, if you wish to
-        retrieve view results in raw JSON format use the provided database API
-        of :func:`~cloudant.database.CouchDatabase.get_view_raw_result` instead.
+        retrieve view results in raw JSON format use ``raw_result=True`` with
+        the provided database API of
+        :func:`~cloudant.database.CouchDatabase.get_view_result` instead.
 
         :param bool descending: Return documents in descending key order.
         :param endkey: Stop returning records at this specified key.  Can be

--- a/tests/unit/db/database_tests.py
+++ b/tests/unit/db/database_tests.py
@@ -295,7 +295,8 @@ class DatabaseTests(UnitTestDbBase):
         self.db.create_document(data)
         self.populate_db_with_documents()
 
-        raw_rslt = self.db.get_view_raw_result('_design/ddoc01', 'view01')
+        raw_rslt = self.db.get_view_result(
+            '_design/ddoc01', 'view01', raw_result=True)
         self.assertIsInstance(raw_rslt, dict)
         self.assertEqual(len(raw_rslt.get('rows')), 100)
 


### PR DESCRIPTION
## What

Combine `get_view_result` and `get_view_raw_result` into one method.

## How

The default setting of get_view_result is `raw_result=False` and will return a Result object. 
If the user requires manually changing the paging and iteration, then they would use the setting `raw_result=True` and pass in the skip and/or limit parameter. 

## Testing

The existing test case `test_retrieve_raw_view_results` that used the method `get_view_raw_result` now uses  `get_view_result` with `raw_result=True`.
Tests added to assert that the result contains the correct number of documents using `raw_result=True` and limit, skip, or both parameters.

## Reviewers

reviewer: @alfinkel
reviewer @ricellis

## Issues
#43 