### PR TITLE
Rename account.py to client.py

### DIFF
--- a/docs/client.rst
+++ b/docs/client.rst
@@ -1,7 +1,7 @@
-account
-=======
+client
+======
 
-.. automodule:: cloudant.account
+.. automodule:: cloudant.client
     :members:
     :undoc-members:
     :special-members: __getitem__, __delitem__, __setitem__

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -15,10 +15,10 @@ Connections
 In order to manage a connection you must first initialize the connection by 
 constructing either a ``Cloudant`` or ``CouchDB`` client.  Since connecting to 
 the Cloudant managed service provides extra end points as compared to a CouchDB 
-instance, we provide the two different client implementations in order to 
+server, we provide the two different client implementations in order to 
 connect to the desired database service.  Once the client is constructed, 
-you follow that up by connecting to the account, performing your tasks, and then 
-disconnecting from the account.
+you follow that up by connecting to the server, performing your tasks, and
+then disconnecting from the server.
 
 Later in the `Context managers`_ section we will see how to 
 simplify this process through the use of the Python *with* statement.
@@ -29,16 +29,16 @@ Connecting with a client
 .. code-block:: python
 
     # Use CouchDB to create a CouchDB client
-    # from cloudant.account import CouchDB
+    # from cloudant.client import CouchDB
     # client = CouchDB(USERNAME, PASSWORD, url='http://127.0.0.1:5984')
 
     # Use Cloudant to create a Cloudant client using account
-    from cloudant.account import Cloudant
+    from cloudant.client import Cloudant
     client = Cloudant(USERNAME, PASSWORD, account=ACCOUNT_NAME)
     # or using url
     # client = Cloudant(USERNAME, PASSWORD, url='https://acct.cloudant.com')
     
-    # Connect to the account
+    # Connect to the server
     client.connect()
 
     # Perform client tasks...
@@ -46,7 +46,7 @@ Connecting with a client
     print 'Username: {0}'.format(session['userCtx']['name'])
     print 'Databases: {0}'.format(client.all_dbs())
 
-    # Disconnect from the account
+    # Disconnect from the server
     client.disconnect()
 
 *********
@@ -75,8 +75,8 @@ Opening a database
 
 Opening an existing database is done by supplying the name of an existing 
 database to the client.  Since the ``Cloudant`` and ``CouchDB`` classes are 
-sub-classes of ``dict``, this is accomplished through standard ``dict`` 
-notation.
+sub-classes of ``dict``, this can be accomplished through standard Python
+``dict`` notation.
 
 .. code-block:: python
 

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -4,7 +4,7 @@ Modules
 .. toctree::
    :maxdepth: 2
 
-   account
+   client
    database
    document
    design_document

--- a/src/cloudant/__init__.py
+++ b/src/cloudant/__init__.py
@@ -20,7 +20,7 @@ __version__ = '2.0.0.dev'
 # pylint: disable=wrong-import-position
 import contextlib
 # pylint: disable=wrong-import-position
-from .account import Cloudant, CouchDB
+from .client import Cloudant, CouchDB
 
 @contextlib.contextmanager
 def cloudant(user, passwd, **kwargs):

--- a/src/cloudant/changes.py
+++ b/src/cloudant/changes.py
@@ -27,7 +27,7 @@ class Feed(object):
     ``_changes`` and ``_db_updates``, suitable for feeding a daemon.  A Feed
     object is instantiated with a reference to a client's Session object and a
     feed endpoint URL.  Instead of using this class directly, it is recommended
-    to use the client API :func:`~cloudant.account.CouchDB.db_updates`
+    to use the client API :func:`~cloudant.client.CouchDB.db_updates`
     convenience method for interacting with a client's ``_db_updates`` feed
     and the database API :func:`~cloudant.database.CouchDatabase.changes`
     convenience method for interacting with a database's ``_changes`` feed.

