### PR TITLE
Rewrite rules property in design_document.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 ==================
 - [NEW] Added support for Cloudant Search execution.
 - [NEW] Added support for Cloudant Search index management.
+- [NEW] Added ``rewrites`` accessor property for URL rewriting.
 
 2.0.3 (2016-06-03)
 ==================

--- a/src/cloudant/design_document.py
+++ b/src/cloudant/design_document.py
@@ -48,6 +48,44 @@ class DesignDocument(Document):
         self.setdefault('indexes', dict())
 
     @property
+    def rewrites(self):
+        """
+        Provides an accessor property to a list of dictionaries with rewrite
+        rules in the locally cached DesignDocument.  Each rule for URL rewriting
+        is a JSON object with four fields: ``from``, ``to``, ``method``,
+        and ``query``.
+
+        Note: Requests that match the rewrite rules must have a URL path that
+        starts with ``/$DATABASE/_design/doc/_rewrite``.
+
+        Rewrite rule example:
+
+        .. code-block:: python
+
+            # Add the rule to ``rewrites`` and save the design document
+            ddoc = DesignDocument(self.db, '_design/ddoc001')
+            ddoc['rewrites'] = [
+                {"from": "/old/topic",
+                 "to": "/new/",
+                 "method": "GET",
+                 "query": {}
+                 }
+            ]
+            ddoc.save()
+
+        Once the rewrite rule is saved to the remote database, the GET
+        request URL ``/$DATABASE/_design/doc/_rewrite/old/topic?k=v`` would be
+        rewritten as ``/$DATABASE/_design/doc/_rewrite/new?k=v``.
+
+        For more details on URL rewriting, see the `rewrite rules
+        documentation <https://docs.cloudant.com/design_documents.html
+        #rewrite-rules>`_.
+
+        :returns: List of dictionaries containing rewrite rules as key/value
+        """
+        return self.get('rewrites')
+
+    @property
     def views(self):
         """
         Provides an accessor property to the View dictionary in the locally

--- a/tests/unit/design_document_tests.py
+++ b/tests/unit/design_document_tests.py
@@ -1035,5 +1035,31 @@ class DesignDocumentTests(UnitTestDbBase):
                 '{"store": true}); }\n}'}
         )
 
+    def test_rewrite_rule(self):
+        """
+        Test that design document URL is rewritten to the expected test document.
+        """
+        ddoc = DesignDocument(self.db, '_design/ddoc001')
+        ddoc['rewrites'] = [
+            {"from": "",
+             "to": "/../../rewrite_doc",
+             "method": "GET",
+             "query": {}
+             }
+        ]
+        self.assertIsInstance(ddoc.rewrites, list)
+        self.assertIsInstance(ddoc.rewrites[0], dict)
+        ddoc.save()
+        doc = Document(self.db, 'rewrite_doc')
+        doc.save()
+        resp = self.client.r_session.get('/'.join([ddoc.document_url, '_rewrite']))
+        self.assertEquals(
+            resp.json(),
+            {
+                '_id': 'rewrite_doc',
+                '_rev': doc['_rev']
+            }
+        )
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## What

Support URL rewriting with ``rewrites`` property in design document module. Documentation and an example are included with the property accessor.

## How

- Added ``rewrite`` accessor property with docstring that includes documentation

## Testing

Added test case for using ``rewrite`` property in DesignDocumentTests.
Created local sphinx build to review documentation.

## Reviewers

@tomblench

## Issues
fixes #175 