### PR TITLE
Add Result class validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@
 - [FIX] Fixed Document.get_attachment method to successfully create text and binary files based on http response Content-Type.  The method also returns text, binary, and json content based on http response Content-Type.
 - [NEW] Added support for CouchDB Admin Party mode.  This library can now be used with CouchDB instances where everyone is Admin.
 - [IMPROVED] Changed the handling of queries using the keys argument to issue a http POST request instead of a http GET request so that the request is no longer bound by any URL length limitation.
+- [IMPROVED] Added support for Result data access via index value and added validation logic to ``Result.__getitem__()``.
 
 2.0.0b2 (2016-02-24)
 ====================

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -182,36 +182,49 @@ Dealing with results
 ********************
 
 If you want to get Pythonic with your returned data content, we've added a 
-``Result`` class that wraps your content and exposes Pythonic ways to access it. 
-Instantiate a ``Result`` with a raw data callable such as ``all_docs`` from a 
-database object or the callable reference from a ``view`` and then access the 
-data as you would normally.  The following example uses ``all_docs`` and shows 
-ways to slice and iterate over the result set.  It assumes that either a 
-``CloudantDatabase`` or a ``CouchDatabase`` object already exists.
+``Result`` class that provides a key accessible, sliceable, and iterable 
+interface to result collections.  To use it, construct a ``Result`` object 
+passing in a reference to a raw data callable such as the ``all_docs`` method 
+from a database object or a ``view`` object itself, which happens to be defined 
+as callable and then access the data as you would using standard Python key 
+access, slicing, and iteration techniques.  The following set of examples 
+illustrate ``Result`` key access, slicing and iteration over a result collection 
+in action.  It assumes that either a ``CloudantDatabase`` or a ``CouchDatabase`` 
+object already exists.
 
 .. code-block:: python
 
-    from cloudant.result import Result
+    from cloudant.result import Result, ResultByKey
 
-    # Retrieve Result wrapped document content
-    # The include_docs argument is optional and defaults to False
-    result_set = Result(my_database.all_docs, include_docs=True)
+    # Retrieve Result wrapped document content.
+    # Note: The include_docs parameter is optional and is used to illustrate that view query 
+    # parameters can be used to customize the result collection.
+    result_collection = Result(my_database.all_docs, include_docs=True)
+
+    # Get the result at a given location in the result collection
+    # Note: Valid result collection indexing starts at 0
+    result = result_collection[0]                   # result is the 1st in the collection
+    result = result_collection[9]                   # result is the 10th in the collection
 
     # Get the result for matching a key
-    result = result_set['julia30']
+    result = result_collection['julia30']           # result is all that match key 'julia30'
+    
+    # If your key is an integer then use the ResultByKey class to differentiate your integer 
+    # key from an indexed location within the result collection which is also an integer.
+    result = result_collection[ResultByKey(9)]      # result is all that match key 9
 
-    # Slice by startkey and endkey
-    result = result_set['julia30':'ruby99'] # result between keys
-    result = result_set['julia30':] # result after key
-    result = result_set[:'ruby99'] # result up to key
+    # Slice by key values
+    result = result_collection['julia30': 'ruby99'] # result is between and including keys
+    result = result_collection['julia30': ]         # result is after and including key
+    result = result_collection[: 'ruby99']          # result is up to and including key
 
-    # Slice by block
-    result = result_set[100:200] # result 100 to 200
-    result = result_set[:200] # result up to the 200th
-    result = result_set[100:] # result after the 100th
+    # Slice by index values
+    result = result_collection[100: 200]            # result is between 100 to 200, including 200th
+    result = result_collection[: 200]               # result is up to and including the 200th
+    result = result_collection[100: ]               # result is after the 100th
 
-    # Iterate over results
-    for result in result_set:
+    # Iterate over the result collection
+    for result in result_collection:
         print result
 
 ****************
@@ -225,8 +238,8 @@ Handling your business using *with* blocks saves you from having to connect and
 disconnect your client as well as saves you from having to perform a lot of 
 fetch and save operations as the context managers handle these operations for 
 you.  This example uses the ``cloudant`` context helper to illustrate the 
-process but identical functionality exists for CouchDB through the use of the 
-``couchdb`` context helper.
+process but identical functionality exists for CouchDB through the ``couchdb`` 
+and ``couchdb_admin_party`` context helpers.
 
 .. code-block:: python
 

