### PR TITLE
Rename views.py module to view.py

### DIFF
--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -8,7 +8,7 @@ Modules
    database
    document
    design_document
-   views
+   view
    query
    indexes
    result

--- a/docs/view.rst
+++ b/docs/view.rst
@@ -1,7 +1,7 @@
-views
-=====
+view
+====
 
-.. automodule:: cloudant.views
+.. automodule:: cloudant.view
     :members:
     :undoc-members:
     :special-members: __call__

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -24,7 +24,7 @@ from requests.exceptions import HTTPError
 from ._2to3 import url_quote_plus
 from .document import Document
 from .design_document import DesignDocument
-from .views import View
+from .view import View
 from .indexes import Index, TextIndex, SpecialIndex
 from .index_constants import JSON_INDEX_TYPE
 from .index_constants import TEXT_INDEX_TYPE

--- a/src/cloudant/design_document.py
+++ b/src/cloudant/design_document.py
@@ -17,7 +17,7 @@ API module/class for interacting with a design document in a database.
 """
 from ._2to3 import iteritems_
 from .document import Document
-from .views import View, QueryIndexView
+from .view import View, QueryIndexView
 from .errors import CloudantArgumentError, CloudantException
 
 QUERY_LANGUAGE = 'query'
@@ -67,9 +67,9 @@ class DesignDocument(Document):
 
         :param str view_name: Name used to identify the View.
         :param str map_func: Javascript map function.  Can also be a
-            :class:`~cloudant.views.Code` object.
+            :class:`~cloudant.view.Code` object.
         :param str reduce_func: Optional Javascript reduce function.
-            Can also be a :class:`~cloudant.views.Code` object.
+            Can also be a :class:`~cloudant.view.Code` object.
         """
         if self.get_view(view_name) is not None:
             msg = "View {0} already exists in this design doc".format(view_name)
@@ -94,9 +94,9 @@ class DesignDocument(Document):
 
         :param str view_name: Name used to identify the View.
         :param str map_func: Javascript map function.  Can also be a
-            :class:`~cloudant.views.Code` object.
+            :class:`~cloudant.view.Code` object.
         :param str reduce_func: Optional Javascript reduce function.
-            Can also be a :class:`~cloudant.views.Code` object.
+            Can also be a :class:`~cloudant.view.Code` object.
         """
         view = self.get_view(view_name)
         if view is None:

--- a/src/cloudant/result.py
+++ b/src/cloudant/result.py
@@ -60,7 +60,7 @@ def python_to_couch(options):
     code that formulates a query to retrieve results data from the
     remote database, such as the database API convenience method
     :func:`~cloudant.database.CouchDatabase.all_docs` or the View
-    :func:`~cloudant.views.View.__call__` callable, both used to retrieve data.
+    :func:`~cloudant.view.View.__call__` callable, both used to retrieve data.
 
     :param dict options: Python style parameters to be translated.
 
@@ -158,7 +158,7 @@ class Result(object):
     collections.  A Result object is constructed with a raw data callable
     reference such as the database API convenience method
     :func:`~cloudant.database.CouchDatabase.all_docs` or the View
-    :func:`~cloudant.views.View.__call__` callable, used to retrieve data.
+    :func:`~cloudant.view.View.__call__` callable, used to retrieve data.
     A Result object can also use optional extra arguments for result
     customization and supports efficient, paged iteration over the result
     collection to avoid large result data from adversely affecting memory.
@@ -238,7 +238,7 @@ class Result(object):
 
     :param method_ref: A reference to the method or callable that returns
         the JSON content result to be wrapped as a Result.
-    :param options: See :func:`~cloudant.views.View.make_result` for a
+    :param options: See :func:`~cloudant.view.View.make_result` for a
         list of valid result customization options.
     """
     def __init__(self, method_ref, **options):
@@ -404,7 +404,7 @@ class Result(object):
         a batch of data from the result collection and then yields each
         element.
 
-        See :func:`~cloudant.views.View.make_result` for a list of valid
+        See :func:`~cloudant.view.View.make_result` for a list of valid
         result customization options.
 
         See :class:`~cloudant.result.Result` for Result iteration examples.

--- a/src/cloudant/view.py
+++ b/src/cloudant/view.py
@@ -79,7 +79,7 @@ class View(dict):
 
     The default result collection provides basic functionality,
     which can be customized with other arguments using the