--- a/src/cloudant/client.py
+++ b/src/cloudant/client.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2015 IBM. All rights reserved.
+# Copyright (c) 2015, 2016 IBM. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Top level API module that maps to a Cloudant or CouchDB
-client connection instance.
+Top level API module that maps to a Cloudant or CouchDB client connection
+instance.
 """
 import base64
 import json
@@ -38,8 +38,8 @@ class CouchDB(dict):
     Encapsulates a CouchDB client, handling top level user API calls having to
     do with session and database management.
 
-    Maintains a requests.Session for working with the
-    instance specified in the constructor.
+    Maintains a requests.Session for working with the instance specified in the
+    constructor.
 
     Parameters can be passed in to control behavior:
 
@@ -325,7 +325,7 @@ class CouchDB(dict):
         Note:  The only way to override the default for the ``remote`` argument
         setting it to True is to call __setitem__ directly.  A much simpler
         approach is to use
-        :func:`~cloudant.account.CouchDB.create_database` instead, if your
+        :func:`~cloudant.client.CouchDB.create_database` instead, if your
         intention is to create a database remotely.
 
         :param str key: Database name to be used as the key for the database in

--- a/src/cloudant/replicator.py
+++ b/src/cloudant/replicator.py
@@ -39,7 +39,7 @@ class Replicator(object):
         except Exception:
             raise CloudantException(
                 'Unable to acquire _replicator database.  '
-                'Verify that the account client is valid and try again.'
+                'Verify that the client is valid and try again.'
             )
 
     def create_replication(self, source_db=None, target_db=None,

--- a/tests/unit/db/client_tests.py
+++ b/tests/unit/db/client_tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2015 IBM. All rights reserved.
+# Copyright (c) 2015, 2016 IBM. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-_account_tests_
-
-account module - Unit tests for CouchDB and Cloudant account classes
+client module - Unit tests for CouchDB and Cloudant client classes
 
 See configuration options for environment variables in unit_t_db_base
 module docstring.
@@ -30,15 +28,15 @@ import os
 from datetime import datetime
 
 from cloudant import cloudant, couchdb, couchdb_admin_party
-from cloudant.account import Cloudant, CouchDB
+from cloudant.client import Cloudant, CouchDB
 from cloudant.errors import CloudantException, CloudantArgumentError
 
 from .unit_t_db_base import UnitTestDbBase
 from ... import bytes_, str_
 
-class AccountTests(UnitTestDbBase):
+class ClientTests(UnitTestDbBase):
     """
-    CouchDB/Cloudant Account unit tests
+    CouchDB/Cloudant client unit tests
     """
 
     @unittest.skipIf(
@@ -76,7 +74,7 @@ class AccountTests(UnitTestDbBase):
 
     def test_constructor_with_url(self):
         """
-        Test instantiating an account object using a URL
+        Test instantiating a client object using a URL
         """
         self.assertEqual(
             self.client.cloudant_url,
@@ -153,7 +151,7 @@ class AccountTests(UnitTestDbBase):
 
     def test_all_dbs(self):
         """
-        Test getting a list of all of the databases in the account
+        Test getting a list of all of the databases
         """
         dbnames = [self.dbname() for _ in range(3)]
         try:
@@ -216,7 +214,7 @@ class AccountTests(UnitTestDbBase):
 
     def test_keys(self):
         """
-        Test retrieving the list of database names for the given client account
+        Test retrieving the list of database names
         """
         try:
             self.client.connect()
@@ -278,7 +276,7 @@ class AccountTests(UnitTestDbBase):
 
     def test_delete_remote_db_via_delitem(self):
         """
-        Test __delitem__ when removing a database from the account
+        Test __delitem__ when removing a database
         """
         dbname = self.dbname()
         try:
@@ -317,7 +315,7 @@ class AccountTests(UnitTestDbBase):
 
     def test_get_remote_db_via_get(self):
         """
