### PR TITLE
60008 429 backoff

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,6 @@
 2.0.0 (Unreleased)
 ==================
+- [NEW] Handle HTTP status code ``429 Too Many Requests`` with blocking backoff and retries.
 - [BREAKING] Replace "session" and "url" feed constructor arguments with "source" which can be either a client or a database object.  Changes also made to the client ``db_updates`` method signature and the database ``changes`` method signature.
 - [IMPORVED] Added feed functionality to process ``_changes`` and ``_db_updates`` with their supported options.  Also added an infinite feed option.
 - [BREAKING] Removed the make_result method from View and Query classes.  If you need to make a query or view result, use ``CloudantDatabase.get_query_result``, ``CouchDatabase.get_view_result``, or the ``View.custom_result`` context manager.  Additionally, the ``Result`` and ``QueryResult`` classes can be called directly to construct a result object.

--- a/src/cloudant/client.py
+++ b/src/cloudant/client.py
@@ -22,6 +22,8 @@ import posixpath
 import sys
 import requests
 
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util import Retry
 from ._2to3 import bytes_, unicode_
 from .database import CloudantDatabase, CouchDatabase
 from .feed import Feed, InfiniteFeed
@@ -70,6 +72,21 @@ class CouchDB(dict):
         authentication.
         """
         self.r_session = requests.Session()
+        # Configure a Transport Adapter for custom retry behaviour
+        self.r_session.mount(self.server_url, HTTPAdapter(
+            max_retries=Retry(
+                # Allow 10 retries for status
+                total=10,
+                # No retries for connect|read errors
+                connect=0,
+                read=0,
+                # Allow retries for all the CouchDB HTTP method types
+                method_whitelist=frozenset(['GET', 'HEAD', 'PUT', 'POST',
+                                            'DELETE', 'COPY']),
+                # Only retry for a 429 too many requests status code
+                status_forcelist=[429],
+                # Configure the doubling backoff to start at 0.25 s
+                backoff_factor=0.25)))
         if self._client_user_header is not None:
             self.r_session.headers.update(self._client_user_header)
         if not self.admin_party:


### PR DESCRIPTION
## What

Added backoff/retry for 429 status codes.

## How

Use the request library's built in `HTTPAdapter`to provide retry configuration to the underlying urllib3 library. Configure for 10 retries starting at a 250 ms backoff for all CouchDB HTTP methods. Use 0 retries for connection and read so these retries apply only to the `status_forcelist` which includes only the 429 status code, so no other retry behaviour is affected by the change.

## Testing

No new tests, provides configuration to underlying library. Existing tests would fail if configuration syntax was wrong. Testing the actual retry function would require adding a mock server. The pattern in python-cloudant has been to avoid testing underlying library code in this way. I have manually verified that the retry functions. 

## Reviewers

reviewer: @alfinkel
reviewer: @emlaver

## Issues
Internal case 60008
