### PR TITLE
Update readthedocs links

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 2.0.1 (Unreleased)
 ==================
 - [FIX] Fixed issue with Windows platform compatibility,replaced usage of os.uname for the user-agent string.
+- [FIX] Fixed readthedocs link in README.rst to resolve to documentation home page.
+- [IMPROVED] Updated documentation links from python-cloudant.readthedocs.org to python-cloudant.readthedocs.io.
 
 2.0.0 (2016-05-02)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -11,12 +11,12 @@ Cloudant Python Client
 .. |docs| image:: https://readthedocs.org/projects/pip/badge/
     :alt: docs
     :scale: 100%
-    :target: http://python-cloudant.readthedocs.org
+    :target: http://python-cloudant.readthedocs.io/en/latest/default.html
 
 .. |compatibility| image:: https://img.shields.io/badge/python-2.7%2C%203.5-blue.svg
     :alt: compatibility
     :scale: 100%
-    :target: http://python-cloudant.readthedocs.org/en/latest/compatibility.html
+    :target: http://python-cloudant.readthedocs.io/en/latest/compatibility.html
 
 This is the official Cloudant library for Python.
 
@@ -42,19 +42,19 @@ In order to install the latest version, execute
 Getting started
 ===============
 
-See `Getting started (readthedocs.org) <http://python-cloudant.readthedocs.org/en/latest/getting_started.html>`_
+See `Getting started (readthedocs.io) <http://python-cloudant.readthedocs.io/en/latest/getting_started.html>`_
 
 =============
 API Reference
 =============
 
-See `API reference docs (readthedocs.org) <http://python-cloudant.readthedocs.org/en/latest/cloudant.html>`_
+See `API reference docs (readthedocs.io) <http://python-cloudant.readthedocs.io/en/latest/cloudant.html>`_
 
 =====================
 Related Documentation
 =====================
 
-* `Cloudant Python client library docs (readthedocs.org) <http://python-cloudant.readthedocs.org>`_
+* `Cloudant Python client library docs (readthedocs.io) <http://python-cloudant.readthedocs.io>`_
 * `Cloudant documentation <http://docs.cloudant.com/>`_
 * `Cloudant for developers <https://cloudant.com/for-developers/>`_
 


### PR DESCRIPTION
## What

- Update the doc links in the README because readthedocs.org are moving the documentation sub-domains to readthedocs.io.

- The current link to the library documentation in the README.rst is set to http://python-cloudant.readthedocs.org. This resolves to http://python-cloudant.readthedocs.org/index.html which is actually our index module documentation. This link should go to the default.html documentation home page.

## How

- Update readthedocs link from index module to default documentation page
- Update doc links in README from readthedocs.org to readthedocs.io

## Testing

No test cases needed.

## Reviewers

## Issues
fixes #155 
fixes #161 