### PR TITLE
CloudantDesignDocument class for managing query indexes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,6 @@
 2.0.1 (Unreleased)
 ==================
 - [FIX] Fixed issue with Windows platform compatibility,replaced usage of os.uname for the user-agent string.
-- [BREAKING] Moved existing query index management into new Cloudant-based design document class.
 
 2.0.0 (2016-05-02)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 2.0.1 (Unreleased)
 ==================
 - [FIX] Fixed issue with Windows platform compatibility,replaced usage of os.uname for the user-agent string.
+- [BREAKING] Moved existing query index management into new Cloudant-based design document class.
 
 2.0.0 (2016-05-02)
 ==================

--- a/src/cloudant/design_document.py
+++ b/src/cloudant/design_document.py
@@ -27,7 +27,7 @@ class DesignDocument(Document):
     :class:`~cloudant.document.Document`.  A DesignDocument object is
     instantiated with a reference to a database and
     provides an API to view management, list and show
-    functions, search indexes, etc.  When instantiating a DesignDocument or
+    functions, etc.  When instantiating a DesignDocument or
     when setting the document id (``_id``) field, the value must start with
     ``_design/``.  If it does not, then ``_design/`` will be prepended to
     the provided document id value.
@@ -59,10 +59,7 @@ class DesignDocument(Document):
     def add_view(self, view_name, map_func, reduce_func=None, **kwargs):
         """
         Appends a MapReduce view to the locally cached DesignDocument View
-        dictionary.  To create a JSON query index use
-        :func:`~cloudant.database.CloudantDatabase.create_query_index` instead.
-        A CloudantException is raised if an attempt to add a QueryIndexView
-        (JSON query index) using this method is made.
+        dictionary.
 
         :param str view_name: Name used to identify the View.
         :param str map_func: Javascript map function.
@@ -71,10 +68,6 @@ class DesignDocument(Document):
         if self.get_view(view_name) is not None:
             msg = "View {0} already exists in this design doc".format(view_name)
             raise CloudantArgumentError(msg)
-        if self.get('language', None) == QUERY_LANGUAGE:
-            msg = ('Cannot add a MapReduce view to a '
-                   'design document for query indexes.')
-            raise CloudantException(msg)
 
         view = View(self, view_name, map_func, reduce_func, **kwargs)
         self.views.__setitem__(view_name, view)
@@ -82,12 +75,7 @@ class DesignDocument(Document):
     def update_view(self, view_name, map_func, reduce_func=None, **kwargs):
         """
         Modifies/overwrites an existing MapReduce view definition in the
-        locally cached DesignDocument View dictionary.  To update a JSON
-        query index use
-        :func:`~cloudant.database.CloudantDatabase.delete_query_index` followed
-        by :func:`~cloudant.database.CloudantDatabase.create_query_index`
-        instead.  A CloudantException is raised if an attempt to update a
-        QueryIndexView (JSON query index) using this method is made.
+        locally cached DesignDocument View dictionary.
 
         :param str view_name: Name used to identify the View.
         :param str map_func: Javascript map function.
@@ -97,9 +85,6 @@ class DesignDocument(Document):
         if view is None:
             msg = "View {0} does not exist in this design doc".format(view_name)
             raise CloudantArgumentError(msg)
-        if isinstance(view, QueryIndexView):
-            msg = 'Cannot update a query index view using this method.'
-            raise CloudantException(msg)
 
         view = View(self, view_name, map_func, reduce_func, **kwargs)
         self.views.__setitem__(view_name, view)
@@ -107,27 +92,21 @@ class DesignDocument(Document):
     def delete_view(self, view_name):
         """
         Removes an existing MapReduce view definition from the locally cached
-        DesignDocument View dictionary.  To delete a JSON query index
-        use :func:`~cloudant.database.CloudantDatabase.delete_query_index`
-        instead.  A CloudantException is raised if an attempt to delete a
-        QueryIndexView (JSON query index) using this method is made.
+        DesignDocument View dictionary.
 
         :param str view_name: Name used to identify the View.
         """
         view = self.get_view(view_name)
         if view is None:
             return