--- a/src/cloudant/errors.py
+++ b/src/cloudant/errors.py
@@ -49,3 +49,30 @@ class CloudantArgumentError(CloudantException):
     """
     def __init__(self, msg, code=400):
         super(CloudantArgumentError, self).__init__(msg, code)
+
+class ResultException(CloudantException):
+    """
+    Provides a way to issue Cloudant Python client library result specific
+    exceptions.
+
+    :param int code: A code value used to identify the result exception.
+        Defaults to 100.
+    :param args: A list of arguments used to format the exception message.
+    """
+
+    def __init__(self, code=100, *args):
+        messages = {
+            100:'A general result exception was raised.',
+            101:'Failed to interpret the argument {0} as a valid key value or as a valid slice.',
+            102:'Cannot use {0} when performing key access or key slicing.  Found {1}.',
+            103:'Cannot use {0} for iteration.  Found {1}.',
+            104:'Invalid page_size: {0}'
+        }
+
+        try:
+            msg = messages[code].format(*args)
+        # pylint: disable=broad-except
+        except Exception:
+            code = 100
+            msg = messages[code]
+        super(ResultException, self).__init__(msg, code)

--- a/src/cloudant/result.py
+++ b/src/cloudant/result.py
@@ -19,7 +19,7 @@ import json
 from collections import Sequence
 
 from ._2to3 import STRTYPE, UNITYPE, NONETYPE, iteritems_
-from .errors import CloudantArgumentError
+from .errors import CloudantArgumentError, ResultException
 
 ARG_TYPES = {
     'descending': (bool,),
@@ -129,40 +129,80 @@ def type_or_none(typerefs, value):
     """
     return isinstance(value, typerefs) or value is None
 
-class Result(object):
+class ResultByKey(object):
     """
-    Provides a sliceable and iterable interface to result collections.
-    A Result object is instantiated with a raw data callable reference
-    such as the database API convenience method
-    :func:`~cloudant.database.CouchDatabase.all_docs` or the View
-    :func:`~cloudant.views.View.__call__` callable, both used to retrieve data.
-    A Result object can also use optional extra arguments for result
-    customization and supports efficient, paged iteration over the result
-    collection to avoid large result data from adversely affecting memory.
-
-    In Python, slicing returns by value, whereas iteration will yield
-    elements of the sequence.  This means that slicing will perform better
-    for smaller data collections, whereas iteration will be more
-    efficient for larger data collections.
+    Provides a wrapper for a value used to retrieve records from a result
+    collection based on an actual document key value.  This comes in handy when
+    the document key value is an ``int``.
 
     For example:
 
     .. code-block:: python
 
-        # Access by key:
-        result['key'] # get all records matching key
+        result = Result(callable)
+        result[ResultByKey(9)]   # gets records where the key matches 9
+        # as opposed to:
+        result[9]                # gets the 10th record of the result collection
 
-        # Slicing by startkey/endkey:
-        result[['2013','10']:['2013','11']] # results between compound keys
-        result['2013':'2014']               # results between string keys
-        result['2013':]                     # all results after key
-        result[:'2014']                     # all results up to key
+        :param value: A value representing a Result key.
+    """
+    def __init__(self, value):
+        self._value = value
 
