### PR TITLE
Rename cloudant attribute references in couchdb classes

### DIFF
--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -48,8 +48,8 @@ class CouchDatabase(dict):
     """
     def __init__(self, client, database_name, fetch_limit=100):
         super(CouchDatabase, self).__init__()
-        self.cloudant_account = client
-        self._database_host = client.cloudant_url
+        self.client = client
+        self._database_host = client.server_url
         self.database_name = database_name
         self.r_session = client.r_session
         self._fetch_limit = fetch_limit
@@ -63,7 +63,7 @@ class CouchDatabase(dict):
 
         :returns: CouchDB Admin Party mode status
         """
-        return self.cloudant_account.admin_party
+        return self.client.admin_party
 
     @property
     def database_url(self):
@@ -88,8 +88,8 @@ class CouchDatabase(dict):
         if self.admin_party:
             return None
         return {
-            "basic_auth": self.cloudant_account.basic_auth_str(),
-            "user_ctx": self.cloudant_account.session()['userCtx']
+            "basic_auth": self.client.basic_auth_str(),
+            "user_ctx": self.client.session()['userCtx']
         }
 
     def exists(self):

--- a/src/cloudant/document.py
+++ b/src/cloudant/document.py
@@ -57,15 +57,15 @@ class Document(dict):
     """
     def __init__(self, database, document_id=None):
         super(Document, self).__init__()
-        self._cloudant_account = database.cloudant_account
-        self._cloudant_database = database
-        self._database_host = self._cloudant_account.cloudant_url
+        self._client = database.client
+        self._database = database
+        self._database_host = self._client.server_url
         self._database_name = database.database_name
         self.r_session = database.r_session
         self._document_id = document_id
         if self._document_id is not None:
             self['_id'] = self._document_id
-        self._encoder = self._cloudant_account.encoder
+        self._encoder = self._client.encoder
 
     @property
     def document_url(self):
@@ -131,7 +131,7 @@ class Document(dict):
 
         headers = {'Content-Type': 'application/json'}
         resp = self.r_session.post(
-            self._cloudant_database.database_url,
+            self._database.database_url,
             headers=headers,
             data=json.dumps(doc, cls=self._encoder)
         )

--- a/src/cloudant/feed.py
+++ b/src/cloudant/feed.py
@@ -70,13 +70,13 @@ class Feed(object):
         self._options = options
         self._source = source.__class__.__name__
         if self._source == 'CouchDB':
-            self._url = '/'.join([source.cloudant_url, '_db_updates'])
+            self._url = '/'.join([source.server_url, '_db_updates'])
             # Set CouchDB _db_updates option defaults as they differ from
             # the _changes and Cloudant _db_updates option defaults
             self._options['feed'] = self._options.get('feed', 'longpoll')
             self._options['heartbeat'] = self._options.get('heartbeat', True)
         elif self._source == 'Cloudant':
-            self._url = '/'.join([source.cloudant_url, '_db_updates'])
+            self._url = '/'.join([source.server_url, '_db_updates'])
         else:
             self._url = '/'.join([source.database_url, '_changes'])
         self._chunk_size = self._options.pop('chunk_size', 512)

--- a/src/cloudant/query.py
+++ b/src/cloudant/query.py
@@ -103,7 +103,7 @@ class Query(dict):
         super(Query, self).__init__()
         self._database = database
         self._r_session = self._database.r_session
-        self._encoder = self._database.cloudant_account.encoder
+        self._encoder = self._database.client.encoder
         if kwargs:
             super(Query, self).update(kwargs)
         self.result = QueryResult(self)

--- a/tests/unit/client_tests.py
+++ b/tests/unit/client_tests.py
@@ -78,7 +78,7 @@ class ClientTests(UnitTestDbBase):
         Test instantiating a client object using a URL
         """
         self.assertEqual(
-            self.client.cloudant_url,
+            self.client.server_url,
             self.url
             )
         self.assertEqual(self.client.encoder, json.JSONEncoder)
@@ -384,7 +384,7 @@ class ClientTests(UnitTestDbBase):
             db_updates = self.client.db_updates(limit=100)
             self.assertIs(type(db_updates), Feed)
             self.assertEqual(
-                db_updates._url, '/'.join([self.client.cloudant_url, '_db_updates']))
+                db_updates._url, '/'.join([self.client.server_url, '_db_updates']))
             self.assertIsInstance(db_updates._r_session, requests.Session)
             self.assertFalse(db_updates._raw_data)
             self.assertEqual(db_updates._options.get('limit'), 100)