-    :func:`~cloudant.views.View.custom_result` context manager.
+    :func:`~cloudant.view.View.custom_result` context manager.
 
     For example:
 
@@ -106,9 +106,9 @@ class View(dict):
         identify the view.
     :param str view_name: Name used in part to identify the view.
     :param str map_func: Optional Javascript map function.  Can also be a
-        :class:`~cloudant.views.Code` object.
+        :class:`~cloudant.view.Code` object.
     :param str reduce_func: Optional Javascript reduce function.  Can also be a
-        :class:`~cloudant.views.Code` object.
+        :class:`~cloudant.view.Code` object.
     """
     def __init__(
             self,
@@ -144,7 +144,7 @@ class View(dict):
             print view.map
 
         :param str js_func: Javascript function.  Can also be a
-            :class:`~cloudant.views.Code` object.
+            :class:`~cloudant.view.Code` object.
 
         :returns: Codified map function
         """
@@ -173,7 +173,7 @@ class View(dict):
             print view.reduce
 
         :param str js_func: Javascript function.  Can also be a
-            :class:`~cloudant.views.Code` object.
+            :class:`~cloudant.view.Code` object.
 
         :returns: Codified reduce function
         """
@@ -454,7 +454,7 @@ class QueryIndexView(View):
     def make_result(self, **options):
         """
         This method overrides the View base class
-        :func:`~cloudant.views.View.make_result` method with the sole purpose of
+        :func:`~cloudant.view.View.make_result` method with the sole purpose of
         disabling it.  Since QueryIndexView objects are not callable, there is
         no reason to wrap their output in a Result.  If you wish to execute a
         query using a query index, use

--- a/tests/unit/db/design_document_tests.py
+++ b/tests/unit/db/design_document_tests.py
@@ -26,7 +26,7 @@ import unittest
 
 from cloudant.document import Document 
 from cloudant.design_document import DesignDocument
-from cloudant.views import View, QueryIndexView
+from cloudant.view import View, QueryIndexView
 from cloudant.errors import CloudantArgumentError, CloudantException
 
 from .unit_t_db_base import UnitTestDbBase

--- a/tests/unit/db/index_tests.py
+++ b/tests/unit/db/index_tests.py
@@ -30,7 +30,7 @@ import requests
 
 from cloudant.indexes import Index, TextIndex, SpecialIndex
 from cloudant.query import Query
-from cloudant.views import QueryIndexView
+from cloudant.view import QueryIndexView
 from cloudant.design_document import DesignDocument
 from cloudant.document import Document
 from cloudant.errors import CloudantArgumentError, CloudantException

--- a/tests/unit/db/view_tests.py
+++ b/tests/unit/db/view_tests.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-_views_tests_
+_view_tests_
 
-views module - Unit tests for the View/QueryIndexView classes
+view module - Unit tests for the View/QueryIndexView classes
 
 See configuration options for environment variables in unit_t_db_base
 module docstring.
@@ -29,8 +29,8 @@ import requests
 import os
 
 from cloudant.design_document import DesignDocument
-from cloudant.views import View, QueryIndexView
-from cloudant.views import Code
+from cloudant.view import View, QueryIndexView
+from cloudant.view import Code
 from cloudant.result import Result
 from cloudant.errors import CloudantArgumentError, CloudantException
 

--- a/tests/unit/mocked/view_test.py
+++ b/tests/unit/mocked/view_test.py
@@ -13,21 +13,21 @@
 # See the License for the specific language governing permissions and 
 # limitations under the License.
 """
-_views_test_
+_view_test_
 
-views module unit tests
+view module unit tests
 
 """
 import mock
 import unittest
 
-from cloudant.views import Code, View
+from cloudant.view import Code, View
 from cloudant.design_document import DesignDocument
 from cloudant.result import Result
 
 
 class CodeTests(unittest.TestCase):
-    """tests for cloudant.views.Code, not much to test here yet..."""
+    """tests for cloudant.view.Code, not much to test here yet..."""
     def test_code(self):
         """test instantiation/manipulation"""
         c = Code("function(doc){emit(doc._id, 1)}")


### PR DESCRIPTION
## What:

Rename views.py to view.py to match naming pattern for modules within this library.
#132 

## How:

- Rename views.py to view.py
- Update all import references in code and tests
- Update Sphinx documentation .rst files
- Update docsting comments

## Testing:

- No additional tests
- All tests using views module now use view module

## Reviewers:

reviewer @alfinkel 
reviewer @ricellis