-        # Slicing by value:
-        result[100:200] # results between the 100th and the 200th result
-        result[:200]    # results up to the 200th result
-        result[100:]    # results after 100th result
-        result[:]       # all results
+    def __call__(self):
+        return self._value
+
+class Result(object):
+    """
+    Provides a key accessible, sliceable, and iterable interface to result
+    collections.  A Result object is constructed with a raw data callable
+    reference such as the database API convenience method
+    :func:`~cloudant.database.CouchDatabase.all_docs` or the View
+    :func:`~cloudant.views.View.__call__` callable, used to retrieve data.
+    A Result object can also use optional extra arguments for result
+    customization and supports efficient, paged iteration over the result
+    collection to avoid large result data from adversely affecting memory.
+
+    In Python, slicing returns by value, whereas iteration will yield
+    elements of the sequence.  This means that individual key access and slicing
+    will perform better for smaller data collections, whereas iteration will
+    be more efficient for larger data collections.
+
+    For example:
+
+    .. code-block:: python
+
+        # Key access:
+
+        # Access by index value:
+        result = Result(callable)
+        result(9)                 # skip first 9 records and get 10th
+
+        # Access by key value:
+        result = Result(callable)
+        result['foo']             # get records matching 'foo'
+        result[ResultByKey(9)]    # get records matching 9
+
+        # Slice access:
+
+        # Access by index slices:
+        result = Result(callable)
+        result[100: 200]          # get records after the 100th and up to and including the 200th
+        result[: 200]             # get records up to and including the 200th
+        result[100: ]             # get all records after the 100th
+        result[: ]                # get all records
+
+        # Access by key slices:
+        result = Result(callable)
+        result['bar':'foo']       # get records between and including 'bar' and 'foo'
+        result['foo':]            # get records after and including 'foo'
+        result[:'foo']            # get records up to and including 'foo'
+
+        result[['foo', 10]:
+               ['foo', 11]]       # Complex key access and slicing works the same as simple keys
+
+        result[ResultByKey(5):
+               ResultByKey(10)]   # key slice access of integer keys
 
         # Iteration:
 
@@ -176,99 +216,193 @@ class Result(object):
         for i in result:
             print i
 
-        # Iterate over the entire result collection,
-        # including documents and in batches of a 1000.
+        # Iterate over the entire result collection in batches of 1000, including documents.
         result = Result(callable, include_docs=True, page_size=1000)
         for i in result:
             print i
 
-        :param method_ref: A reference to the method or callable that returns
-            the JSON content result to be wrapped.
-        :param options: See :func:`~cloudant.views.View.make_result` for a
-            list of valid result customization options.
+    Note: Since Result object key access, slicing, and iteration use query
+    parameters behind the scenes to handle their processing, some query
+    parameters are not permitted as part of a Result customization,
+    depending on whether key access, slicing, or iteration is being performed.
+
+    Such as:
+
+    +-------------------------------+-----------------------------------------------------------+
+    | Access/Slicing by index value | No restrictions                                           |
+    +-------------------------------+-----------------------------------------------------------+
+    | Access/Slicing by key value   | ``key``, ``keys``, ``startkey``, ``endkey`` not permitted |
+    +-------------------------------+-----------------------------------------------------------+
+    | Iteration                     | ``limit``, ``skip`` not permitted                         |
+    +-------------------------------+-----------------------------------------------------------+
+
+    :param method_ref: A reference to the method or callable that returns
+        the JSON content result to be wrapped as a Result.
+    :param options: See :func:`~cloudant.views.View.make_result` for a
+        list of valid result customization options.
     """
     def __init__(self, method_ref, **options):
         self.options = options
         self._ref = method_ref
         self._page_size = options.pop('page_size', 100)
 
-    def __getitem__(self, key):
+    def __getitem__(self, arg):
         """
         Provides Result key access and slicing support.
 
-        See :class:`~cloudant.result.Result` for key access and slicing
-        examples.
+        An ``int`` argument will be interpreted as a ``skip`` and then a get of
+        the next record.  For example ``[100]`` means skip the first 100 records
+        and then get the next record.
 
-        :param key:  Can be either a single value as a ``str`` or ``list``
-            which will be passed as the key to the query for entries matching
-            that key or slice.  Slices with integers will be interpreted as
-            ``skip:limit-skip`` style pairs.  For example ``[100:200]`` means
-            skip the first 100 records then get up to and including the 200th
-            record so that you get the range between the supplied slice values.
-            Slices with strings/lists will be interpreted as startkey/endkey
-            style keys.
+        A ``str``, ``list`` or :class:`~cloudant.result.ResultByKey` argument
+        will be interpreted as a ``key`` and then get all records that match the
+        given key.  For example ``['foo']`` will get all records that match
+        the key 'foo'.
 
-        :returns: Rows data in JSON format
+        An ``int`` slice argument will be interpreted as a ``skip:limit-skip``
+        style pair.  For example ``[100: 200]`` means skip the first 100 records
+        then get up to and including the 200th record so that you get the range
+        between the supplied slice values.
+
+        A slice argument that contains ``str``, ``list``, or
+        :class:`~cloudant.result.ResultByKey` will be interpreted as a
+        ``startkey: endkey`` style pair.  For example ``['bar': 'foo']`` means
+        get the range of records where the keys are between and including
+        'bar' and 'foo'.
+
+        See :class:`~cloudant.result.Result` for more detailed key access and
+        slicing examples.
+
+        :param arg:  A single value representing a key or a pair of values
+            representing a slice.  The argument value(s) can be ``int``,
+            ``str``, ``list`` (in the case of complex keys), or
+            :class:`~cloudant.result.ResultByKey`.
+
+        :returns: Rows data as a list in JSON format
         """