-        if isinstance(view, QueryIndexView):
-            msg = 'Cannot delete a query index view using this method.'
-            raise CloudantException(msg)
 
         self.views.__delitem__(view_name)
 
     def fetch(self):
         """
         Retrieves the remote design document content and populates the locally
-        cached DesignDocument dictionary.  View content is stored either as
-        View or QueryIndexView objects which are extensions of the ``dict``
+        cached DesignDocument dictionary.  View content is stored as
+        a View object which is an extension of the ``dict``
         type.  All other design document data are stored directly as
         ``dict`` types.
         """
@@ -139,14 +118,6 @@ class DesignDocument(Document):
             for view_name, view_def in iteritems_(self.get('views', dict())):
                 if self.get('language', None) != QUERY_LANGUAGE:
                     self['views'][view_name] = View(
-                        self,
-                        view_name,
-                        view_def.pop('map', None),
-                        view_def.pop('reduce', None),
-                        **view_def
-                    )
-                else:
-                    self['views'][view_name] = QueryIndexView(
                         self,
                         view_name,
                         view_def.pop('map', None),
@@ -168,13 +139,6 @@ class DesignDocument(Document):
                 for view_name, view in self.iterviews():
                     if isinstance(view, QueryIndexView):
                         msg = 'View {0} must be of type View.'.format(view_name)
-                        raise CloudantException(msg)
-            else:
-                for view_name, view in self.iterviews():
-                    if not isinstance(view, QueryIndexView):
-                        msg = (
-                            'View {0} must be of type QueryIndexView.'
-                        ).format(view_name)
                         raise CloudantException(msg)
         else:
             # Ensure empty views dict is not saved remotely.
@@ -243,3 +207,128 @@ class DesignDocument(Document):
         GET databasename/_design/{ddoc}/_info
         """
         raise NotImplementedError("_info not yet implemented")
+
+class CloudantDesignDocument(DesignDocument):
+    """
+    Encapsulates a Cloudant version of a
+    :class:`~cloudant.design_document.DesignDocument`.
+    A CloudantDesignDocument object is instantiated with a reference
+    to a Cloudant database and provides an API to query index management,
+    list and show functions, etc.
+
+    Note:  Currently only the query view management API exists.  Remaining
+    Cloudant design document functionality will be added later.
+
+    :param database: A ``CloudantDatabase`` instance used by the
+        CloudantDesignDocument.
+    :param str document_id: Optional document id.  If provided and does not
+        start with ``_design/``, it will be prepended with ``_design/``.
+    """
+    def __init__(self, database, document_id=None):
+        super(CloudantDesignDocument, self).__init__(database, document_id)
+
+    def add_view(self, view_name, map_func, reduce_func=None, **kwargs):
+        """
+        Appends a MapReduce view to the locally cached CloudantDesignDocument
+        View dictionary. A CloudantException is raised if an attempt to add a
+        QueryIndexView (JSON query index) using this method is made.
+
+        :param str view_name: Name used to identify the View.
+        :param str map_func: Javascript map function.
+        :param str reduce_func: Optional Javascript reduce function.
+        """
+        if self.get('language', None) == QUERY_LANGUAGE:
+            msg = ('Cannot add a MapReduce view to a '
+                   'design document for query indexes.')
+            raise CloudantException(msg)
+
+        super(CloudantDesignDocument, self).add_view(view_name, map_func,
+                                                     reduce_func, **kwargs)
+
+    def update_view(self, view_name, map_func, reduce_func=None, **kwargs):
+        """
+        Modifies/overwrites an existing MapReduce view definition in the
+        locally cached CloudantDesignDocument View dictionary.
+        To update a JSON query index use
+        :func:`~cloudant.database.CloudantDatabase.delete_query_index` followed
+        by :func:`~cloudant.database.CloudantDatabase.create_query_index`
+        instead.  A CloudantException is raised if an attempt to update a
+        QueryIndexView (JSON query index) using this method is made.
+
+        :param str view_name: Name used to identify the View.
+        :param str map_func: Javascript map function.
+        :param str reduce_func: Optional Javascript reduce function.
+        """
+        view = self.get_view(view_name)
+        if isinstance(view, QueryIndexView):
+            msg = 'Cannot update a query index view using this method.'
+            raise CloudantException(msg)
+
+        super(CloudantDesignDocument, self).update_view(view_name, map_func,
+                                                        reduce_func, **kwargs)
+
+    def delete_view(self, view_name):
+        """
+        Removes an existing MapReduce view definition from the locally cached
+        CloudantDesignDocument View dictionary.  To delete a JSON query index
+        use :func:`~cloudant.database.CloudantDatabase.delete_query_index`
+        instead.  A CloudantException is raised if an attempt to delete a
+        QueryIndexView (JSON query index) using this method is made.
+
+        :param str view_name: Name used to identify the View.
+        """
+        view = self.get_view(view_name)
+        if isinstance(view, QueryIndexView):
+            msg = 'Cannot delete a query index view using this method.'
+            raise CloudantException(msg)
+
+        super(CloudantDesignDocument, self).delete_view(view_name)
+
+    def fetch(self):
+        """
+        Retrieves the remote design document content and populates the locally
+        cached CloudantDesignDocument dictionary.  View content is stored either
+        as View or QueryIndexView objects which are extensions of the ``dict``
+        type.  All other design document data are stored directly as
+        ``dict`` types.
+        """
+        super(CloudantDesignDocument, self).fetch()
+
+        if self.views:
+            for view_name, view_def in iteritems_(self.get('views', dict())):
+                if self.get('language', None) == QUERY_LANGUAGE:
+                    self['views'][view_name] = QueryIndexView(
+                        self,
+                        view_name,
+                        view_def.pop('map', None),
+                        view_def.pop('reduce', None),
+                        **view_def
+                    )
+
+    def save(self):
+        """
+        Saves changes made to the locally cached CloudantDesignDocument object's
+        data structures to the remote database.  If the design document does not
+        exist remotely then it is created in the remote database.  If the object
+        does exist remotely then the design document is updated remotely.  In
+        either case the locally cached CloudantDesignDocument object is also
+        updated accordingly based on the successful response of the operation.
+        """
+        if self.views:
+            for view_name, view in self.iterviews():
+                if not isinstance(view, QueryIndexView):
+                    msg = (
+                        'View {0} must be of type QueryIndexView.'
+                    ).format(view_name)
+                    raise CloudantException(msg)
+
+        super(CloudantDesignDocument, self).save()
+
+    def info(self):
+        """
+        Retrieves the Cloudant design document view information data,
+        returns dictionary
+
+        GET databasename/_design/{ddoc}/_info
+        """
+        super(CloudantDesignDocument, self).info()

--- a/tests/unit/design_document_tests.py
+++ b/tests/unit/design_document_tests.py
@@ -21,11 +21,11 @@ See configuration options for environment variables in unit_t_db_base
 module docstring.
 
 """
-
+import os
 import unittest
 
-from cloudant.document import Document 
-from cloudant.design_document import DesignDocument
+from cloudant.document import Document
+from cloudant.design_document import DesignDocument, CloudantDesignDocument
 from cloudant.view import View, QueryIndexView
 from cloudant.error import CloudantArgumentError, CloudantException
 
@@ -164,21 +164,6 @@ class DesignDocumentTests(UnitTestDbBase):
                 'View view001 already exists in this design doc'
             )
 
