### PR TITLE
Fix Cloudant._usage_endpoint() to only accept both year and month or neither

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,6 @@
 2.0.0 (Unreleased)
 ==================
+- [FIX] Added validation to Cloudant.bill, Cloudant.volume_usage, and Cloudant.requests_usage methods to ensure that a valid year/month combination or neither are used as arguments.
 - [FIX] Fixed the handling of empty views in the DesignDocument.
 - [BREAKING] Fixed CloudantDatabase.share_database to accept all valid permission roles.  Changed the method signature to accept roles as a list argument.
 - [FIX] The CouchDatabase.create_document method now will handle both documents and design documents correctly.  If the document created is a design document then the locally cached object will be a DesignDocument otherwise it will be a Document.

--- a/tests/unit/db/account_tests.py
+++ b/tests/unit/db/account_tests.py
@@ -31,7 +31,7 @@ from datetime import datetime
 
 from cloudant import cloudant, couchdb, couchdb_admin_party
 from cloudant.account import Cloudant, CouchDB
-from cloudant.errors import CloudantException
+from cloudant.errors import CloudantException, CloudantArgumentError
 
 from .unit_t_db_base import UnitTestDbBase
 from ... import bytes_, str_
@@ -439,14 +439,80 @@ class CloudantAccountTests(UnitTestDbBase):
                 'http_light'
                 ]
             # Test using year and month
-            year = datetime.now().year
-            month = datetime.now().month
+            year = 2016
+            month = 1
             data = self.client.bill(year, month)
             self.assertTrue(all(x in expected for x in data.keys()))
             #Test without year and month arguments
             del data
             data = self.client.bill()
             self.assertTrue(all(x in expected for x in data.keys()))
+        finally:
+            self.client.disconnect()
+
+    def test_set_year_without_month_for_billing_data(self):
+        """
+        Test raising an exception when retrieving billing data with only
+        year parameter
+        """
+        try:
+            self.client.connect()
+            year = 2016
+            with self.assertRaises(CloudantArgumentError) as cm:
+                self.client.bill(year)
+            expected = ('Invalid year and/or month supplied.  '
+                        'Found: year - 2016, month - None')
+            self.assertEqual(str(cm.exception), expected)
+        finally:
+            self.client.disconnect()
+
+    def test_set_month_without_year_for_billing_data(self):
+        """
+        Test raising an exception when retrieving billing data with only
+        month parameter
+        """
+        try:
+            self.client.connect()
+            month = 1
+            with self.assertRaises(CloudantArgumentError) as cm:
+                self.client.bill(None, month)
+            expected = ('Invalid year and/or month supplied.  '
+                        'Found: year - None, month - 1')
+            self.assertEqual(str(cm.exception), expected)
+        finally:
+            self.client.disconnect()
+
+    def test_set_invalid_type_year_for_billing_data(self):
+        """
+        Test raising an exception when retrieving billing data with a type
+        string for the year parameter
+        """
+        try:
+            self.client.connect()
+            year = 'foo'
+            month = 1
+            with self.assertRaises(CloudantArgumentError) as cm:
+                self.client.bill(year, month)
+            expected = ('Invalid year and/or month supplied.  '
+                        'Found: year - foo, month - 1')
+            self.assertEqual(str(cm.exception), expected)
+        finally:
+            self.client.disconnect()
+
+    def test_set_year_with_invalid_month_for_billing_data(self):
+        """
+        Test raising an exception when retrieving billing data with an
+        invalid month parameter
+        """
+        try:
+            self.client.connect()
+            year = 2016
+            month = 13
+            with self.assertRaises(CloudantArgumentError) as cm:
+                self.client.bill(year, month)
+            expected = ('Invalid year and/or month supplied.  '
+                        'Found: year - 2016, month - 13')
+            self.assertEqual(str(cm.exception), expected)
         finally:
             self.client.disconnect()
 
@@ -463,14 +529,80 @@ class CloudantAccountTests(UnitTestDbBase):
                 'end'
                 ]
             # Test using year and month
-            year = datetime.now().year
-            month = datetime.now().month
+            year = 2016
+            month = 12
             data = self.client.volume_usage(year, month)
             self.assertTrue(all(x in expected for x in data.keys()))
             #Test without year and month arguments
             del data
             data = self.client.volume_usage()
             self.assertTrue(all(x in expected for x in data.keys()))