-        if isinstance(key, STRTYPE):
-            data = self._ref(key=key, **self.options)
-            return self._parse_data(data)
+        data = None
+        if isinstance(arg, int):
+            data = self._handle_result_by_index(arg)
+        elif isinstance(arg, STRTYPE) or isinstance(arg, list):
+            data = self._handle_result_by_key(arg)
+        elif isinstance(arg, ResultByKey):
+            data = self._handle_result_by_key(arg())
+        elif isinstance(arg, slice):
+            # slice is entire result set - no additional processing required
+            if arg.start is None and arg.stop is None:
+                data = self._ref(**self.options)
+            # key slice identified
+            elif (type_or_none((STRTYPE, list, ResultByKey), arg.start) and
+                  type_or_none((STRTYPE, list, ResultByKey), arg.stop)):
+                data = self._handle_result_by_key_slice(arg)
+            # index slice identified
+            elif (type_or_none(int, arg.start) and
+                  type_or_none(int, arg.stop)):
+                data = self._handle_result_by_idx_slice(arg)
+        if data is None:
+            raise ResultException(101, arg)
+        return self._parse_data(data)
 
-        if isinstance(key, list):
-            data = self._ref(key=key, **self.options)
-            return self._parse_data(data)
+    def _handle_result_by_index(self, idx):
+        """
+        Handle processing when the result argument provided is an integer.
+        """
+        if idx < 0:
+            return None
+        opts = dict(self.options)
+        skip = opts.pop('skip', 0)
+        limit = opts.pop('limit', None)
+        _validate('skip', skip)
+        _validate('limit', limit)
+        if limit is not None and idx >= limit:
+            # Result is out of range
+            return dict()
+        return self._ref(skip=skip+idx, limit=1, **opts)
 
-        if isinstance(key, slice):
-            # slice is startkey and endkey if str or array
-            str_or_none_start = type_or_none((STRTYPE, list), key.start)
-            str_or_none_stop = type_or_none((STRTYPE, list), key.stop)
-            if str_or_none_start and str_or_none_stop:
-                # startkey/endkey
-                if key.start is not None and key.stop is not None:
-                    data = self._ref(
-                        startkey=key.start,
-                        endkey=key.stop,
-                        **self.options
-                    )
-                if key.start is not None and key.stop is None:
-                    data = self._ref(startkey=key.start, **self.options)
-                if key.start is None and key.stop is not None:
-                    data = self._ref(endkey=key.stop, **self.options)
-                if key.start is None and key.stop is None:
-                    data = self._ref(**self.options)
-                return self._parse_data(data)
-            # slice is skip:skip+limit if ints
-            int_or_none_start = type_or_none(int, key.start)
-            int_or_none_stop = type_or_none(int, key.stop)
-            if int_or_none_start and int_or_none_stop:
-                if key.start is not None and key.stop is not None:
-                    limit = key.stop - key.start
-                    data = self._ref(
-                        skip=key.start,
-                        limit=limit,
-                        **self.options
-                    )
-                if key.start is not None and key.stop is None:
-                    data = self._ref(skip=key.start, **self.options)
-                if key.start is None and key.stop is not None:
-                    data = self._ref(limit=key.stop, **self.options)
-                # both None case handled already
-                return self._parse_data(data)
-        msg = (
-            'Failed to interpret the argument {0} '
-            'as a valid key value or as a valid slice.'
-        ).format(key)
-        raise CloudantArgumentError(msg)
+    def _handle_result_by_key(self, key):
+        """
+        Handle processing when the result argument provided is a document key.
+        """
+        invalid_options = ('key', 'keys', 'startkey', 'endkey')
+        if any(x in invalid_options for x in self.options):
+            raise ResultException(102, invalid_options, self.options)
+        return self._ref(key=key, **self.options)
+
+    def _handle_result_by_idx_slice(self, idx_slice):
+        """
+        Handle processing when the result argument provided is an index slice.
+        """
+        opts = dict(self.options)
+        skip = opts.pop('skip', 0)
+        limit = opts.pop('limit', None)
+        _validate('skip', skip)
+        _validate('limit', limit)
+        start = idx_slice.start
+        stop = idx_slice.stop
+        data = None
+        if (start is not None and stop is not None and
+                start >= 0 and stop >= 0 and start <= stop):
+            if limit is not None:
+                if start >= limit:
+                    # Result is out of range
+                    return dict()
+                elif stop > limit:
+                    # Ensure that slice does not extend past original limit
+                    return self._ref(skip=skip+start, limit=limit-start, **opts)
+            data = self._ref(skip=skip+start, limit=stop-start, **opts)
+        elif start is not None and stop is None and start >= 0:
+            if limit is not None:
+                if start >= limit:
+                    # Result is out of range
+                    return dict()
+                # Ensure that slice does not extend past original limit
+                data = self._ref(skip=skip+start, limit=limit-start, **opts)
+            else:
+                data = self._ref(skip=skip+start, **opts)
+        elif start is None and stop is not None and stop >= 0:
+            if limit is not None and stop > limit:
+                # Ensure that slice does not extend past original limit
+                data = self._ref(skip=skip, limit=limit, **opts)
+            else:
+                data = self._ref(skip=skip, limit=stop, **opts)
+        return data
+
+    def _handle_result_by_key_slice(self, key_slice):
+        """
+        Handle processing when the result argument provided is a key slice.
+        """
+        invalid_options = ('key', 'keys', 'startkey', 'endkey')
+        if any(x in invalid_options for x in self.options):
+            raise ResultException(102, invalid_options, self.options)
+
+        if isinstance(key_slice.start, ResultByKey):
+            start = key_slice.start()
+        else:
+            start = key_slice.start
+
+        if isinstance(key_slice.stop, ResultByKey):
+            stop = key_slice.stop()
+        else:
+            stop = key_slice.stop
+
+        if (start is not None and stop is not None and
+                isinstance(start, type(stop))):
+            data = self._ref(startkey=start, endkey=stop, **self.options)
+        elif start is not None and stop is None:
+            data = self._ref(startkey=start, **self.options)
+        elif start is None and stop is not None:
+            data = self._ref(endkey=stop, **self.options)
+        else:
+            data = None
+        return data
 
     def __iter__(self):
         """
         Provides iteration support, primarily for large data collections.
-        The iterator uses the skip/limit parameters to consume data in chunks
-        controlled by the ``page_size`` setting and retrieves a batch of data
-        from the result collection and then yields each element.  Since the
-        iterator uses the skip/limit parameters to perform the iteration,
-        ``skip`` and ``limit`` cannot be included as part of the original result
-        customization options.
+        The iterator uses the ``skip`` and ``limit`` options to consume
+        data in chunks controlled by the ``page_size`` option.  It retrieves
+        a batch of data from the result collection and then yields each
+        element.
 
         See :func:`~cloudant.views.View.make_result` for a list of valid
         result customization options.
@@ -277,25 +411,25 @@ class Result(object):
 
         :returns: Iterable data sequence
         """