-    def test_adding_query_index_view(self):
-        """
-        Test that adding a query index view fails as expected.
-        """
-        ddoc = DesignDocument(self.db, '_design/ddoc001')
-        ddoc['language'] = 'query'
-        with self.assertRaises(CloudantException) as cm:
-            ddoc.add_view('view001', {'foo': 'bar'})
-        err = cm.exception
-        self.assertEqual(
-            str(err),
-            'Cannot add a MapReduce view to a '
-            'design document for query indexes.'
-        )
-
     def test_update_a_view(self):
         """
         Test that updating a view updates the contents of the correct
@@ -216,37 +201,6 @@ class DesignDocumentTests(UnitTestDbBase):
                 'View view001 does not exist in this design doc'
             )
 
-    def test_update_query_index_view(self):
-        """
-        Test that updating a query index view fails as expected.
-        """
-        # This is not the preferred way of dealing with query index
-        # views but it works best for this test.
-        data = {
-            '_id': '_design/ddoc001',
-            'language': 'query',
-            'views': {
-                'view001': {'map': {'fields': {'name': 'asc', 'age': 'asc'}},
-                            'reduce': '_count',
-                            'options': {'def': {'fields': ['name', 'age']},
-                                        'w': 2}
-                            }
-                    }
-        }
-        self.db.create_document(data)
-        ddoc = DesignDocument(self.db, '_design/ddoc001')
-        ddoc.fetch()
-        with self.assertRaises(CloudantException) as cm:
-            ddoc.update_view(
-                'view001',
-                'function (doc) {\n  emit(doc._id, 1);\n}'
-            )
-        err = cm.exception
-        self.assertEqual(
-            str(err),
-            'Cannot update a query index view using this method.'
-        )
-
     def test_delete_a_view(self):
         """
         Test deleting a view from the DesignDocument dictionary.
