### PR TITLE
Remove make_result from Query and View

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,6 @@
 2.0.0 (Unreleased)
 ==================
+- [BREAKING] Removed the make_result method from View and Query classes.  If you need to make a query or view result, use ``CloudantDatabase.get_query_result``, ``CouchDatabase.get_view_result``, or the ``View.custom_result`` context manager.  Additionally, the ``Result`` and ``QueryResult`` classes can be called directly to construct a result object.
 - [BREAKING] Renamed modules account.py, errors.py, indexes.py, views.py, to client.py, error.py, index.py, and view.py.
 - [FIX] Added validation to ``Cloudant.bill``, ``Cloudant.volume_usage``, and ``Cloudant.requests_usage`` methods to ensure that a valid year/month combination or neither are used as arguments.
 - [FIX] Fixed the handling of empty views in the DesignDocument.

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -31,7 +31,7 @@ from .index_constants import TEXT_INDEX_TYPE
 from .index_constants import SPECIAL_INDEX_TYPE
 from .query import Query
 from .error import CloudantException, CloudantArgumentError
-from .result import python_to_couch, Result
+from .result import python_to_couch, Result, QueryResult
 from .changes import Feed
 
 class CouchDatabase(dict):
@@ -299,7 +299,7 @@ class CouchDatabase(dict):
         if raw_result:
             return view(**kwargs)
         elif kwargs:
-            return view.make_result(**kwargs)
+            return Result(view, **kwargs)
         else:
             return view.result
 
@@ -998,6 +998,6 @@ class CloudantDatabase(CouchDatabase):
         if raw_result:
             return query(**kwargs)
         if kwargs:
-            return query.make_result(**kwargs)
+            return QueryResult(query, **kwargs)
         else:
             return query.result

--- a/src/cloudant/query.py
+++ b/src/cloudant/query.py
@@ -193,43 +193,6 @@ class Query(dict):
         resp.raise_for_status()
         return resp.json()
 
-    def make_result(self, **options):
-        """
-        Wraps the raw JSON content of the Query object callable in a
-        :class:`~cloudant.result.QueryResult` object.  The use of ``skip``
-        and ``limit`` as options are not valid when using a QueryResult since
-        the ``skip`` and ``limit`` functionality is handled in the QueryResult.
-
-        Note:  Rather than using this method directly, if you wish to
-        retrieve query data as a QueryResult object, use the provided database
-        API of :func:`~cloudant.database.CouchDatabase.get_query_result`
-        using the ``raw_result=False`` default setting instead.
-
-        :param str bookmark: A string that enables you to specify which page of
-            results you require. Only valid for queries using indexes of type
-            *text*.
-        :param list fields: A list of fields to be returned by the query.
-        :param int page_size: Sets the page size for result iteration.  Default
-            is 100.
-        :param int r: Read quorum needed for the result.  Each document is read
-            from at least 'r' number of replicas before it is returned in the
-            results.
-        :param str selector: Dictionary object describing criteria used to
-            select documents.
-        :param list sort: A list of fields to sort by.  Optionally the list can
-            contain elements that are single member dictionary structures that
-            specify sort direction.  For example
-            ``sort=['name', {'age': 'desc'}]`` means to sort the query results
-            by the "name" field in ascending order and the "age" field in
-            descending order.
-        :param str use_index: Identifies a specific index for the query to run
-            against, rather than using the Cloudant Query algorithm which finds
-            what it believes to be the best index.
-
-        :returns: Query result data wrapped in a QueryResult instance
-        """
-        return QueryResult(self, **options)
-
     @contextlib.contextmanager
     def custom_result(self, **options):
         """
@@ -270,6 +233,6 @@ class Query(dict):
 
         :returns: Query result data wrapped in a QueryResult instance
         """
-        rslt = self.make_result(**options)
+        rslt = QueryResult(self, **options)
         yield rslt
         del rslt