-        if 'skip' in self.options:
-            msg = 'Cannot use skip for iteration'
-            raise CloudantArgumentError(msg)
-        if 'limit' in self.options:
-            msg = 'Cannot use limit for iteration'
-            raise CloudantArgumentError(msg)
-        if self._page_size <= 0:
-            msg = 'Invalid page_size: {0}'.format(self._page_size)
-            raise CloudantArgumentError(msg)
+        invalid_options = ('skip', 'limit')
+        if any(x in invalid_options for x in self.options):
+            raise ResultException(103, invalid_options, self.options)
+
+        try:
+            if int(self._page_size) <= 0:
+                raise ResultException(104, self._page_size)
+        except ValueError:
+            raise ResultException(104, self._page_size)
 
         skip = 0
         while True:
             response = self._ref(
-                limit=self._page_size,
+                limit=int(self._page_size),
                 skip=skip,
                 **self.options
             )
             result = self._parse_data(response)
-            skip += self._page_size
+            skip += int(self._page_size)
             if len(result) > 0:
                 for row in result:
                     yield row

--- a/tests/unit/db/query_result_tests.py
+++ b/tests/unit/db/query_result_tests.py
@@ -26,7 +26,7 @@ import requests
 
 from cloudant.query import Query
 from cloudant.result import QueryResult
-from cloudant.errors import CloudantArgumentError
+from cloudant.errors import CloudantArgumentError, ResultException
 
 from .unit_t_db_base import UnitTestDbBase
 
@@ -204,11 +204,9 @@ class QueryResultTests(UnitTestDbBase):
             selector={'_id': {'$gt': 0}},
             fields=['_id', '_rev']
         )