@@ -259,34 +213,6 @@ class DesignDocumentTests(UnitTestDbBase):
         )
         ddoc.delete_view('view001')
         self.assertEqual(ddoc.get('views'), {})
-
-    def test_delete_a_query_index_view(self):
-        """
-        Test deleting a query index view fails as expected.
-        """
-        # This is not the preferred way of dealing with query index
-        # views but it works best for this test.
-        data = {
-            '_id': '_design/ddoc001',
-            'language': 'query',
-            'views': {
-                'view001': {'map': {'fields': {'name': 'asc', 'age': 'asc'}},
-                            'reduce': '_count',
-                            'options': {'def': {'fields': ['name', 'age']},
-                                        'w': 2}
-                            }
-                    }
-        }
-        self.db.create_document(data)
-        ddoc = DesignDocument(self.db, '_design/ddoc001')
-        ddoc.fetch()
-        with self.assertRaises(CloudantException) as cm:
-            ddoc.delete_view('view001')
-        err = cm.exception
-        self.assertEqual(
-            str(err),
-            'Cannot delete a query index view using this method.'
-        )
 
     def test_fetch_map_reduce(self):
         """
@@ -336,124 +262,6 @@ class DesignDocumentTests(UnitTestDbBase):
         self.assertEqual(ddoc_remote['_rev'], ddoc['_rev'])
         self.assertEqual(ddoc_remote.views, {})
 
-    def test_fetch_query_views(self):
-        """
-        Ensure that the document fetch from the database returns the
-        DesignDocument format as expected when retrieving a design document
-        containing query index views.
-        """
-        # This is not the preferred way of dealing with query index
-        # views but it works best for this test.
-        data = {
-            '_id': '_design/ddoc001',
-            'language': 'query',
-            'views': {
-                'view001': {'map': {'fields': {'name': 'asc', 'age': 'asc'}},
-                            'reduce': '_count',
-                            'options': {'def': {'fields': ['name', 'age']},
-                                        'w': 2}
-                            }
-                    }
-        }
-        doc = self.db.create_document(data)
-        self.assertIsInstance(doc, Document)
-        data['_rev'] = doc['_rev']
-        ddoc = DesignDocument(self.db, '_design/ddoc001')
-        ddoc.fetch()
-        self.assertIsInstance(ddoc, DesignDocument)
-        self.assertEqual(ddoc, data)
-        self.assertIsInstance(ddoc['views']['view001'], QueryIndexView)
-
-    def test_fetch_text_indexes(self):
-        """
-        Ensure that the document fetch from the database returns the
-        DesignDocument format as expected when retrieving a design document
-        containing query index views.
-        """
-        # This is not the preferred way of dealing with query index
-        # views but it works best for this test.
-        data = {
-            '_id': '_design/ddoc001',
-            'language': 'query',
-            'indexes': {'index001': 
-                     {'index': {'index_array_lengths': True,
-                                'fields': [{'name': 'name', 'type': 'string'},
-                                           {'name': 'age', 'type': 'number'}],
-                                'default_field': {'enabled': True,
-                                                  'analyzer': 'german'},
-                                'default_analyzer': 'keyword',
-                                'selector': {}},
-                      'analyzer': {'name': 'perfield',
-                                   'default': 'keyword',
-                                   'fields': {'$default': 'german'}}}}}
-        doc = self.db.create_document(data)
-        self.assertIsInstance(doc, Document)
-        ddoc = DesignDocument(self.db, '_design/ddoc001')
-        ddoc.fetch()
-        self.assertIsInstance(ddoc, DesignDocument)
-        data['_rev'] = doc['_rev']
-        data['views'] = dict()
-        self.assertEqual(ddoc, data)
-        self.assertIsInstance(ddoc['indexes']['index001'], dict)
-
-    def test_fetch_text_indexes_and_query_views(self):
-        """
-        Ensure that the document fetch from the database returns the
-        DesignDocument format as expected when retrieving a design document
-        containing query index views and text index definitions.
-        """
-        # This is not the preferred way of dealing with query index
-        # views but it works best for this test.
-        data = {
-            '_id': '_design/ddoc001',
-            'language': 'query',
-            'views': {
-                'view001': {'map': {'fields': {'name': 'asc', 'age': 'asc'}},
-                            'reduce': '_count',
-                            'options': {'def': {'fields': ['name', 'age']},
-                                        'w': 2}
-                            }
-                    },
-            'indexes': {'index001': {
-                'index': {'index_array_lengths': True,
-                          'fields': [{'name': 'name', 'type': 'string'},
-                                     {'name': 'age', 'type': 'number'}],
-                          'default_field': {'enabled': True,
-                                            'analyzer': 'german'},
-                          'default_analyzer': 'keyword',
-                          'selector': {}},
-                'analyzer': {'name': 'perfield',
-                             'default': 'keyword',
-                             'fields': {'$default': 'german'}}}}}
-        doc = self.db.create_document(data)
-        self.assertIsInstance(doc, Document)
-        data['_rev'] = doc['_rev']
-        ddoc = DesignDocument(self.db, '_design/ddoc001')
-        ddoc.fetch()
-        self.assertIsInstance(ddoc, DesignDocument)
-        self.assertEqual(ddoc, data)
-        self.assertIsInstance(ddoc['indexes']['index001'], dict)
-        self.assertIsInstance(ddoc['views']['view001'], QueryIndexView)
-
-    def test_mr_view_save_fails_when_lang_is_query(self):
-        """
-        Tests that save fails when language is query but views are map reduce
-        views.
-        """
-        ddoc = DesignDocument(self.db, '_design/ddoc001')
-        view_map = 'function (doc) {\n  emit(doc._id, 1);\n}'
-        view_reduce = '_count'
-        db_copy = '{0}-copy'.format(self.db.database_name)
-        ddoc.add_view('view001', view_map, view_reduce, dbcopy=db_copy)
-        ddoc['language'] = 'query'
-        with self.assertRaises(CloudantException) as cm:
-            ddoc.save()
-        err = cm.exception
-        self.assertEqual(
-            str(err),
-            'View view001 must be of type QueryIndexView.'
-        )
-
     def test_mr_view_save_succeeds(self):
         """
         Tests that save succeeds when no language is specified and views are map
