### PR TITLE
Update user agent format

### DIFF
--- a/src/cloudant/client.py
+++ b/src/cloudant/client.py
@@ -20,6 +20,7 @@ import base64
 import json
 import posixpath
 import sys
+import os
 import requests
 
 from ._2to3 import bytes_, unicode_
@@ -27,11 +28,15 @@ from .database import CloudantDatabase, CouchDatabase
 from .feed import Feed, InfiniteFeed
 from .error import CloudantException, CloudantArgumentError
 
-_USER_AGENT = 'python-cloudant/{0} (Python, Version {1}.{2}.{3})'.format(
+_USER_AGENT = '/'.join([
+    'python-cloudant',
     sys.modules['cloudant'].__version__,
-    sys.version_info[0],
-    sys.version_info[1],
-    sys.version_info[2])
+    'Python',
+    '{0}.{1}.{2}'.format(
+        sys.version_info[0], sys.version_info[1], sys.version_info[2]),
+    os.uname()[0],
+    os.uname()[4]
+])
 
 class CouchDB(dict):
     """

--- a/tests/unit/client_tests.py
+++ b/tests/unit/client_tests.py
@@ -24,6 +24,7 @@ import unittest
 import requests
 import json
 import base64
+import sys
 import os
 from datetime import datetime
 
@@ -435,7 +436,15 @@ class CloudantClientTests(UnitTestDbBase):
                 self.account
                 )
             agent = self.client.r_session.headers.get('User-Agent')
-            self.assertTrue(agent.startswith('python-cloudant'))
+            ua_parts = agent.split('/')
+            self.assertEqual(len(ua_parts), 6)
+            self.assertEqual(ua_parts[0], 'python-cloudant')
+            self.assertEqual(ua_parts[1], sys.modules['cloudant'].__version__)
+            self.assertEqual(ua_parts[2], 'Python')
+            self.assertEqual(ua_parts[3], '{0}.{1}.{2}'.format(
+                sys.version_info[0], sys.version_info[1], sys.version_info[2])),
+            self.assertEqual(ua_parts[4], os.uname()[0]),
+            self.assertEqual(ua_parts[5], os.uname()[4])
         finally:
             self.client.disconnect()
 


### PR DESCRIPTION
## What:

Update User-Agent format to be `python-cloudant/<library version>/Python/<Python version>/<OS name>/<OS architecture>`.

So an example User-Agent will look like `python-cloudant/2.0.0/Python/2.7.10/Darwin/x86_64`.

## How:

- Update the _USER_AGENT setting in the client.py

## Testing:

- Update the client test that tests the connection specifics to include checks for the User-Agent string components.

## Reviewers:

reviewer: @ricellis 
reviewer: @emlaver 

## Issues:

- #150 