-        Test retrieving a database from the account
+        Test retrieving a database
         """
         dbname = self.dbname()
         try:
@@ -378,11 +376,11 @@ class AccountTests(UnitTestDbBase):
 
 @unittest.skipUnless(
     os.environ.get('RUN_CLOUDANT_TESTS') is not None,
-    'Skipping Cloudant Account specific tests'
+    'Skipping Cloudant client specific tests'
 )
-class CloudantAccountTests(UnitTestDbBase):
+class CloudantClientTests(UnitTestDbBase):
     """
-    Cloudant specific Account unit tests
+    Cloudant specific client unit tests
     """
 
     def test_cloudant_context_helper(self):
@@ -399,7 +397,7 @@ class CloudantAccountTests(UnitTestDbBase):
     
     def test_constructor_with_account(self):
         """
-        Test instantiating an account object using an account name
+        Test instantiating a client object using an account name
         """
         # Ensure that the client is new
         del self.client
@@ -708,7 +706,7 @@ class CloudantAccountTests(UnitTestDbBase):
 
     def test_generate_api_key(self):
         """
-        Test the generation of an API key for this account
+        Test the generation of an API key for this client account
         """
         try:
             self.client.connect()
@@ -721,7 +719,8 @@ class CloudantAccountTests(UnitTestDbBase):
 
     def test_cors_configuration(self):
         """
-        Test the retrieval of the current CORS configuration for this account
+        Test the retrieval of the current CORS configuration for this client
+        account
         """
         try:
             self.client.connect()

--- a/tests/unit/db/database_tests.py
+++ b/tests/unit/db/database_tests.py
@@ -76,8 +76,8 @@ class DatabaseTests(UnitTestDbBase):
 
     def test_retrieve_creds(self):
         """
-        Test retrieving account credentials.
-        Account credentials are None if CouchDB Admin Party mode was selected.
+        Test retrieving client credentials. The client credentials are None if
+        CouchDB Admin Party mode was selected.
         """
         if self.client.admin_party:
             self.assertIsNone(self.db.creds)

--- a/tests/unit/db/replicator_tests.py
+++ b/tests/unit/db/replicator_tests.py
@@ -82,7 +82,7 @@ class ReplicatorTests(UnitTestDbBase):
     def test_constructor_failure(self):
         """
         Test that constructing a Replicator will not work
-        without a valid account.
+        without a valid client.
         """
         repl = None
         try:
@@ -93,7 +93,7 @@ class ReplicatorTests(UnitTestDbBase):
             self.assertEqual(
                 str(err),
                 'Unable to acquire _replicator database.  '
-                'Verify that the account client is valid and try again.'
+                'Verify that the client is valid and try again.'
             )
         finally:
             self.assertIsNone(repl)

--- a/tests/unit/db/unit_t_db_base.py
+++ b/tests/unit/db/unit_t_db_base.py
@@ -58,7 +58,7 @@ import requests
 import os
 import uuid
 
-from cloudant.account import CouchDB, Cloudant
+from cloudant.client import CouchDB, Cloudant
 from cloudant.design_document import DesignDocument
 
 from ... import unicode_

--- a/tests/unit/mocked/client_test.py
+++ b/tests/unit/mocked/client_test.py
@@ -13,20 +13,17 @@
 # See the License for the specific language governing permissions and 
 # limitations under the License.
 """
-_account_test_
-
-account module unit tests
-
+client module unit tests
 """
 import mock
 import unittest
 import requests
 
-from cloudant.account import Cloudant, CouchDB
+from cloudant.client import Cloudant, CouchDB
 from cloudant.errors import CloudantException
 
 
-class CouchDBAccountTests(unittest.TestCase):
+class CouchDBClientTests(unittest.TestCase):
     def setUp(self):
         """
         mock out requests.Session