--- a/src/cloudant/result.py
+++ b/src/cloudant/result.py
@@ -236,10 +236,38 @@ class Result(object):
     | Iteration                     | ``limit``, ``skip`` not permitted                         |
     +-------------------------------+-----------------------------------------------------------+
 
-    :param method_ref: A reference to the method or callable that returns
+    :param str method_ref: A reference to the method or callable that returns
         the JSON content result to be wrapped as a Result.
-    :param options: See :func:`~cloudant.view.View.make_result` for a
-        list of valid result customization options.
+    :param bool descending: Return documents in descending key order.
+    :param endkey: Stop returning records at this specified key.
+        Not valid when used with key access and key slicing.
+    :param str endkey_docid: Stop returning records when the specified
+        document id is reached.
+    :param bool group: Using the reduce function, group the results to a
+        group or single row.
+    :param group_level: Only applicable if the view uses complex keys: keys
+        that are JSON arrays. Groups reduce results for the specified number
+        of array fields.
+    :param bool include_docs: Include the full content of the documents.
+    :param bool inclusive_end: Include rows with the specified endkey.
+    :param key: Return only documents that match the specified key.
+        Not valid when used with key access and key slicing.
+    :param list keys: Return only documents that match the specified keys.
+        Not valid when used with key access and key slicing.
+    :param int limit: Limit the number of returned documents to the
+        specified count.  Not valid when used with key iteration.
+    :param int page_size: Sets the page size for result iteration.
+    :param bool reduce: True to use the reduce function, false otherwise.
+    :param int skip: Skip this number of rows from the start.
+        Not valid when used with key iteration.
+    :param str stale: Allow the results from a stale view to be used. This
+        makes the request return immediately, even if the view has not been
+        completely built yet. If this parameter is not given, a response is
+        returned only after the view has been built.
+    :param startkey: Return records starting with the specified key.
+        Not valid when used with key access and key slicing.
+    :param str startkey_docid: Return records starting with the specified
+        document ID.
     """
     def __init__(self, method_ref, **options):
         self.options = options
@@ -404,9 +432,6 @@ class Result(object):
         a batch of data from the result collection and then yields each
         element.
 
-        See :func:`~cloudant.view.View.make_result` for a list of valid
-        result customization options.
-
         See :class:`~cloudant.result.Result` for Result iteration examples.
 
         :returns: Iterable data sequence
@@ -505,8 +530,26 @@ class QueryResult(Result):
 
     :param query: A reference to the query callable that returns
         the JSON content result to be wrapped.
-    :param options: See :func:`~cloudant.query.Query.make_result` for a
-        list of valid query result customization options.
+    :param str bookmark: A string that enables you to specify which page of
+        results you require. Only valid for queries using indexes of type
+        *text*.
+    :param list fields: A list of fields to be returned by the query.
+    :param int page_size: Sets the page size for result iteration.  Default
+        is 100.
+    :param int r: Read quorum needed for the result.  Each document is read
+        from at least 'r' number of replicas before it is returned in the
+        results.
+    :param str selector: Dictionary object describing criteria used to
+        select documents.
+    :param list sort: A list of fields to sort by.  Optionally the list can
+        contain elements that are single member dictionary structures that
+        specify sort direction.  For example
+        ``sort=['name', {'age': 'desc'}]`` means to sort the query results
+        by the "name" field in ascending order and the "age" field in
+        descending order.
+    :param str use_index: Identifies a specific index for the query to run
+        against, rather than using the Cloudant Query algorithm which finds
+        what it believes to be the best index.
     """
     def __init__(self, query, **options):
         # Move skip/limit to options so super class Result can handle as needed.

--- a/src/cloudant/view.py
+++ b/src/cloudant/view.py
@@ -260,58 +260,6 @@ class View(dict):
         resp.raise_for_status()
         return resp.json()
 