@@ -420,7 +420,7 @@ class CloudantClientTests(UnitTestDbBase):
         del self.client
         self.client = Cloudant(self.user, self.pwd, account=self.account)
         self.assertEqual(
-            self.client.cloudant_url,
+            self.client.server_url,
             'https://{0}.cloudant.com'.format(self.account)
             )
 
@@ -449,7 +449,7 @@ class CloudantClientTests(UnitTestDbBase):
             db_updates = self.client.infinite_db_updates()
             self.assertIsInstance(db_updates, InfiniteFeed)
             self.assertEqual(
-                db_updates._url, '/'.join([self.client.cloudant_url, '_db_updates']))
+                db_updates._url, '/'.join([self.client.server_url, '_db_updates']))
             self.assertIsInstance(db_updates._r_session, requests.Session)
             self.assertFalse(db_updates._raw_data)
             self.assertDictEqual(db_updates._options, {'feed': 'continuous'})

--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -61,7 +61,7 @@ class DatabaseTests(UnitTestDbBase):
         """
         Test instantiating a database
         """
-        self.assertEqual(self.db.cloudant_account, self.client)
+        self.assertEqual(self.db.client, self.client)
         self.assertEqual(self.db.database_name, self.test_dbname)
         self.assertEqual(self.db.r_session, self.client.r_session)
         self.assertIsInstance(self.db.result, Result)
@@ -72,7 +72,7 @@ class DatabaseTests(UnitTestDbBase):
         """
         self.assertEqual(
             self.db.database_url,
-            posixpath.join(self.client.cloudant_url, self.test_dbname)
+            posixpath.join(self.client.server_url, self.test_dbname)
             )
 
     def test_retrieve_creds(self):
@@ -136,7 +136,7 @@ class DatabaseTests(UnitTestDbBase):
         same.  Therefore comparing keys is a valid test of this functionality.
         """
         resp = self.db.r_session.get(
-            posixpath.join(self.client.cloudant_url, self.test_dbname)
+            posixpath.join(self.client.server_url, self.test_dbname)
             )
         expected = resp.json()
         actual = self.db.metadata()

--- a/tests/unit/db_updates_tests.py
+++ b/tests/unit/db_updates_tests.py
@@ -66,7 +66,7 @@ class CouchDbUpdatesTests(DbUpdatesTestsBase):
         """
         feed = Feed(self.client, feed='continuous', heartbeat=False, timeout=2)
         self.assertEqual(feed._url,
-            '/'.join([self.client.cloudant_url, '_db_updates']))
+            '/'.join([self.client.server_url, '_db_updates']))
         self.assertIsInstance(feed._r_session, Session)
         self.assertFalse(feed._raw_data)
         self.assertDictEqual(feed._options,
@@ -225,7 +225,7 @@ class CloudantDbUpdatesTests(DbUpdatesTestsBase):
         """
         feed = Feed(self.client, feed='continuous', heartbeat=5000)
         self.assertEqual(feed._url,
-            '/'.join([self.client.cloudant_url, '_db_updates']))
+            '/'.join([self.client.server_url, '_db_updates']))
         self.assertIsInstance(feed._r_session, Session)
         self.assertFalse(feed._raw_data)
         self.assertDictEqual(feed._options,

--- a/tests/unit/infinite_feed_tests.py
+++ b/tests/unit/infinite_feed_tests.py
@@ -113,7 +113,7 @@ class InfiniteFeedTests(UnitTestDbBase):
         Test constructing an infinite _db_updates feed.
         """
         feed = InfiniteFeed(self.client, chunk_size=1, timeout=100, feed='continuous')
-        self.assertEqual(feed._url, '/'.join([self.client.cloudant_url, '_db_updates']))
+        self.assertEqual(feed._url, '/'.join([self.client.server_url, '_db_updates']))
         self.assertIsInstance(feed._r_session, Session)
         self.assertFalse(feed._raw_data)
         self.assertDictEqual(feed._options, {'feed': 'continuous', 'timeout': 100})


### PR DESCRIPTION
## What:

A number of the CouchDB specific classes have public and private attributes with "cloudant" as part of their name.  This PR removes "cloudant" references from those attributes to make things clearer from a useability and maintenance point of view.

## How:

- Rename client module CouchDB class attributes referencing Cloudant
- Rename database module CouchDatabase class attributes referencing Cloudant
- Rename document module Document class attributes referencing Cloudant
- Rename feed module Feed/InfiniteFeed class attributes referencing Cloudant
- Rename query module Query class attributes referencing Cloudant

## Testing:

- Rename cloudant references in tests as needed based on above.

## Reviewers:

reviewer: @rhyshort 
reviewer: @brynh 

## Issues

- #58 