@@ -59,7 +56,7 @@ class CouchDBAccountTests(unittest.TestCase):
             {"dbname": "somedb2", "type": "created", "account": "bob", "seq": "11-g1AAAABteJzLYWBgYMxgTmFQSElKzi9KdUhJMtHLTc1NzTcwMNdLzskvTUnMK9HLSy3JAapkSmTIY2H4DwRZGcyJ3LlAIfa0tKQUQ2NTIkzIAgABWCJk"}
             {"dbname": "somedb1", "type": "updated", "account": "bob", "seq": "12-g1AAAABteJzLYWBgYMxgTmFQSElKzi9KdUhJMtHLTc1NzTcwMNdLzskvTUnMK9HLSy3JAapkSmTIY2H4DwRZGcyJPLlAIfa0tKQUQ2NTIkzIAgABiSJl"}
         """
-        with mock.patch('cloudant.account.Feed') as mock_feed:
+        with mock.patch('cloudant.client.Feed') as mock_feed:
             feed = (x.strip() for x in updates_feed.split('\n'))
             mock_feed.__iter__ = mock.MagicMock()
             mock_feed.return_value = feed
@@ -195,7 +192,7 @@ class CouchDBAccountTests(unittest.TestCase):
         self.assertTrue(isinstance(c['b'], c._DATABASE_CLASS))
         self.assertRaises(KeyError, c.__getitem__, 'd')
 
-        with mock.patch('cloudant.account.CouchDatabase.exists') as mock_exists:
+        with mock.patch('cloudant.client.CouchDatabase.exists') as mock_exists:
             mock_exists.return_value = True
             self.assertTrue(isinstance(c['c'], c._DATABASE_CLASS))
 
@@ -239,13 +236,13 @@ class CouchDBAccountTests(unittest.TestCase):
         self.assertEqual(c.get('a'), c['a'])
         self.assertEqual(c.get('d', None), None)
 
-        with mock.patch('cloudant.account.CouchDatabase.exists') as mock_exists:
+        with mock.patch('cloudant.client.CouchDatabase.exists') as mock_exists:
             mock_exists.return_value = True
             self.assertTrue(isinstance(c.get('b', remote=True), c._DATABASE_CLASS))
 
         self.assertTrue(c.get('d', None, remote=True) is None)
 
-class CloudantAccountTests(unittest.TestCase):
+class CloudantClientTests(unittest.TestCase):
     """
     Unittests with mocked out remote calls
 
@@ -405,7 +402,7 @@ class CloudantAccountTests(unittest.TestCase):
     def test_bill(self):
         """test bill API call"""
         with mock.patch(
-            'cloudant.account.Cloudant._usage_endpoint'
+            'cloudant.client.Cloudant._usage_endpoint'
         ) as mock_usage:
             mock_usage.return_value = {'usage': 'mock'}
             c = Cloudant(self.username, self.password, account=self.username)
@@ -415,7 +412,7 @@ class CloudantAccountTests(unittest.TestCase):
 
     def test_volume_usage(self):
         with mock.patch(
-            'cloudant.account.Cloudant._usage_endpoint'
+            'cloudant.client.Cloudant._usage_endpoint'
         ) as mock_usage:
             mock_usage.return_value = {'usage': 'mock'}
             c = Cloudant(self.username, self.password, account=self.username)
@@ -425,7 +422,7 @@ class CloudantAccountTests(unittest.TestCase):
 
     def test_requests_usage(self):
         with mock.patch(
-            'cloudant.account.Cloudant._usage_endpoint'
+            'cloudant.client.Cloudant._usage_endpoint'
         ) as mock_usage:
             mock_usage.return_value = {'usage': 'mock'}
             c = Cloudant(self.username, self.password, account=self.username)

--- a/tests/unit/mocked/database_test.py
+++ b/tests/unit/mocked/database_test.py
@@ -36,15 +36,15 @@ class CouchDBTest(unittest.TestCase):
         self.mock_session.put = mock.Mock()
         self.mock_session.delete = mock.Mock()
 
-        self.account = mock.Mock()
-        self.account.cloudant_url = "https://bob.cloudant.com"
-        self.account.r_session = self.mock_session
+        self.client = mock.Mock()
+        self.client.cloudant_url = "https://bob.cloudant.com"
+        self.client.r_session = self.mock_session
 
         self.username = "bob"
         self.db_name = "testdb"
 