-    def make_result(self, **options):
-        """
-        Wraps the raw JSON content of the View object callable in a
-        :class:`~cloudant.result.Result` object.  Depending on how you are
-        accessing, slicing or iterating through your result collection certain
-        query parameters are not permitted.  See
-        :class:`~cloudant.result.Result` for additional details.
-
-        Note:  Rather than using this method directly, if you wish to
-        retrieve view data as a Result object, use the provided database
-        API of :func:`~cloudant.database.CouchDatabase.get_view_result` instead.
-
-        :param bool descending: Return documents in descending key order.
-        :param endkey: Stop returning records at this specified key.
-            Not valid when used with :class:`~cloudant.result.Result` key
-            access and key slicing.
-        :param str endkey_docid: Stop returning records when the specified
-            document id is reached.
-        :param bool group: Using the reduce function, group the results to a
-            group or single row.
-        :param group_level: Only applicable if the view uses complex keys: keys
-            that are JSON arrays. Groups reduce results for the specified number
-            of array fields.
-        :param bool include_docs: Include the full content of the documents.
-        :param bool inclusive_end: Include rows with the specified endkey.
-        :param key: Return only documents that match the specified key.
-            Not valid when used with :class:`~cloudant.result.Result` key
-            access and key slicing.
-        :param list keys: Return only documents that match the specified keys.
-            Not valid when used with :class:`~cloudant.result.Result` key
-            access and key slicing.
-        :param int limit: Limit the number of returned documents to the
-            specified count.  Not valid when used with
-            :class:`~cloudant.result.Result` iteration.
-        :param int page_size: Sets the page size for result iteration.
-        :param bool reduce: True to use the reduce function, false otherwise.
-        :param int skip: Skip this number of rows from the start.
-            Not valid when used with :class:`~cloudant.result.Result` iteration.
-        :param str stale: Allow the results from a stale view to be used. This
-            makes the request return immediately, even if the view has not been
-            completely built yet. If this parameter is not given, a response is
-            returned only after the view has been built.
-        :param startkey: Return records starting with the specified key.
-            Not valid when used with :class:`~cloudant.result.Result` key
-            access and key slicing.
-        :param str startkey_docid: Return records starting with the specified
-            document ID.
-
-        :returns: View result data wrapped in a Result instance
-        """
-        return Result(self, **options)
-
     @contextlib.contextmanager
     def custom_result(self, **options):
         """
@@ -368,7 +316,7 @@ class View(dict):
 
         :returns: View result data wrapped in a Result instance
         """
-        rslt = self.make_result(**options)
+        rslt = Result(self, **options)
         yield rslt
         del rslt
 
@@ -451,17 +399,17 @@ class QueryIndexView(View):
             'use the database \'get_query_result\' convenience method.'
         )
 
-    def make_result(self, **options):
+    def custom_result(self, **options):
         """
         This method overrides the View base class
-        :func:`~cloudant.view.View.make_result` method with the sole purpose of
+        :func:`~cloudant.view.View.custom_result` method with the sole purpose of
         disabling it.  Since QueryIndexView objects are not callable, there is
         no reason to wrap their output in a Result.  If you wish to execute a
         query using a query index, use
         :func:`~cloudant.database.CloudantDatabase.get_query_result` instead.
         """
         raise CloudantException(
-            'Cannot make a result using a QueryIndexView.  If you wish to '
-            'execute a query use the database \'get_query_result\' convenience '
-            'method.'
+            'Cannot create a custom result context manager using a '
+            'QueryIndexView.  If you wish to execute a query use the '
+            'database \'get_query_result\' convenience method instead.'
         )

--- a/tests/unit/db/database_tests.py
+++ b/tests/unit/db/database_tests.py
@@ -277,7 +277,7 @@ class DatabaseTests(UnitTestDbBase):
         self.assertIsInstance(rslt, Result)
         self.assertEqual(rslt[:1], rslt['julia000'])
 
