### PR TITLE
Remove usage of os.uname since it is unavaiable on windows.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,6 @@
-2.1.0 (Unreleased)
+2.0.1 (Unreleased)
 ==================
-
+- [FIX] Fixed issue with Windows platform compatibility,replaced usage of os.uname for the user-agent string.
 
 2.0.0 (2016-05-02)
 ==================

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -18,7 +18,7 @@ throughout the library.
 """
 
 import sys
-import os
+import platform
 from collections import Sequence
 import json
 
@@ -33,8 +33,8 @@ USER_AGENT = '/'.join([
     'Python',
     '{0}.{1}.{2}'.format(
         sys.version_info[0], sys.version_info[1], sys.version_info[2]),
-    os.uname()[0],
-    os.uname()[4]
+    platform.system(),
+    platform.machine()
 ])
 
 QUERY_LANGUAGE = 'query'


### PR DESCRIPTION
## What

Fixed compatibility issue with windows.

## How

Removed usage of `os.uname` for the user-agent string.

## Testing

No new tests, running on Windows is enough to confirm fix.

## Reviewers
reviewer @ricellis

## Issues

Fixes #163