+        finally:
+            self.client.disconnect()
+
+    def test_set_year_without_month_for_volume_usage_data(self):
+        """
+        Test raising an exception when retrieving volume usage data with only
+        year parameter
+        """
+        try:
+            self.client.connect()
+            year = 2016
+            with self.assertRaises(CloudantArgumentError) as cm:
+                self.client.volume_usage(year)
+            expected = ('Invalid year and/or month supplied.  '
+                        'Found: year - 2016, month - None')
+            self.assertEqual(str(cm.exception), expected)
+        finally:
+            self.client.disconnect()
+
+    def test_set_month_without_year_for_volume_usage_data(self):
+        """
+        Test raising an exception when retrieving volume usage data with only
+        month parameter
+        """
+        try:
+            self.client.connect()
+            month = 1
+            with self.assertRaises(CloudantArgumentError) as cm:
+                self.client.volume_usage(None, month)
+            expected = ('Invalid year and/or month supplied.  '
+                        'Found: year - None, month - 1')
+            self.assertEqual(str(cm.exception), expected)
+        finally:
+            self.client.disconnect()
+
+    def test_set_invalid_type_year_for_volume_usage_data(self):
+        """
+        Test raising an exception when retrieving volume usage data with a type
+        string for the year parameter
+        """
+        try:
+            self.client.connect()
+            year = 'foo'
+            month = 1
+            with self.assertRaises(CloudantArgumentError) as cm:
+                self.client.volume_usage(year, month)
+            expected = ('Invalid year and/or month supplied.  '
+                        'Found: year - foo, month - 1')
+            self.assertEqual(str(cm.exception), expected)
+        finally:
+            self.client.disconnect()
+
+    def test_set_year_with_invalid_month_for_volume_usage_data(self):
+        """
+        Test raising an exception when retrieving volume usage data with an
+        invalid month parameter
+        """
+        try:
+            self.client.connect()
+            year = 2016
+            month = 13
+            with self.assertRaises(CloudantArgumentError) as cm:
+                self.client.volume_usage(year, month)
+            expected = ('Invalid year and/or month supplied.  '
+                        'Found: year - 2016, month - 13')
+            self.assertEqual(str(cm.exception), expected)
         finally:
             self.client.disconnect()
 
@@ -487,14 +619,80 @@ class CloudantAccountTests(UnitTestDbBase):
                 'end'
                 ]
             # Test using year and month
-            year = datetime.now().year
-            month = datetime.now().month
+            year = 2016
+            month = 1
             data = self.client.requests_usage(year, month)
             self.assertTrue(all(x in expected for x in data.keys()))
             #Test without year and month arguments
             del data
             data = self.client.requests_usage()
             self.assertTrue(all(x in expected for x in data.keys()))
+        finally:
+            self.client.disconnect()
+
+    def test_set_year_without_month_for_requests_usage_data(self):
+        """
+        Test raising an exception when retrieving requests usage data with an
+        invalid month parameter
+        """
+        try:
+            self.client.connect()
+            year = 2016
+            with self.assertRaises(CloudantArgumentError) as cm:
+                self.client.requests_usage(year)
+            expected = ('Invalid year and/or month supplied.  '
+                        'Found: year - 2016, month - None')
+            self.assertEqual(str(cm.exception), expected)
+        finally:
+            self.client.disconnect()
+
+    def test_set_month_without_year_for_requests_usage_data(self):
+        """
+        Test raising an exception when retrieving requests usage data with only
+        month parameter
+        """
+        try:
+            self.client.connect()
+            month = 1
+            with self.assertRaises(CloudantArgumentError) as cm:
+                self.client.requests_usage(None, month)
+            expected = ('Invalid year and/or month supplied.  '
+                        'Found: year - None, month - 1')
+            self.assertEqual(str(cm.exception), expected)
+        finally:
+            self.client.disconnect()
+
+    def test_set_invalid_type_year_for_requests_usage_data(self):
+        """
+        Test raising an exception when retrieving requests usage data with
+        a type string for the year parameter
+        """
+        try:
+            self.client.connect()
+            year = 'foo'
+            month = 1
+            with self.assertRaises(CloudantArgumentError) as cm:
+                self.client.requests_usage(year, month)
+            expected = ('Invalid year and/or month supplied.  '
+                        'Found: year - foo, month - 1')
+            self.assertEqual(str(cm.exception), expected)
+        finally:
+            self.client.disconnect()
+
+    def test_set_year_with_invalid_month_for_requests_usage_data(self):
+        """
+        Test raising an exception when retrieving requests usage data with only
+        year parameter
+        """
+        try:
+            self.client.connect()
+            year = 2016
+            month = 13
+            with self.assertRaises(CloudantArgumentError) as cm:
+                self.client.requests_usage(year, month)
+            expected = ('Invalid year and/or month supplied.  '
+                        'Found: year - 2016, month - 13')
+            self.assertEqual(str(cm.exception), expected)
         finally:
             self.client.disconnect()
 


### PR DESCRIPTION
## What

In the account module, the Cloudant._usage_endpoint() method should only accept either both a year and a month or nothing.

## How

If both year and month exist, create endpoint request with both parameters. 
If either year or month do not exist, raise a CloudantException.

## Testing

Additional test cases to assert that CloudantException is raised when only year parameter exists for `bill`, `requests_usage`, and `volume_usage`. 

## Reviewers
reviewer @alfinkel 
reviewer @mikerhodes 

## Issues

#59 