-        self.db_url = posixpath.join(self.account.cloudant_url, self.db_name)
-        self.c = CouchDatabase(self.account, self.db_name)
+        self.db_url = posixpath.join(self.client.cloudant_url, self.db_name)
+        self.c = CouchDatabase(self.client, self.db_name)
 
         self.db_info = {
             "update_seq": "1-g1AAAADfeJzLYWBg",
@@ -207,13 +207,13 @@ class CloudantDBTest(unittest.TestCase):
         self.mock_session.put = mock.Mock()
         self.mock_session.delete = mock.Mock()
 
-        self.account = mock.Mock()
-        self.account.cloudant_url = "https://bob.cloudant.com"
-        self.account.r_session = self.mock_session
+        self.client = mock.Mock()
+        self.client.cloudant_url = "https://bob.cloudant.com"
+        self.client.r_session = self.mock_session
 
         self.username = "bob"
         self.db_name = "testdb"
-        self.cl = CloudantDatabase(self.account, self.db_name)
+        self.cl = CloudantDatabase(self.client, self.db_name)
 
         self.sec_doc = {
             "_id": "_security",
@@ -313,7 +313,7 @@ class CloudantDBTest(unittest.TestCase):
 
         expected_data = {doc_id: ['rev1', 'rev2', 'rev3']}
         expected_url = posixpath.join(
-            self.account.cloudant_url,
+            self.client.cloudant_url,
             self.db_name,
             '_missing_revs'
         )
@@ -343,7 +343,7 @@ class CloudantDBTest(unittest.TestCase):
 
         expected_data = {doc_id: ['rev1', 'rev2', 'rev3']}
         expected_url = posixpath.join(
-            self.account.cloudant_url,
+            self.client.cloudant_url,
             self.db_name,
             '_revs_diff'
         )
@@ -358,7 +358,7 @@ class CloudantDBTest(unittest.TestCase):
     def test_revs_limit(self):
         limit = 500
         expected_url = posixpath.join(
-            self.account.cloudant_url,
+            self.client.cloudant_url,
             self.db_name,
             '_revs_limit'
         )
@@ -406,7 +406,7 @@ class CloudantDBTest(unittest.TestCase):
 
     def test_view_cleanup(self):
         expected_url = posixpath.join(
-            self.account.cloudant_url,
+            self.client.cloudant_url,
             self.db_name,
             '_view_cleanup'
         )

--- a/tests/unit/mocked/document_test.py
+++ b/tests/unit/mocked/document_test.py
@@ -39,14 +39,14 @@ class DocumentTest(unittest.TestCase):
         self.mock_session.put = mock.Mock()
         self.mock_session.delete = mock.Mock()
 
-        self.account = mock.Mock()
-        self.account.cloudant_url = "https://bob.cloudant.com"
-        self.account.r_session = self.mock_session
-        self.account.encoder = json.JSONEncoder
+        self.client = mock.Mock()
+        self.client.cloudant_url = "https://bob.cloudant.com"
+        self.client.r_session = self.mock_session
+        self.client.encoder = json.JSONEncoder
         self.database = mock.Mock()
         self.database.r_session = self.mock_session
         self.database.database_name = "unittest"
-        self.database.cloudant_account = self.account
+        self.database.cloudant_account = self.client
 
     def test_document_crud(self):
         """test basic crud operations with mocked backend"""

--- a/tests/unit/mocked/replicator_test.py
+++ b/tests/unit/mocked/replicator_test.py
@@ -51,17 +51,17 @@ class ReplicatorTests(unittest.TestCase):
         self.username = "steve"
         self.password = "abc123"
 
-        self.mock_account = mock.Mock()
-        self.mock_account.__getitem__ = mock.Mock()
-        self.mock_account.__getitem__.return_value = CouchDatabase(
-            self.mock_account,
+        self.mock_client = mock.Mock()
+        self.mock_client.__getitem__ = mock.Mock()
+        self.mock_client.__getitem__.return_value = CouchDatabase(
+            self.mock_client,
             '_replicator'
         )
-        self.mock_account.session = mock.Mock()
-        self.mock_account.session.return_value = {
+        self.mock_client.session = mock.Mock()
+        self.mock_client.session.return_value = {
             "userCtx": "user Context"
         }
-        self.mock_account.admin_party = False
+        self.mock_client.admin_party = False
 
     def tearDown(self):
         self.patcher.stop()
@@ -72,15 +72,15 @@ class ReplicatorTests(unittest.TestCase):
             mock_target = mock.Mock()
             mock_target.database_url = "http://bob.cloudant.com/target"
             mock_target.creds = {'basic_auth': "target_auth"}
-            mock_target.cloudant_account = self.mock_account
+            mock_target.cloudant_account = self.mock_client
             mock_target.admin_party = False
             mock_source = mock.Mock()
             mock_source.database_url = "http://bob.cloudant.com/source"
             mock_source.creds = {'basic_auth': "source_auth"}
-            mock_source.cloudant_account = self.mock_account
+            mock_source.cloudant_account = self.mock_client
             mock_source.admin_party = False
 
-            repl = Replicator(self.mock_account)
+            repl = Replicator(self.mock_client)
             repl.create_replication(mock_source, mock_target, "REPLID")
 
         self.assertTrue(mock_create.called)
@@ -114,7 +114,7 @@ class ReplicatorTests(unittest.TestCase):
         mock_source.database_url = "http://bob.cloudant.com/source"
         mock_source.creds = {'basic_auth': "source_auth"}
 
-        repl = Replicator(self.mock_account)
+        repl = Replicator(self.mock_client)
         self.assertRaises(
             CloudantException,
             repl.create_replication,
@@ -137,7 +137,7 @@ class ReplicatorTests(unittest.TestCase):
                     {"id": "replication_2", "doc": {"_id": "replication_2"}}
                 ]
             }
-            repl = Replicator(self.mock_account)
+            repl = Replicator(self.mock_client)
 
             self.assertEqual(
                 repl.list_replications(),
@@ -146,7 +146,7 @@ class ReplicatorTests(unittest.TestCase):
 
     def test_replication_state(self):
         """test replication state method"""
-        repl = Replicator(self.mock_account)
+        repl = Replicator(self.mock_client)
 
         mock_doc = mock.Mock()
         mock_doc.fetch = mock.Mock()
@@ -166,7 +166,7 @@ class ReplicatorTests(unittest.TestCase):
 
     def test_stop_replication(self):
         """test stop_replication call"""
-        repl = Replicator(self.mock_account)
+        repl = Replicator(self.mock_client)
 
         mock_doc = mock.Mock()
         mock_doc.fetch = mock.Mock()
@@ -194,7 +194,7 @@ class ReplicatorTests(unittest.TestCase):
                 {"id": "replication_1", "_replication_state": "not finished"},
                 {"id": "replication_1", "_replication_state": "completed"},
             ]
-            repl = Replicator(self.mock_account)
+            repl = Replicator(self.mock_client)
 
             mock_doc = mock.Mock()
             mock_doc.fetch = mock.Mock()


### PR DESCRIPTION
## What:

Rename the account module to be the client module.

## Why:

The notion of an account is clear when it comes to Cloudant but less so when it comes to CouchDB.  Since this library serves both, we are switching the name of the account module to client so that it makes sense for both Cloudant and CouchDB.

## How:

- Rename account.py as client.py
- Update all import references in code and tests
- Update documentation .rst files
- Update docsting comments as necessary to reference client instead of account

## Testing:

- No additional tests but all tests using account module now use client module
- Comments updated as necessary

## Reviewers:

reviewer: @rhyshort 
reviewer: @emlaver 

## Issues

- #44 