@@ -466,64 +274,6 @@ class DesignDocumentTests(UnitTestDbBase):
         ddoc.add_view('view001', view_map, view_reduce, dbcopy=db_copy)
         ddoc.save()
         self.assertTrue(ddoc['_rev'].startswith('1-'))
-
-    def test_query_view_save_fails_when_lang_is_not_query(self):
-        """
-        Tests that save fails when language is not query but views are query
-        index views.
-        """
-        # This is not the preferred way of dealing with query index
-        # views but it works best for this test.
-        data = {
-            '_id': '_design/ddoc001',
-            'language': 'query',
-            'views': {
-                'view001': {'map': {'fields': {'name': 'asc', 'age': 'asc'}},
-                            'reduce': '_count',
-                            'options': {'def': {'fields': ['name', 'age']},
-                                        'w': 2}
-                            }
-                    }
-        }
-        self.db.create_document(data)
-        ddoc = DesignDocument(self.db, '_design/ddoc001')
-        ddoc.fetch()
-        with self.assertRaises(CloudantException) as cm:
-            ddoc['language'] = 'not-query'
-            ddoc.save()
-        err = cm.exception
-        self.assertEqual(str(err), 'View view001 must be of type View.')
-
-        with self.assertRaises(CloudantException) as cm:
-            del ddoc['language']
-            ddoc.save()
-        err = cm.exception
-        self.assertEqual(str(err), 'View view001 must be of type View.')
-
-    def test_query_view_save_succeeds(self):
-        """
-        Tests that save succeeds when language is query and views are query
-        index views.
-        """
-        # This is not the preferred way of dealing with query index
-        # views but it works best for this test.
-        data = {
-            '_id': '_design/ddoc001',
-            'language': 'query',
-            'views': {
-                'view001': {'map': {'fields': {'name': 'asc', 'age': 'asc'}},
-                            'reduce': '_count',
-                            'options': {'def': {'fields': ['name', 'age']},
-                                        'w': 2}
-                            }
-                    }
-        }
-        self.db.create_document(data)
-        ddoc = DesignDocument(self.db, '_design/ddoc001')
-        ddoc.fetch()
-        self.assertTrue(ddoc['_rev'].startswith('1-'))
-        ddoc.save()
-        self.assertTrue(ddoc['_rev'].startswith('2-'))
 
     def test_save_with_no_views(self):
         """
@@ -625,6 +375,279 @@ class DesignDocumentTests(UnitTestDbBase):
             self.fail('Above statement should raise an Exception')
         except NotImplementedError as err:
             self.assertEqual(str(err), '_info not yet implemented')
+
+@unittest.skipUnless(
+    os.environ.get('RUN_CLOUDANT_TESTS') is not None,
+    'Skipping Cloudant Query tests'
+    )
+class CloudantDesignDocumentTests(UnitTestDbBase):
+    """
+    CloudantDesignDocument unit tests
+    """
+
+    def setUp(self):
+        """
+        Set up test attributes
+        """
+        super(CloudantDesignDocumentTests, self).setUp()
+        self.db_set_up()
+
+    def tearDown(self):
+        """
+        Reset test attributes
+        """
+        self.db_tear_down()
+        super(CloudantDesignDocumentTests, self).tearDown()
+
+    def test_adding_query_index_view(self):
+        """
+        Test that adding a query index view fails as expected.
+        """
+        ddoc = CloudantDesignDocument(self.db, '_design/ddoc001')
+        ddoc['language'] = 'query'
+        with self.assertRaises(CloudantException) as cm:
+            ddoc.add_view('view001', {'foo': 'bar'})
+        err = cm.exception
+        self.assertEqual(
+            str(err),
+            'Cannot add a MapReduce view to a '
+            'design document for query indexes.'
+        )
+
+    def test_update_query_index_view(self):
+        """
+        Test that updating a query index view fails as expected.
+        """
+        # This is not the preferred way of dealing with query index
+        # views but it works best for this test.
+        data = {
+            '_id': '_design/ddoc001',
+            'language': 'query',
+            'views': {
+                'view001': {'map': {'fields': {'name': 'asc', 'age': 'asc'}},
+                            'reduce': '_count',
+                            'options': {'def': {'fields': ['name', 'age']},
+                                        'w': 2}
+                            }
+                    }
+        }
+        self.db.create_document(data)
+        ddoc = CloudantDesignDocument(self.db, '_design/ddoc001')
+        ddoc.fetch()
+        with self.assertRaises(CloudantException) as cm:
+            ddoc.update_view(
+                'view001',
+                'function (doc) {\n  emit(doc._id, 1);\n}'
+            )
+        err = cm.exception
+        self.assertEqual(
+            str(err),
+            'Cannot update a query index view using this method.'
+        )
+
+    def test_delete_a_query_index_view(self):
+        """
+        Test deleting a query index view fails as expected.
+        """
+        # This is not the preferred way of dealing with query index
+        # views but it works best for this test.
+        data = {
+            '_id': '_design/ddoc001',
+            'language': 'query',
+            'views': {
+                'view001': {'map': {'fields': {'name': 'asc', 'age': 'asc'}},
+                            'reduce': '_count',
+                            'options': {'def': {'fields': ['name', 'age']},
+                                        'w': 2}
+                            }
+                    }
+        }
+        self.db.create_document(data)
+        ddoc = CloudantDesignDocument(self.db, '_design/ddoc001')
+        ddoc.fetch()
+        with self.assertRaises(CloudantException) as cm:
+            ddoc.delete_view('view001')
+        err = cm.exception
+        self.assertEqual(
+            str(err),
+            'Cannot delete a query index view using this method.'
+        )
+
+    def test_fetch_query_views(self):
+        """
+        Ensure that the document fetch from the database returns the
+        CloudantDesignDocument format as expected when retrieving a design
+        document containing query index views.
+        """
+        # This is not the preferred way of dealing with query index
+        # views but it works best for this test.
+        data = {
+            '_id': '_design/ddoc001',
+            'language': 'query',
+            'views': {
+                'view001': {'map': {'fields': {'name': 'asc', 'age': 'asc'}},
+                            'reduce': '_count',
+                            'options': {'def': {'fields': ['name', 'age']},
+                                        'w': 2}
+                            }
+                    }
+        }
+        doc = self.db.create_document(data)
+        self.assertIsInstance(doc, Document)
+        data['_rev'] = doc['_rev']
+        ddoc = CloudantDesignDocument(self.db, '_design/ddoc001')
+        ddoc.fetch()
+        self.assertIsInstance(ddoc, CloudantDesignDocument)
+        self.assertEqual(ddoc, data)
+        self.assertIsInstance(ddoc['views']['view001'], QueryIndexView)
+
+    def test_fetch_text_indexes(self):
+        """
+        Ensure that the document fetch from the database returns the
+        CloudantDesignDocument format as expected when retrieving a design
+        document containing query index views.
+        """
+        # This is not the preferred way of dealing with query index
+        # views but it works best for this test.
+        data = {
+            '_id': '_design/ddoc001',
+            'language': 'query',
+            'indexes': {'index001':
+                     {'index': {'index_array_lengths': True,
+                                'fields': [{'name': 'name', 'type': 'string'},
+                                           {'name': 'age', 'type': 'number'}],
+                                'default_field': {'enabled': True,
+                                                  'analyzer': 'german'},
+                                'default_analyzer': 'keyword',
+                                'selector': {}},
+                      'analyzer': {'name': 'perfield',
+                                   'default': 'keyword',
+                                   'fields': {'$default': 'german'}}}}}
+        doc = self.db.create_document(data)
+        self.assertIsInstance(doc, Document)
+        ddoc = CloudantDesignDocument(self.db, '_design/ddoc001')
+        ddoc.fetch()
+        self.assertIsInstance(ddoc, CloudantDesignDocument)
+        data['_rev'] = doc['_rev']
+        data['views'] = dict()
+        self.assertEqual(ddoc, data)
+        self.assertIsInstance(ddoc['indexes']['index001'], dict)
+
+    def test_fetch_text_indexes_and_query_views(self):
+        """
+        Ensure that the document fetch from the database returns the
+        CloudantDesignDocument format as expected when retrieving a design
+        document containing query index views and text index definitions.
+        """
+        # This is not the preferred way of dealing with query index
+        # views but it works best for this test.
+        data = {
+            '_id': '_design/ddoc001',
+            'language': 'query',
+            'views': {
+                'view001': {'map': {'fields': {'name': 'asc', 'age': 'asc'}},
+                            'reduce': '_count',
+                            'options': {'def': {'fields': ['name', 'age']},
+                                        'w': 2}
+                            }
+                    },
+            'indexes': {'index001': {
+                'index': {'index_array_lengths': True,
+                          'fields': [{'name': 'name', 'type': 'string'},
+                                     {'name': 'age', 'type': 'number'}],
+                          'default_field': {'enabled': True,
+                                            'analyzer': 'german'},
+                          'default_analyzer': 'keyword',
+                          'selector': {}},
+                'analyzer': {'name': 'perfield',
+                             'default': 'keyword',
+                             'fields': {'$default': 'german'}}}}}
+        doc = self.db.create_document(data)
+        self.assertIsInstance(doc, Document)
+        data['_rev'] = doc['_rev']
+        ddoc = CloudantDesignDocument(self.db, '_design/ddoc001')
+        ddoc.fetch()
+        self.assertIsInstance(ddoc, CloudantDesignDocument)
+        self.assertEqual(ddoc, data)
+        self.assertIsInstance(ddoc['indexes']['index001'], dict)
+        self.assertIsInstance(ddoc['views']['view001'], QueryIndexView)
+
+    def test_mr_view_save_fails_when_lang_is_query(self):
+        """
+        Tests that save fails when language is query but views are map reduce
+        views.
+        """
+        ddoc = CloudantDesignDocument(self.db, '_design/ddoc001')
+        view_map = 'function (doc) {\n  emit(doc._id, 1);\n}'
+        view_reduce = '_count'
+        db_copy = '{0}-copy'.format(self.db.database_name)
+        ddoc.add_view('view001', view_map, view_reduce, dbcopy=db_copy)
+        ddoc['language'] = 'query'
+        with self.assertRaises(CloudantException) as cm:
+            ddoc.save()
+        err = cm.exception
+        self.assertEqual(
+            str(err),
+            'View view001 must be of type QueryIndexView.'
+        )
+
+    def test_query_view_save_fails_when_lang_is_not_query(self):
+        """
+        Tests that save fails when language is not query but views are query
+        index views.
+        """
+        # This is not the preferred way of dealing with query index
+        # views but it works best for this test.
+        data = {
+            '_id': '_design/ddoc001',
+            'language': 'query',
+            'views': {
+                'view001': {'map': {'fields': {'name': 'asc', 'age': 'asc'}},
+                            'reduce': '_count',
+                            'options': {'def': {'fields': ['name', 'age']},
+                                        'w': 2}
+                            }
+                    }
+        }
+        self.db.create_document(data)
+        ddoc = CloudantDesignDocument(self.db, '_design/ddoc001')
+        ddoc.fetch()
+        with self.assertRaises(CloudantException) as cm:
+            ddoc['language'] = 'not-query'
+            ddoc.save()
+        err = cm.exception
+        self.assertEqual(str(err), 'View view001 must be of type View.')
+
+        with self.assertRaises(CloudantException) as cm:
+            del ddoc['language']
+            ddoc.save()
+        err = cm.exception
+        self.assertEqual(str(err), 'View view001 must be of type View.')
+
+    def test_query_view_save_succeeds(self):
+        """
+        Tests that save succeeds when language is query and views are query
+        index views.
+        """
+        # This is not the preferred way of dealing with query index
+        # views but it works best for this test.
+        data = {
+            '_id': '_design/ddoc001',
+            'language': 'query',
+            'views': {
+                'view001': {'map': {'fields': {'name': 'asc', 'age': 'asc'}},
+                            'reduce': '_count',
+                            'options': {'def': {'fields': ['name', 'age']},
+                                        'w': 2}
+                            }
+                    }
+        }
+        self.db.create_document(data)
+        ddoc = CloudantDesignDocument(self.db, '_design/ddoc001')
+        ddoc.fetch()
+        self.assertTrue(ddoc['_rev'].startswith('1-'))
+        ddoc.save()
+        self.assertTrue(ddoc['_rev'].startswith('2-'))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## What

Create a Cloudant specific design document for managing query indexes.

## How

- Add new CloudantDesignDocument class in design_document.py
- Move query index functionality from DesignDocument functions to CloudantDesignDocument functions

## Testing

Move existing query index tests into CloudantDesignDocumentTests.
No new tests created.

## Reviewers

reviewer @ricellis
reviewer @alfinkel

## Issues

#164 