### PR TITLE
Cloudant search index query

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,6 @@
 2.1.0 (Unreleased)
 ==================
+- [NEW] Added support for Cloudant Search execution.
 
 
 2.0.3 (2016-06-03)

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -114,6 +114,27 @@ QUERY_ARG_TYPES = {
 
 TEXT_INDEX_ARGS = {'fields': list, 'default_field': dict, 'selector': dict}
 
+SEARCH_INDEX_ARGS = {
+    'bookmark': STRTYPE,
+    'counts': list,
+    'drilldown': list,
+    'group_field': STRTYPE,
+    'group_limit': (int, NONETYPE),
+    'group_sort': list,
+    'include_docs': bool,
+    'limit': (int, NONETYPE),
+    'query': (STRTYPE, int),
+    'ranges': dict,
+    'sort': (STRTYPE, list),
+    'stale': STRTYPE,
+    'highlight_fields': list,
+    'highlight_pre_tag': STRTYPE,
+    'highlight_post_tag': STRTYPE,
+    'highlight_number': (int, NONETYPE),
+    'highlight_size': (int, NONETYPE),
+    'include_fields': list
+}
+
 # Functions
 
 def feed_arg_types(feed_type):

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -21,15 +21,18 @@ import posixpath
 
 from requests.exceptions import HTTPError
 
-from ._2to3 import url_quote_plus
+from ._2to3 import url_quote_plus, iteritems_
+from ._common_util import (
+    JSON_INDEX_TYPE,
+    SEARCH_INDEX_ARGS,
+    SPECIAL_INDEX_TYPE,
+    TEXT_INDEX_TYPE,
+    python_to_couch
+)
 from .document import Document
 from .design_document import DesignDocument
 from .view import View
 from .index import Index, TextIndex, SpecialIndex
-from ._common_util import JSON_INDEX_TYPE
-from ._common_util import TEXT_INDEX_TYPE
-from ._common_util import SPECIAL_INDEX_TYPE
-from ._common_util import python_to_couch
 from .query import Query
 from .error import CloudantException, CloudantArgumentError
 from .result import Result, QueryResult
@@ -1098,3 +1101,128 @@ class CloudantDatabase(CouchDatabase):
             return QueryResult(query, **kwargs)
         else:
             return query.result
+
+    def get_search_result(self, ddoc_id, index_name, **query_params):
+        """
+        Retrieves the raw JSON content from the remote database based on the
+        search index on the server, using the query_params provided as query
+        parameters. A ``query`` parameter containing the Lucene query
+        syntax is mandatory.
+
+        Example for search queries:
+
+        .. code-block:: python
+
+            # Assuming that 'searchindex001' exists as part of the
+            # 'ddoc001' design document in the remote database...
+            # Retrieve documents where the Lucene field name is 'name' and
+            # the value is 'julia*'
+            resp = db.get_search_result('ddoc001', 'searchindex001',
+                                        query='name:julia*',
+                                        include_docs=True)
+            for row in resp['rows']:
+                # Process search index data (in JSON format).
+
+        Example if the search query requires grouping by using
+        the ``group_field`` parameter:
+
+        .. code-block:: python
+
+            # Assuming that 'searchindex001' exists as part of the
+            # 'ddoc001' design document in the remote database...
+            # Retrieve JSON response content, limiting response to 10 documents
+            resp = db.get_search_result('ddoc001', 'searchindex001',
+                                        query='name:julia*',
+                                        group_field='name',
+                                        limit=10)
+            for group in resp['groups']:
+                for row in group['rows']:
+                # Process search index data (in JSON format).
+
+        :param str ddoc_id: Design document id used to get the search result.
+        :param str index_name: Name used in part to identify the index.
+        :param str bookmark: Optional string that enables you to specify which
+            page of results you require. Only valid for queries that do not
+            specify the ``group_field`` query parameter.
+        :param list counts: Optional JSON array of field names for which
+            counts should be produced. The response will contain counts for each
+            unique value of this field name among the documents matching the
+            search query.
+            Requires the index to have faceting enabled.
+        :param list drilldown:  Optional list of fields that each define a
+            pair of a field name and a value. This field can be used several
+            times.  The search will only match documents that have the given
+            value in the field name. It differs from using
+            ``query=fieldname:value` only in that the values are not analyzed.
+        :param str group_field: Optional string field by which to group
+            search matches.  Fields containing other data
+            (numbers, objects, arrays) can not be used.
+        :param int group_limit: Optional number with the maximum group count.
+            This field can only be used if ``group_field`` query parameter
+            is specified.
+        :param group_sort: Optional JSON field that defines the order of the
+            groups in a search using ``group_field``. The default sort order
+            is relevance. This field can have the same values as the sort field,
+            so single fields as well as arrays of fields are supported.
+        :param int limit: Optional number to limit the maximum count of the
+            returned documents. In case of a grouped search, this parameter
+            limits the number of documents per group.
+        :param query: A Lucene query in the form of ``name:value``.
+            If name is omitted, the special value ``default`` is used.
+        :param ranges: Optional JSON facet syntax that reuses the standard
+            Lucene syntax to return counts of results which fit into each
+            specified category. Inclusive range queries are denoted by brackets.
+            Exclusive range queries are denoted by curly brackets.
+            For example ``ranges={"price":{"cheap":"[0 TO 100]"}}`` has an
+            inclusive range of 0 to 100.
+            Requires the index to have faceting enabled.
+        :param sort: Optional JSON string of the form ``fieldname<type>`` for
+            ascending or ``-fieldname<type>`` for descending sort order.
+            Fieldname is the name of a string or number field and type is either
+            number or string or a JSON array of such strings. The type part is
+            optional and defaults to number.
+        :param str stale: Optional string to allow the results from a stale
+            index to be used. This makes the request return immediately, even
+            if the index has not been completely built yet.
+        :param list highlight_fields: Optional list of fields which should be
+            highlighted.
+        :param str highlight_pre_tag: Optional string inserted before the
+            highlighted word in the highlights output.  Defaults to ``<em>``.
+        :param str highlight_post_tag: Optional string inserted after the
+            highlighted word in the highlights output.  Defaults to ``</em>``.
+        :param int highlight_number: Optional number of fragments returned in
+            highlights. If the search term occurs less often than the number of
+            fragments specified, longer fragments are returned.  Default is 1.
+        :param int highlight_size: Optional number of characters in each
+            fragment for highlights.  Defaults to 100 characters.
+        :param list include_fields: Optional list of field names to include in
+            search results. Any fields included must have been indexed with the
+            ``store:true`` option.
+
+        :returns: Search query result data in JSON format
+        """
+        if not query_params.get('query'):
+            raise CloudantArgumentError(
+                'No query parameter found.  Please add a query parameter '
+                'containing Lucene syntax and retry.')
+
+        # Validate query arguments and values
+        for key, val in iteritems_(query_params):
+            if key not in list(SEARCH_INDEX_ARGS.keys()):
+                msg = 'Invalid argument: {0}'.format(key)
+                raise CloudantArgumentError(msg)
+            if not isinstance(val, SEARCH_INDEX_ARGS[key]):
+                msg = (
+                    'Argument {0} is not an instance of expected type: {1}'
+                ).format(key, SEARCH_INDEX_ARGS[key])
+                raise CloudantArgumentError(msg)
+        # Execute query search
+        headers = {'Content-Type': 'application/json'}
+        ddoc = DesignDocument(self, ddoc_id)
+        resp = self.r_session.post(
+            '/'.join([ddoc.document_url, '_search', index_name]),
+            headers=headers,
+            data=json.dumps(query_params, cls=self.client.encoder)
+        )
+        resp.raise_for_status()
+        return resp.json()

--- a/tests/unit/unit_t_db_base.py
+++ b/tests/unit/unit_t_db_base.py
@@ -228,3 +228,17 @@ class UnitTestDbBase(unittest.TestCase):
         self.view004 = self.ddoc.get_view('view004')
         self.view005 = self.ddoc.get_view('view005')
         self.view006 = self.ddoc.get_view('view006')
+
+    def create_search_index(self):
+        """
+        Create a design document with search indexes for use
+        with search query tests.
+        """
+        self.search_ddoc = DesignDocument(self.db, 'searchddoc001')
+        self.search_ddoc['indexes'] = {'searchindex001': {
+                'index': 'function (doc) {\n  index("default", doc._id); \n '
+                'if (doc.name) {\n index("name", doc.name, {"store": true}); \n} '
+                'if (doc.age) {\n index("age", doc.age, {"facet": true}); \n} \n} '
+            }
+        }
+        self.search_ddoc.save()


### PR DESCRIPTION
## What

Support Cloudant search query parameter processing and execution.

## How

- Handled search query parameter processing and execution in `CloudantDatabase.get_search_result`
- Added dictionary of search query parameters in common_util

## Testing

- Unit tests for search index query in `CloudantDatabaseTests` class
- Created a search index during test class setup for querying tests with `create_search_index`

## Reviewers

reviewer: @alfinkel 
reviewer @ricellis

## Issues

#158