-        #Test with custom Result
+        # Test with custom Result
         rslt = self.db.get_view_result(
             '_design/ddoc01',
             'view01',

--- a/tests/unit/db/query_tests.py
+++ b/tests/unit/db/query_tests.py
@@ -168,25 +168,6 @@ class QueryTests(UnitTestDbBase):
             [{'_id': 'julia039'}, {'_id': 'julia038'}, {'_id': 'julia037'}]
         )
 
-    def test_make_result(self):
-        """
-        Test that make_result wraps the query response as a QueryResult
-        """
-        self.populate_db_with_documents(100)
-        query = Query(
-            self.db,
-            selector={'_id': {'$lt': 'julia050'}},
-            fields=['_id'],
-            sort=[{'_id': 'desc'}],
-            r=1
-        )
-        rslt = query.make_result()
-        self.assertIsInstance(rslt, QueryResult)
-        self.assertEqual(
-            rslt[10:13],
-            [{'_id': 'julia039'}, {'_id': 'julia038'}, {'_id': 'julia037'}]
-        )
-
     def test_custom_result_context_manager(self):
         """
         Test that custom_result yields a context manager and returns expected

--- a/tests/unit/db/view_tests.py
+++ b/tests/unit/db/view_tests.py
@@ -295,20 +295,6 @@ class ViewTests(UnitTestDbBase):
         except requests.HTTPError as err:
             self.assertEqual(err.response.status_code, 500)
 
-    def test_make_result(self):
-        """
-        Ensure that the view results are wrapped in a Result object
-        """
-        self.populate_db_with_documents()
-        ddoc = DesignDocument(self.db, 'ddoc001')
-        ddoc.add_view(
-            'view001',
-            'function (doc) {\n  emit(doc._id, 1);\n}'
-        )
-        ddoc.save()
-        view = ddoc.get_view('view001')
-        self.assertIsInstance(view.make_result(), Result)
-
     def test_custom_result_context_manager(self):
         """
         Test that the context manager for custom results returns
@@ -442,20 +428,6 @@ class QueryIndexViewTests(unittest.TestCase):
             'use the database \'get_query_result\' convenience method.'
         )
 
-    def test_make_result_disabled(self):
-        """
-        Test that the make_result method for QueryIndexView does not execute.
-        """
-        with self.assertRaises(CloudantException) as cm:
-            self.view.make_result()
-        err = cm.exception
-        self.assertEqual(
-            str(err),
-            'Cannot make a result using a QueryIndexView.  If you wish to '
-            'execute a query use the database \'get_query_result\' '
-            'convenience method.'
-        )
-
     def test_custom_result_disabled(self):
         """
         Test that the custom_result context manager for QueryIndexView does not
@@ -467,9 +439,9 @@ class QueryIndexViewTests(unittest.TestCase):
         err = cm.exception
         self.assertEqual(
             str(err),
-            'Cannot make a result using a QueryIndexView.  If you wish to '
-            'execute a query use the database \'get_query_result\' '
-            'convenience method.'
+            'Cannot create a custom result context manager using a '
+            'QueryIndexView.  If you wish to execute a query use the '
+            'database \'get_query_result\' convenience method instead.'
         )
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What

The make_result method in Query and View classes is redundant and confusing. It should be removed. A Result/QueryResult object can be stood up that essentially would perform the same functionality. Likewise the database convenience methods of get_view_results and get_query_results also perform the same functionality.

## How

In database.py module:
- change get_view_results to standup a new Result object passing it **kwargs.
- change get_query_results to standup a new QueryResult object passing it **kwargs.

In result.py module:
- Move parameter docs from make_result methods to Result/QueryResult class docstring.
- Remove references to make_result in comments.

In view.py module:
- Remove make_result.
- Refactor custom_result to use a new Result object passing it **kwargs.
- Add QueryIndexView.custom_result to override and disable the base method View.custom_result

In query.py module:
- Remove make_result.
- Refactor custom_result to use a new QueryResult object passing it **kwargs.

## Testing

No additional tests.
Removed make_result tests.

## Reviewers

reviewer @alfinkel 
reviewer @ricellis

## Issues

#46 