-        try:
-            docs = result[10:5]
-            self.fail('Above statement should raise an Exception')
-        except requests.HTTPError as err:
-            self.assertEqual(err.response.status_code, 400)
+        with self.assertRaises(ResultException) as cm:
+            invalid_result = result[10:5]
+        self.assertEqual(cm.exception.status_code, 101)
 
     def test_key_access_is_not_supported(self):
         """
@@ -265,14 +263,9 @@ class QueryResultTests(UnitTestDbBase):
             fields=['_id', '_rev'],
             skip=10
         )
-        try:
-            for doc in result:
-                self.fail('Above statement should raise an Exception')
-        except CloudantArgumentError as err:
-            self.assertEqual(
-                str(err),
-                'Cannot use skip for iteration'
-            )
+        with self.assertRaises(ResultException) as cm:
+            invalid_result = [row for row in result]
+        self.assertEqual(cm.exception.status_code, 103)
 
     def test_iteration_with_limit_option_fails(self):
         """
@@ -285,14 +278,9 @@ class QueryResultTests(UnitTestDbBase):
             fields=['_id', '_rev'],
             limit=10
         )
-        try:
-            for doc in result:
-                self.fail('Above statement should raise an Exception')
-        except CloudantArgumentError as err:
-            self.assertEqual(
-                str(err),
-                'Cannot use limit for iteration'
-            )
+        with self.assertRaises(ResultException) as cm:
+            invalid_result = [row for row in result]
+        self.assertEqual(cm.exception.status_code, 103)
 
     def test_iteration_invalid_page_size(self):
         """
@@ -305,11 +293,9 @@ class QueryResultTests(UnitTestDbBase):
             fields=['_id', '_rev'],
             page_size=0
         )
-        try:
-            for doc in result:
-                self.fail('Above statement should raise an Exception')
-        except CloudantArgumentError as err:
-            self.assertEqual(str(err), 'Invalid page_size: 0')
+        with self.assertRaises(ResultException) as cm:
+            invalid_result = [row for row in result]
+        self.assertEqual(cm.exception.status_code, 104)
 
     def test_iteration_result_eq_page_size(self):
         """

--- a/tests/unit/mocked/result_test.py
+++ b/tests/unit/mocked/result_test.py
@@ -22,7 +22,7 @@ import datetime
 import unittest
 
 from cloudant.result import python_to_couch, Result, type_or_none
-from cloudant.errors import CloudantArgumentError
+from cloudant.errors import CloudantArgumentError, ResultException
 
 import mock
 
@@ -111,9 +111,9 @@ class ResultTests(unittest.TestCase):
         self.assertEqual(rslt[1:], [1,2,3])
         self.assertEqual(ref.call_args, mock.call(skip=1))
         self.assertEqual(rslt[:100], [1,2,3])
-        self.assertEqual(ref.call_args, mock.call(limit=100))
+        self.assertEqual(ref.call_args, mock.call(limit=100, skip=0))
 
-        self.assertRaises(CloudantArgumentError, rslt.__getitem__, {})
+        self.assertRaises(ResultException, rslt.__getitem__, {})
 
     def test_iter_method(self):
         """test basics of iter method"""
@@ -126,10 +126,10 @@ class ResultTests(unittest.TestCase):
         run_iter = lambda x: [y for y in x]
 
         rslt = Result(ref, skip=1000)
-        self.assertRaises(CloudantArgumentError, run_iter, rslt)
+        self.assertRaises(ResultException, run_iter, rslt)
 
         rslt = Result(ref, limit=1000)
-        self.assertRaises(CloudantArgumentError, run_iter, rslt)
+        self.assertRaises(ResultException, run_iter, rslt)
 
     def test_iter_paging(self):
         """iterate with multiple pages of data"""


### PR DESCRIPTION
## What:

Add result collection key/index access, key/index slicing and iteration validation logic to the Result class and update supporting documentation.

## How:

- Add a ResultException class to handle all Result specific exceptions.
- Add logic to Result `__getitem__()` to handle data access via index.  As in `result[10]` will return the data in position 10 of the result collection.
- Add validation logic to key slicing to ensure that invalid requests are caught.
- Update iteration logic validation to use ResultException.
- Update "Dealing with Results" section of the "Getting Started" documentation.
- Update all affected docstring content in database, views, and result modules.

## Testing:

All tests have been written and the new tests all pass successfully under Python 2.7 and 3.5 targeting both CouchDB as well as Cloudant database instances.  The tests will be submitted in a follow up PR to keep the review process manageable.

## Reviewers:

reviewer: @emlaver 
reviewer: @brynh 

## Issues:

- #42 
