### PR TITLE
Cloudant Search index management

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 2.1.0 (Unreleased)
 ==================
 - [NEW] Added support for Cloudant Search execution.
-
+- [NEW] Added support for Cloudant Search index management.
 
 2.0.3 (2016-06-03)
 ==================

--- a/src/cloudant/design_document.py
+++ b/src/cloudant/design_document.py
@@ -15,25 +15,25 @@
 """
 API module/class for interacting with a design document in a database.
 """
-from ._2to3 import iteritems_
+from ._2to3 import iteritems_, STRTYPE
+from ._common_util import QUERY_LANGUAGE, codify
 from .document import Document
 from .view import View, QueryIndexView
 from .error import CloudantArgumentError, CloudantException
-from ._common_util import QUERY_LANGUAGE
 
 class DesignDocument(Document):
     """
     Encapsulates a specialized version of a
     :class:`~cloudant.document.Document`.  A DesignDocument object is
     instantiated with a reference to a database and
-    provides an API to view management, list and show
-    functions, search indexes, etc.  When instantiating a DesignDocument or
+    provides an API to view management, index management, list and show
+    functions, etc.  When instantiating a DesignDocument or
     when setting the document id (``_id``) field, the value must start with
     ``_design/``.  If it does not, then ``_design/`` will be prepended to
     the provided document id value.
 
-    Note:  Currently only the view management API exists.  Remaining design
-    document functionality will be added later.
+    Note:  Currently only the view management and search index management API
+    exists.  Remaining design document functionality will be added later.
 
     :param database: A database instance used by the DesignDocument.  Can be
         either a ``CouchDatabase`` or ``CloudantDatabase`` instance.
@@ -45,6 +45,7 @@ class DesignDocument(Document):
             document_id = '_design/{0}'.format(document_id)
         super(DesignDocument, self).__init__(database, document_id)
         self.setdefault('views', dict())
+        self.setdefault('indexes', dict())
 
     @property
     def views(self):
@@ -55,6 +56,17 @@ class DesignDocument(Document):
         :returns: Dictionary containing view names and View objects as key/value
         """
         return self.get('views')
+
+    @property
+    def indexes(self):
+        """
+        Provides an accessor property to the indexes dictionary in the
+        locally cached DesignDocument.
+
+        :returns: Dictionary containing index names and index objects
+            as key/value
+        """
+        return self.get('indexes')
 
     def add_view(self, view_name, map_func, reduce_func=None, **kwargs):
         """
@@ -78,6 +90,26 @@ class DesignDocument(Document):
 
         view = View(self, view_name, map_func, reduce_func, **kwargs)
         self.views.__setitem__(view_name, view)
+
+    def add_search_index(self, index_name, search_func, analyzer=None):
+        """
+        Appends a Cloudant search index to the locally cached DesignDocument
+        indexes dictionary.
+
+        :param str index_name: Name used to identify the search index.
+        :param str search_func: Javascript search index function.
+        :param analyzer: Optional analyzer for this search index.
+        """
+        if self.get_index(index_name) is not None:
+            msg = ('An index with name {0} already exists in this design doc'
+                   .format(index_name))
+            raise CloudantArgumentError(msg)
+        if analyzer is not None:
+            search = {'index': codify(search_func), 'analyzer': analyzer}
+        else:
+            search = {'index': codify(search_func)}
+
+        self.indexes.__setitem__(index_name, search)
 
     def update_view(self, view_name, map_func, reduce_func=None, **kwargs):
         """
@@ -104,6 +136,27 @@ class DesignDocument(Document):
         view = View(self, view_name, map_func, reduce_func, **kwargs)
         self.views.__setitem__(view_name, view)
 
