### PR TITLE
Add infinite feed implementation

### DIFF
--- a/src/cloudant/client.py
+++ b/src/cloudant/client.py
@@ -24,7 +24,7 @@ import requests
 
 from ._2to3 import bytes_, unicode_
 from .database import CloudantDatabase, CouchDatabase
-from .feed import Feed
+from .feed import Feed, InfiniteFeed
 from .error import CloudantException, CloudantArgumentError
 
 _USER_AGENT = 'python-cloudant/{0} (Python, Version {1}.{2}.{3})'.format(
@@ -214,21 +214,24 @@ class CouchDB(dict):
         """
         Returns the ``_db_updates`` feed iterator.  The ``_db_updates`` feed can
         be iterated over and once complete can also provide the last sequence
-        identifier of the feed.
+        identifier of the feed.  If necessary, the iteration can be stopped by
+        issuing a call to the ``stop()`` method on the returned iterator object.
 
         For example:
 
         .. code-block:: python
 
             # Iterate over a "normal" _db_updates feed
-            db_updates = db.db_updates()
+            db_updates = client.db_updates()
             for db_update in db_updates:
                 print(db_update)
             print(db_updates.last_seq)
 
             # Iterate over a "continuous" _db_updates feed with additional options
-            db_updates = db.db_updates(feed='continuous', since='now', descending=True)
+            db_updates = client.db_updates(feed='continuous', since='now', descending=True)
             for db_update in db_updates:
+                if some_condition:
+                    db_updates.stop()
                 print(db_update)
 
         :param bool raw_data: If set to True then the raw response data will be
@@ -238,7 +241,8 @@ class CouchDB(dict):
             descending order, i.e. the latest event first. By default, the
             oldest event is returned first.
         :param str feed: Type of feed.  Valid values are ``continuous``,
-            ``longpoll``, and ``normal``.  Default is ``normal``.
+            ``longpoll``, and ``normal``.  Default is ``normal`` for Cloudant
+            and ``longpoll`` for CouchDB.
         :param int heartbeat: Time in milliseconds after which an empty line is
             sent during ``longpoll`` or ``continuous`` if there have been no
             changes.  Must be a positive number.  Default is no heartbeat.
@@ -253,8 +257,11 @@ class CouchDB(dict):
         :param int timeout: Number of milliseconds to wait for data before
             terminating the response. ``heartbeat`` supersedes ``timeout`` if
             both are supplied.
+        :param int chunk_size: The HTTP response stream chunk size.  Defaults to
+            512.
 
-        :returns: Feed object that can be iterated over as a ``_changes`` feed.
+        :returns: Feed object that can be iterated over as a ``_db_updates``
+            feed.
         """
         db_updates_url = '/'.join([self.cloudant_url, '_db_updates'])
         return Feed(self.r_session, db_updates_url, raw_data, **kwargs)
@@ -412,6 +419,47 @@ class Cloudant(CouchDB):
 
         if self.cloudant_url is None:
             raise CloudantException('You must provide a url or an account.')
+
+    def infinite_db_updates(self, **kwargs):
+        """
+        Returns an infinite (perpetually refreshed) ``_db_updates`` feed
+        iterator.  If necessary, the iteration can be stopped by issuing a call
+        to the ``stop()`` method on the returned iterator object.
+
+        For example:
+
+        .. code-block:: python
+
+            # Iterate over an infinite _db_updates feed
+            db_updates = client.infinite_db_updates()
+            for db_update in db_updates:
+                if some_condition:
+                    db_updates.stop()
+                print(db_update)
+
+        :param bool descending: Whether results should be returned in
+            descending order, i.e. the latest event first. By default, the
+            oldest event is returned first.
+        :param int heartbeat: Time in milliseconds after which an empty line is
+            sent if there have been no changes.  Must be a positive number.
+            Default is no heartbeat.
+        :param since: Start the results from changes after the specified
+            sequence identifier. In other words, using since excludes from the
+            list all changes up to and including the specified sequence
+            identifier. If since is 0 (the default), or omitted, the request
+            returns all changes. If it is ``now``, only changes made after the
+            time of the request will be emitted.
+        :param int timeout: Number of milliseconds to wait for data before
+            terminating the response. ``heartbeat`` supersedes ``timeout`` if
+            both are supplied.
+        :param int chunk_size: The HTTP response stream chunk size.  Defaults to
+            512.
+
+        :returns: Feed object that can be iterated over as a ``_db_updates``
+            feed.
+        """
+        db_updates_url = '/'.join([self.cloudant_url, '_db_updates'])
+        return InfiniteFeed(self.r_session, db_updates_url, **kwargs)
 
     def _usage_endpoint(self, endpoint, year=None, month=None):
         """

--- a/tests/unit/db/infinite_feed_tests.py
+++ b/tests/unit/db/infinite_feed_tests.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+# Copyright (c) 2016 IBM. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+feed module - Unit tests for Feed class
+"""
+
+import unittest
+from requests import Session
+import json
+import os
+from time import sleep
+
+from cloudant.feed import InfiniteFeed, Feed
+from cloudant.error import CloudantArgumentError
+
+from .unit_t_db_base import UnitTestDbBase
+
+class InfiniteFeedTests(UnitTestDbBase):
+    """
+    Infinite Feed unit tests
+    """
+
+    def setUp(self):
+        """
+        Set up test attributes
+        """
+        super(InfiniteFeedTests, self).setUp()
+        self.db_set_up()
+        self.changes_url = '/'.join([self.db.database_url, '_changes'])
+        self.session = self.client.r_session
+
+    def tearDown(self):
+        """
+        Reset test attributes
+        """
+        self.db_tear_down()
+        super(InfiniteFeedTests, self).tearDown()
+
+    def test_constructor_no_feed_option(self):
+        """
+        Test constructing an infinite _changes feed when no feed option is set
+        """
+        feed = InfiniteFeed(self.session, self.changes_url, chunk_size=1,
+            timeout=100)
+        self.assertEqual(feed._url, self.changes_url)
+        self.assertIsInstance(feed._r_session, Session)
+        self.assertFalse(feed._raw_data)
+        self.assertDictEqual(feed._options, {'feed': 'continuous', 'timeout': 100})
+        self.assertEqual(feed._chunk_size, 1)
+
+    def test_constructor_with_feed_option(self):
+        """
+        Test constructing an infinite _changes feed when the continuous feed
+        option is set.
+        """
+        feed = InfiniteFeed(self.session, self.changes_url, chunk_size=1,
+            timeout=100, feed='continuous')
+        self.assertEqual(feed._url, self.changes_url)
+        self.assertIsInstance(feed._r_session, Session)
+        self.assertFalse(feed._raw_data)
+        self.assertDictEqual(feed._options, {'feed': 'continuous', 'timeout': 100})
+        self.assertEqual(feed._chunk_size, 1)
+
+    def test_constructor_with_invalid_feed_option(self):
+        """
+        Test constructing an infinite _changes feed when a feed option is set
+        to an invalid value raises an exception.
+        """
+        feed = InfiniteFeed(self.session, self.changes_url, feed='longpoll')
+        with self.assertRaises(CloudantArgumentError) as cm:
+            invalid_feed = [x for x in feed]
+        self.assertEqual(str(cm.exception), 
+            'Invalid infinite feed option: longpoll.  Must be set to continuous.')
+
+    def test_infinite_feed(self):
+        """
+        Test that an infinite feed will continue to issue multiple requests
+        until stopped.  This check is performed in combination by creating
+        documents 3 separate times and checking that the "_start" method on the
+        InfiniteFeed object was called 3 times as well.
+        """
+        
+        # Method proxy callable class
+        class MethodCallCount(object):
+            def __init__(self, meth_ref):
+                self._ref = meth_ref
+                self.called_count = 0
+
+            def __call__(self):
+                self.called_count += 1
+                self._ref()
+
+        self.populate_db_with_documents()
+        feed = InfiniteFeed(self.session, self.changes_url, timeout=100)
+
+        # Create a proxy for the feed._start method so that we can track how
+        # many times it has been called.
+        feed._start = MethodCallCount(feed._start)
+
+        changes = list()
+        for change in feed:
+            self.assertSetEqual(set(change.keys()), set(['seq', 'changes', 'id']))
+            changes.append(change)
+            if len(changes) in (100, 200):
+                sleep(1) # 1 second > .1 second (timeout)
+                self.populate_db_with_documents(off_set=len(changes))
+            elif len(changes) == 300:
+                feed.stop()
+        expected = set(['julia{0:03d}'.format(i) for i in range(300)])
+        self.assertSetEqual(set([x['id'] for x in changes]), expected)
+        self.assertIsNone(feed.last_seq)
+        # Compare infinite/continuous with normal
+        normal = Feed(self.session, self.changes_url)
+        self.assertSetEqual(
+            set([x['id'] for x in changes]), set([n['id'] for n in normal]))
+
+        # Ensuring that the feed._start method was called 3 times, verifies that
+        # the continuous feed was started/restarted 3 separate times.
+        self.assertEqual(feed._start.called_count, 3)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What:

Added the ability for a feed (_changes or _db_updates) to return an infinite iterator.

## How:

Anytime a last sequence identifier is encountered for a `continuous` feed another HTTP request stream is made to the server thus creating a perpetually refreshed feed.  This was done by extending the Feed class as an InfiniteFeed class.  The InfiniteFeed has added logic in the `next()` method call to check for a last sequence identifier and if found to re-issue the HTTP request with a new `since` option set to the last sequence identifier.

The InfiniteFeed implementation is only valid for CouchDatabase and CloudantDatabase _changes feeds and the Cloudant _db_updates feed only.  The CouchDB _db_updates feed does not return a last sequence identifier and does not accept `since` as an option so the client db_updates method was placed on the child Cloudant class instead of the parent CouchDB class.  In other words the _db_updates InfiniteFeed implementation is not supported for CouchDB.

## Testing:

- Added an infinite_feed_tests.py module.  These tests test the actual InfiniteFeed functionality.
- Updated client_tests.py module.  These tests specifically verify that an InfiniteFeed object is constructed and that the necessary settings are in place in the object.
- Updated database_tests.py module.  These tests specifically verify that an InfiniteFeed object is constructed and that the necessary settings are in place in the object.

## Reviewers:

reviewer: @brynh 
reviewer: @ricellis


## Issues:

- #146 