+    def update_search_index(self, index_name, search_func, analyzer=None):
+        """
+        Modifies/overwrites an existing Cloudant search index in the
+        locally cached DesignDocument indexes dictionary.
+
+        :param str index_name: Name used to identify the search index.
+        :param str search_func: Javascript search index function.
+        :param analyzer: Optional analyzer for this search index.
+        """
+        search = self.get_index(index_name)
+        if search is None:
+            msg = ('An index with name {0} does not exist in this design doc'
+                   .format(index_name))
+            raise CloudantArgumentError(msg)
+        if analyzer is not None:
+            search = {'index': codify(search_func), 'analyzer': analyzer}
+        else:
+            search = {'index': codify(search_func)}
+
+        self.indexes.__setitem__(index_name, search)
+
     def delete_view(self, view_name):
         """
         Removes an existing MapReduce view definition from the locally cached
@@ -122,6 +175,19 @@ class DesignDocument(Document):
             raise CloudantException(msg)
 
         self.views.__delitem__(view_name)
+
+    def delete_index(self, index_name):
+        """
+        Removes an existing index in the locally cached DesignDocument
+        indexes dictionary.
+
+        :param str index_name: Name used to identify the index.
+        """
+        index = self.get_index(index_name)
+        if index is None:
+            return
+
+        self.indexes.__delitem__(index_name)
 
     def fetch(self):
         """
@@ -154,6 +220,11 @@ class DesignDocument(Document):
                         **view_def
                     )
 
+        if not self.indexes:
+            # Ensure indexes dict exists in locally cached DesignDocument.
+            self.setdefault('indexes', dict())
+
+    # pylint: disable-msg=too-many-branches
     def save(self):
         """
         Saves changes made to the locally cached DesignDocument object's data
@@ -180,11 +251,36 @@ class DesignDocument(Document):
             # Ensure empty views dict is not saved remotely.
             self.__delitem__('views')
 
+        if self.indexes:
+            if self.get('language', None) != QUERY_LANGUAGE:
+                for index_name, search in self.iterindexes():
+                    # Check the instance of the javascript search function
+                    if not isinstance(search['index'], STRTYPE):
+                        msg = (
+                            'Function for search index {0} must '
+                            'be of type string.'
+                        ).format(index_name)
+                        raise CloudantException(msg)
+            else:
+                for index_name, index in self.iterindexes():
+                    if not isinstance(index['index'], dict):
+                        msg = (
+                            'Definition for query text index {0} must '
+                            'be of type dict.'
+                        ).format(index_name)
+                        raise CloudantException(msg)
+        else:
+            # Ensure empty indexes dict is not saved remotely.
+            self.__delitem__('indexes')
+
         super(DesignDocument, self).save()
 
         if not self.views:
             # Ensure views dict exists in locally cached DesignDocument.
             self.setdefault('views', dict())
+        if not self.indexes:
+            # Ensure indexes dict exists in locally cached DesignDocument.
+            self.setdefault('indexes', dict())
 
     def __setitem__(self, key, value):
         """
@@ -216,6 +312,24 @@ class DesignDocument(Document):
         for view_name, view in iteritems_(self.views):
             yield view_name, view
 
+    def iterindexes(self):
+        """
+        Provides a way to iterate over the locally cached DesignDocument
+        indexes dictionary.
+
+        For example:
+
+        .. code-block:: python
+
+            for index_name, search_func in ddoc.iterindexes():
+                # Perform search index processing
+
+        :returns: Iterable containing index name and associated
+            index object
+        """
+        for index_name, search_func in iteritems_(self.indexes):
+            yield index_name, search_func
+
     def list_views(self):
         """
         Retrieves a list of available View objects in the locally cached
@@ -224,6 +338,15 @@ class DesignDocument(Document):
         :returns: List of view names
         """
         return list(self.views.keys())
+
+    def list_indexes(self):
+        """
+        Retrieves a list of available indexes in the locally cached
+        DesignDocument.
+
+        :returns: List of index names
+        """
+        return list(self.indexes.keys())
 
     def get_view(self, view_name):
         """
@@ -235,6 +358,17 @@ class DesignDocument(Document):
         :returns: View object for the specified view_name
         """
         return self.views.get(view_name)
+
+    def get_index(self, index_name):
+        """
+        Retrieves a specific index from the locally cached DesignDocument
+        indexes dictionary by name.
+
+        :param str index_name: Name used to identify the index.
+
+        :returns: Index dictionary for the specified index name
+        """
+        return self.indexes.get(index_name)
 
     def info(self):
         """

--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -253,8 +253,8 @@ class DatabaseTests(UnitTestDbBase):
         """
         # Get an empty design document object that does not exist remotely
         local_ddoc = self.db.get_design_document('_design/ddoc01')
-        self.assertEqual(local_ddoc, {'_id': '_design/ddoc01', 'views': {}})
-
+        self.assertEqual(local_ddoc, {'_id': '_design/ddoc01', 'indexes': {},
+                                      'views': {}})
         # Add the design document to the database
         map_func = 'function(doc) {\n emit(doc._id, 1); \n}'
         local_ddoc.add_view('view01', map_func)
@@ -856,6 +856,7 @@ class CloudantDatabaseTests(UnitTestDbBase):
         self.assertEqual(ddoc,
                 {'_id': index.design_document_id,
                  '_rev': ddoc['_rev'],
+                 'indexes': {},
                  'language': 'query',
                  'views': {index.name: {'map': {'fields': {'name': 'asc', 
                                                            'age': 'asc'}},

--- a/tests/unit/design_document_tests.py
+++ b/tests/unit/design_document_tests.py
@@ -21,7 +21,6 @@ See configuration options for environment variables in unit_t_db_base
 module docstring.
 
 """
-
 import unittest
 
 from cloudant.document import Document 
@@ -310,6 +309,7 @@ class DesignDocumentTests(UnitTestDbBase):
         self.assertEqual(ddoc_remote, {
             '_id': '_design/ddoc001',
             '_rev': ddoc['_rev'],
+            'indexes': {},
             'views': {
                 'view001': {'map': view_map, 'reduce': view_reduce},
                 'view002': {'map': view_map, 'reduce': view_reduce, 'dbcopy': db_copy},
@@ -330,7 +330,8 @@ class DesignDocumentTests(UnitTestDbBase):
         ddoc.save()
         ddoc_remote = DesignDocument(self.db, '_design/ddoc001')
         ddoc_remote.fetch()
-        self.assertEqual(set(ddoc_remote.keys()), {'_id', '_rev', 'views'})
+        self.assertEqual(set(ddoc_remote.keys()),
+                         {'_id', '_rev', 'indexes', 'views'})
         self.assertEqual(ddoc_remote['_id'], '_design/ddoc001')
         self.assertTrue(ddoc_remote['_rev'].startswith('1-'))
         self.assertEqual(ddoc_remote['_rev'], ddoc['_rev'])
@@ -346,6 +347,7 @@ class DesignDocumentTests(UnitTestDbBase):
         # views but it works best for this test.
         data = {
             '_id': '_design/ddoc001',
+            'indexes': {},
             'language': 'query',
             'views': {
                 'view001': {'map': {'fields': {'name': 'asc', 'age': 'asc'}},
@@ -375,7 +377,7 @@ class DesignDocumentTests(UnitTestDbBase):
         data = {
             '_id': '_design/ddoc001',
             'language': 'query',
-            'indexes': {'index001': 
+            'indexes': {'index001':
                      {'index': {'index_array_lengths': True,
                                 'fields': [{'name': 'name', 'type': 'string'},
                                            {'name': 'age', 'type': 'number'}],
@@ -434,6 +436,65 @@ class DesignDocumentTests(UnitTestDbBase):
         self.assertEqual(ddoc, data)
         self.assertIsInstance(ddoc['indexes']['index001'], dict)
         self.assertIsInstance(ddoc['views']['view001'], QueryIndexView)
+
+    def test_text_index_save_fails_when_lang_is_not_query(self):
+        """
+        Tests that save fails when language is not query and a search index
+        string function is expected.
+        """
+        ddoc = DesignDocument(self.db, '_design/ddoc001')
+        ddoc['indexes']['index001'] = {
+            'index': {'index_array_lengths': True,
+                      'fields': [{'name': 'name', 'type': 'string'},
+                                 {'name': 'age', 'type': 'number'}],
+                      'default_field': {'enabled': True, 'analyzer': 'german'},
+                      'default_analyzer': 'keyword',
+                      'selector': {}},
+            'analyzer': {'name': 'perfield','default': 'keyword',
+                         'fields': {'$default': 'german'}}}
+        self.assertIsInstance(ddoc['indexes']['index001']['index'], dict)
+        with self.assertRaises(CloudantException) as cm:
+            ddoc.save()
+        err = cm.exception
+        self.assertEqual(
+            str(err),
+            'Function for search index index001 must be of type string.'
+        )
+
+    def test_text_index_save_fails_with_existing_search_index(self):
+        """
+        Tests that save fails when language is not query and both a query text
+        index and a search index exist in the design document.
+        """
+        ddoc = DesignDocument(self.db, '_design/ddoc001')
+        search_index = ('function (doc) {\n  index("default", doc._id); '
+                        'if (doc._id) {index("name", doc.name, '
+                        '{"store": true}); }\n}')
+        ddoc.add_search_index('search001', search_index)
+        self.assertIsInstance(
+            ddoc['indexes']['search001']['index'], str
+        )
+        ddoc.save()
+        self.assertTrue(ddoc['_rev'].startswith('1-'))
+        ddoc_remote = DesignDocument(self.db, '_design/ddoc001')
+        ddoc_remote.fetch()
+        ddoc_remote['indexes']['index001'] = {
+            'index': {'index_array_lengths': True,
+                      'fields': [{'name': 'name', 'type': 'string'},
+                                 {'name': 'age', 'type': 'number'}],
+                      'default_field': {'enabled': True, 'analyzer': 'german'},
+                      'default_analyzer': 'keyword',
+                      'selector': {}},
+            'analyzer': {'name': 'perfield','default': 'keyword',
+                         'fields': {'$default': 'german'}}}
+        self.assertIsInstance(ddoc_remote['indexes']['index001']['index'], dict)
+        with self.assertRaises(CloudantException) as cm:
+            ddoc_remote.save()
+        err = cm.exception
+        self.assertEqual(
+            str(err),
+            'Function for search index index001 must be of type string.'
+        )
 
     def test_mr_view_save_fails_when_lang_is_query(self):
         """
@@ -536,7 +597,7 @@ class DesignDocumentTests(UnitTestDbBase):
         ddoc.save()
         # Ensure that locally cached DesignDocument contains an
         # empty views dict.
-        self.assertEqual(set(ddoc.keys()), {'_id', '_rev', 'views'})
+        self.assertEqual(set(ddoc.keys()), {'_id', '_rev', 'indexes', 'views'})
         self.assertEqual(ddoc['_id'], '_design/ddoc001')
         self.assertTrue(ddoc['_rev'].startswith('1-'))
         self.assertEqual(ddoc.views, {})
@@ -625,6 +686,354 @@ class DesignDocumentTests(UnitTestDbBase):
             self.fail('Above statement should raise an Exception')
         except NotImplementedError as err:
             self.assertEqual(str(err), '_info not yet implemented')
+
+    def test_add_a_search_index(self):
+        """
+        Test that adding a search index adds a search index object to
+        the DesignDocument dictionary.
+        """
+        ddoc = DesignDocument(self.db, '_design/ddoc001')
+        self.assertEqual(ddoc.get('indexes'), {})
+        ddoc.add_search_index(
+            'search001',
+            'function (doc) {\n  index("default", doc._id); '
+            'if (doc._id) {index("name", doc.name, {"store": true}); }\n}'
+        )
+        self.assertListEqual(list(ddoc.get('indexes').keys()), ['search001'])
+        self.assertEqual(
+            ddoc.get('indexes')['search001'],
+            {'index': 'function (doc) {\n  index("default", doc._id); '
+                'if (doc._id) {index("name", doc.name, {"store": true}); }\n}'}
+         )
+
+    def test_add_a_search_index_with_analyzer(self):
+        """
+        Test that adding a search index with an analyzer adds a search index
+        object to the DesignDocument dictionary.
+        """
+        ddoc = DesignDocument(self.db, '_design/ddoc001')
+        self.assertEqual(ddoc.get('indexes'), {})
+        ddoc.add_search_index(
+            'search001',
+            'function (doc) {\n  index("default", doc._id); '
+            'if (doc._id) {index("name", doc.name, {"store": true}); }\n}',
+            {'name': 'perfield', 'default': 'english', 'fields': {
+                'spanish': 'spanish'}}
+        )
+        self.assertListEqual(list(ddoc.get('indexes').keys()), ['search001'])
+        self.assertEqual(
+            ddoc.get('indexes')['search001'],
+            {'index': 'function (doc) {\n  index("default", doc._id); '
+                'if (doc._id) {index("name", doc.name, {"store": true}); }\n}',
+                'analyzer': {"name": "perfield", "default": "english", "fields":
+                    {"spanish": "spanish"}}}
+         )
+
+    def test_adding_existing_search_index(self):
+        """
+        Test that adding an existing search index fails as expected.
+        """
+        ddoc = DesignDocument(self.db, '_design/ddoc001')
+        ddoc.add_search_index(
+            'search001',
+            'function (doc) {\n  index("default", doc._id); '
+            'if (doc._id) {index("name", doc.name, {"store": true}); }\n}',
+        )
+        with self.assertRaises(CloudantArgumentError) as cm:
+            ddoc.add_search_index(
+                'search001',
+                'function (doc) {\n  index("default", doc._id); '
+                'if (doc._id) {index("name", doc.name, '
+                '{"store": true}); }\n}'
+            )
+        err = cm.exception
+        self.assertEqual(
+            str(err),
+            'An index with name search001 already exists in this design doc'
+        )
+
+    def test_update_a_search_index(self):
+        """
+        Test that updating a search index updates the contents of the correct
+        search index object in the DesignDocument dictionary.
+        """
+        ddoc = DesignDocument(self.db, '_design/ddoc001')
+        ddoc.add_search_index('search001', 'not-a-valid-search-index')
+        self.assertEqual(
+            ddoc.get('indexes')['search001'],
+            {'index': 'not-a-valid-search-index'}
+        )
+        ddoc.update_search_index(
+            'search001',
+            'function (doc) {\n  index("default", doc._id); '
+            'if (doc._id) {index("name", doc.name, {"store": true}); }\n}',
+        )
+        self.assertEqual(
+            ddoc.get('indexes')['search001'],
+            {'index': 'function (doc) {\n  index("default", doc._id); '
+                'if (doc._id) {index("name", doc.name, '
+                '{"store": true}); }\n}'}
+        )
+
+    def test_update_a_search_index_with_analyzer(self):
+        """
+        Test that updating a search analyzer updates the contents of the correct
+        search index object in the DesignDocument dictionary.
+        """
+        ddoc = DesignDocument(self.db, '_design/ddoc001')
+        ddoc.add_search_index('search001',
+                              'not-a-valid-search-index',
+                              'email')
+        self.assertEqual(
+            ddoc.get('indexes')['search001'],
+            {'index': 'not-a-valid-search-index', 'analyzer': 'email'}
+        )
+        ddoc.update_search_index(
+            'search001',
+            'function (doc) {\n  index("default", doc._id); '
+            'if (doc._id) {index("name", doc.name, {"store": true}); }\n}',
+            'simple'
+        )
+        self.assertEqual(
+            ddoc.get('indexes')['search001'],
+            {'index': 'function (doc) {\n  index("default", doc._id); '
+                'if (doc._id) {index("name", doc.name, '
+                '{"store": true}); }\n}',
+             'analyzer': 'simple'
+            }
+        )
+
+    def test_update_non_existing_search_index(self):
+        """
+        Test that updating a non-existing search index fails as expected.
+        """
+        ddoc = DesignDocument(self.db, '_design/ddoc001')
+        with self.assertRaises(CloudantArgumentError) as cm:
+            ddoc.update_search_index(
+                'search001',
+                'function (doc) {\n  index("default", doc._id); '
+                'if (doc._id) {index("name", doc.name, '
+                '{"store": true}); }\n}'
+            )
+        err = cm.exception
+        self.assertEqual(
+            str(err),
+            'An index with name search001 does not exist in this design doc'
+        )
+
+    def test_delete_a_search_index(self):
+        """
+        Test deleting a search index from the DesignDocument dictionary.
+        """
+        ddoc = DesignDocument(self.db, '_design/ddoc001')
+        ddoc.add_search_index(
+            'search001',
+            'function (doc) {\n  index("default", doc._id); '
+            'if (doc._id) {index("name", doc.name, '
+            '{"store": true}); }\n}'
+        )
+        self.assertEqual(
+            ddoc.get('indexes')['search001'],
+            {'index': 'function (doc) {\n  index("default", doc._id); '
+                'if (doc._id) {index("name", doc.name, '
+                '{"store": true}); }\n}'}
+        )
+        ddoc.delete_index('search001')
+        self.assertEqual(ddoc.get('indexes'), {})
+
+    def test_fetch_search_index(self):
+        """
+        Ensure that the document fetch from the database returns the
+        DesignDocument format as expected when retrieving a design document
+        containing search indexes.
+        """
+        ddoc = DesignDocument(self.db, '_design/ddoc001')
+        search_index = ('function (doc) {\n  index("default", doc._id); '
+                        'if (doc._id) {index("name", doc.name, '
+                        '{"store": true}); }\n} ')
+        ddoc.add_search_index('search001', search_index)
+        ddoc.add_search_index('search002', search_index, 'simple')
+        ddoc.add_search_index('search003', search_index, 'standard')
+        ddoc.save()
+        ddoc_remote = DesignDocument(self.db, '_design/ddoc001')
+        self.assertNotEqual(ddoc_remote, ddoc)
+        ddoc_remote.fetch()
+        self.assertEqual(ddoc_remote, ddoc)
+        self.assertTrue(ddoc_remote['_rev'].startswith('1-'))
+        self.assertEqual(ddoc_remote, {
+            '_id': '_design/ddoc001',
+            '_rev': ddoc['_rev'],
+            'indexes': {
+                'search001': {'index': search_index},
+                'search002': {'index': search_index, 'analyzer': 'simple'},
+                'search003': {'index': search_index, 'analyzer': 'standard'}
+            },
+            'views': {}
+        })
+
+    def test_fetch_no_search_index(self):
+        """
+        Ensure that the document fetched from the database returns the
+        DesignDocument format as expected when retrieving a design document
+        containing no search indexes.
+        The :func:`~cloudant.design_document.DesignDocument.fetch` function
+        adds the ``indexes`` key in the locally cached DesignDocument if
+        indexes do not exist in the remote design document.
+        """
+        ddoc = DesignDocument(self.db, '_design/ddoc001')
+        ddoc.save()
+        ddoc_remote = DesignDocument(self.db, '_design/ddoc001')
+        ddoc_remote.fetch()
+        self.assertEqual(set(ddoc_remote.keys()),
+                         {'_id', '_rev', 'indexes', 'views'})
+        self.assertEqual(ddoc_remote['_id'], '_design/ddoc001')
+        self.assertTrue(ddoc_remote['_rev'].startswith('1-'))
+        self.assertEqual(ddoc_remote['_rev'], ddoc['_rev'])
+        self.assertEqual(ddoc_remote.indexes, {})
+
+    def test_search_index_save_fails_when_lang_is_query(self):
+        """
+        Tests that save fails when language is query and a text index dict
+        definition is expected.
+        """
+        ddoc = DesignDocument(self.db, '_design/ddoc001')
+        ddoc['language'] = 'query'
+        ddoc['indexes']['search001'] = {
+            'index': 'function (doc) {\n  index("default", doc._id); '
+                     'if (doc._id) {index("name", doc.name, '
+                     '{"store": true}); }\n}',
+            'analyzer': 'standard'}
+        self.assertIsInstance(ddoc['indexes']['search001']['index'], str)
+        with self.assertRaises(CloudantException) as cm:
+            ddoc.save()
+        err = cm.exception
+        self.assertEqual(
+            str(err),
+            'Definition for query text index search001 must be of type dict.'
+        )
+
+    def test_search_index_save_fails_with_existing_text_index(self):
+        """
+        Tests that save fails when language is query and both a search index
+        and a text index exist in the design document.
+        """
+        ddoc = DesignDocument(self.db, '_design/ddoc001')
+        ddoc['language'] = 'query'
+        ddoc['indexes']['index001'] = {
+            'index': {'index_array_lengths': True,
+                      'fields': [{'name': 'name', 'type': 'string'},
+                                 {'name': 'age', 'type': 'number'}],
+                      'default_field': {'enabled': True, 'analyzer': 'german'},
+                      'default_analyzer': 'keyword',
+                      'selector': {}},
+            'analyzer': {'name': 'perfield','default': 'keyword',
+                         'fields': {'$default': 'german'}}}
+        ddoc.save()
+        self.assertTrue(ddoc['_rev'].startswith('1-'))
+        search_index = ('function (doc) {\n  index("default", doc._id); '
+                        'if (doc._id) {index("name", doc.name, '
+                        '{"store": true}); }\n}')
+        ddoc.add_search_index('search001', search_index)
+        self.assertIsInstance(
+            ddoc['indexes']['search001']['index'], str
+        )
+        with self.assertRaises(CloudantException) as cm:
+            ddoc.save()
+        err = cm.exception
+        self.assertEqual(
+            str(err),
+            'Definition for query text index search001 must be of type dict.'
+        )
+
+    def test_search_index_save_succeeds(self):
+        """
+        Tests that save succeeds when no language is specified for search
+        indexes.
+        """
+        ddoc = DesignDocument(self.db, '_design/ddoc001')
+        search_index = ('function (doc) {\n  index("default", doc._id); '
+                        'if (doc._id) {index("name", doc.name, '
+                        '{"store": true}); }\n}')
+        ddoc.add_search_index('search001', search_index)
+        ddoc.save()
+        self.assertTrue(ddoc['_rev'].startswith('1-'))
+
+    def test_save_with_no_search_indexes(self):
+        """
+        Tests the functionality when saving a design document without a search
+        index. Both the locally cached and remote DesignDocument should not
+        include the empty indexes sub-document.
+        """
+        ddoc = DesignDocument(self.db, '_design/ddoc001')
+        ddoc.save()
+        # Ensure that locally cached DesignDocument contains an
+        # empty search indexes and views dict.
+        self.assertEqual(set(ddoc.keys()), {'_id', '_rev', 'indexes', 'views'})
+        self.assertEqual(ddoc['_id'], '_design/ddoc001')
+        self.assertTrue(ddoc['_rev'].startswith('1-'))
+        # Ensure that remotely saved design document does not
+        # include a search indexes sub-document.
+        resp = self.client.r_session.get(ddoc.document_url)
+        raw_ddoc = resp.json()
+        self.assertEqual(set(raw_ddoc.keys()), {'_id', '_rev'})
+        self.assertEqual(raw_ddoc['_id'], ddoc['_id'])
+        self.assertEqual(raw_ddoc['_rev'], ddoc['_rev'])
+
+    def test_iterating_over_search_indexes(self):
+        """
+        Test iterating over search indexes within the DesignDocument.
+        """
+        ddoc = DesignDocument(self.db, '_design/ddoc001')
+        search_index = ('function (doc) {\n  index("default", doc._id); '
+                        'if (doc._id) {index("name", doc.name, '
+                        '{"store": true}); }\n}')
+        ddoc.add_search_index('search001', search_index)
+        ddoc.add_search_index('search002', search_index)
+        ddoc.add_search_index('search003', search_index)
+        search_index_names = []
+        for search_index_name, search_index in ddoc.iterindexes():
+            search_index_names.append(search_index_name)
+        self.assertTrue(
+            all(x in search_index_names for
+                x in ['search001', 'search002', 'search003'])
+        )
+
+    def test_list_search_indexes(self):
+        """
+        Test the retrieval of search index name list from DesignDocument.
+        """
+        ddoc = DesignDocument(self.db, '_design/ddoc001')
+        index = 'function (doc) {\n  index("default", doc._id); '
+        'if (doc._id) {index("name", doc.name, '
+        '{"store": true}); }\n}'
+        ddoc.add_search_index('search001', index)
+        ddoc.add_search_index('search002', index)
+        ddoc.add_search_index('search003', index)
+        self.assertTrue(
+            all(x in ddoc.list_indexes() for x in [
+                'search001',
+                'search002',
+                'search003'
+            ])
+        )
+
+    def test_get_search_index(self):
+        """
+        Test retrieval of a search index from the DesignDocument.
+        """
+        ddoc = DesignDocument(self.db, '_design/ddoc001')
+        index = ('function (doc) {\n  index("default", doc._id); '
+                 'if (doc._id) {index("name", doc.name, '
+                 '{"store": true}); }\n}')
+        ddoc.add_search_index('search001', index)
+        ddoc.add_search_index('search002', index)
+        ddoc.add_search_index('search003', index)
+        self.assertEqual(
+            ddoc.get_index('search002'),
+            {'index': 'function (doc) {\n  index("default", doc._id); '
+                'if (doc._id) {index("name", doc.name, '
+                '{"store": true}); }\n}'}
+        )
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/index_tests.py
+++ b/tests/unit/index_tests.py
@@ -138,8 +138,9 @@ class IndexTests(UnitTestDbBase):
             self.assertEqual(ddoc,
                 {'_id': '_design/ddoc001',
                  '_rev': ddoc['_rev'],
+                 'indexes': {},
                  'language': 'query',
-                 'views': {'index001': {'map': {'fields': {'name': 'asc', 
+                 'views': {'index001': {'map': {'fields': {'name': 'asc',
                                                            'age': 'asc'}},
                                         'reduce': '_count',
                                         'options': {'def': {'fields': ['name',
@@ -164,8 +165,9 @@ class IndexTests(UnitTestDbBase):
             self.assertEqual(ddoc,
                 {'_id': index.design_document_id,
                  '_rev': ddoc['_rev'],
+                 'indexes': {},
                  'language': 'query',
-                 'views': {index.name: {'map': {'fields': {'name': 'asc', 
+                 'views': {index.name: {'map': {'fields': {'name': 'asc',
                                                            'age': 'asc'}},
                                         'reduce': '_count',
                                         'options': {'def': {'fields': ['name',
@@ -190,8 +192,9 @@ class IndexTests(UnitTestDbBase):
             self.assertEqual(ddoc,
                 {'_id': index.design_document_id,
                  '_rev': ddoc['_rev'],
+                 'indexes': {},
                  'language': 'query',
-                 'views': {index.name: {'map': {'fields': {'name': 'asc', 
+                 'views': {index.name: {'map': {'fields': {'name': 'asc',
                                                            'age': 'asc'}},
                                         'reduce': '_count',
                                         'options': {'def': {'fields': ['name',
@@ -216,8 +219,9 @@ class IndexTests(UnitTestDbBase):
             self.assertEqual(ddoc,
                 {'_id': '_design/ddoc001',
                  '_rev': ddoc['_rev'],
+                 'indexes': {},
                  'language': 'query',
-                 'views': {'index001': {'map': {'fields': {'name': 'asc', 
+                 'views': {'index001': {'map': {'fields': {'name': 'asc',
                                                            'age': 'asc'}},
                                         'reduce': '_count',
                                         'options': {'def': {'fields': ['name',
@@ -352,7 +356,7 @@ class IndexTests(UnitTestDbBase):
 
 @unittest.skipUnless(
     os.environ.get('RUN_CLOUDANT_TESTS') is not None,
-    'Skipping Cloudant Search Index tests'
+    'Skipping Cloudant Text Index tests'
     )
 class TextIndexTests(UnitTestDbBase):
     """


### PR DESCRIPTION
## What

Functions for managing Cloudant search index in design documents module. 

## How

- Added functions for search index management in `design_document.py`
- New indexes property for the locally cached DesignDocument in `design_document.py`

## Testing

Unit test cases to assert new search index management functions in `DesignDocumentTests`
Added `indexes` key with empty dictionary value to locally cached design documents in existing test case assertions.

## Reviewers

## Issues

fixes #159 
fixes #104 