### PR TITLE
Move duplicated code to common_util.py

### DIFF
--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -234,6 +234,31 @@ def codify(code_or_str):
         return _Code(code_or_str)
     return code_or_str
 
+def get_docs(r_session, url, encoder=None, **params):
+    """
+    Provides a helper for functions that require GET or POST requests
+    with a JSON, text, or raw response containing documents.
+
+    :param r_session: Authentication session from the client
+    :param str url: URL containing the endpoint
+    :param JSONEncoder encoder: Custom encoder from the client
+
+    :returns: Raw response content from the specified endpoint
+    """
+    keys_list = params.pop('keys', None)
+    keys = None
+    if keys_list:
+        keys = json.dumps({'keys': keys_list}, cls=encoder)
+    f_params = python_to_couch(params)
+
+    resp = None
+    if keys:
+        resp = r_session.post(url, params=f_params, data=keys)
+    else:
+        resp = r_session.get(url, params=f_params)
+    resp.raise_for_status()
+    return resp
+
 # Classes
 
 class _Code(str):

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -27,8 +27,7 @@ from ._common_util import (
     SEARCH_INDEX_ARGS,
     SPECIAL_INDEX_TYPE,
     TEXT_INDEX_TYPE,
-    python_to_couch
-)
+    get_docs)
 from .document import Document
 from .design_document import DesignDocument
 from .view import View
@@ -363,16 +362,10 @@ class CouchDatabase(dict):
         :returns: Raw JSON response content from ``_all_docs`` endpoint
 
         """
-        all_docs_url = posixpath.join(self.database_url, '_all_docs')
-        params = python_to_couch(kwargs)
-        keys_list = params.pop('keys', None)
-        resp = None
-        if keys_list:
-            keys = json.dumps({'keys': keys_list})
-            resp = self.r_session.post(all_docs_url, params=params, data=keys)
-        else:
-            resp = self.r_session.get(all_docs_url, params=params)
-        resp.raise_for_status()
+        resp = get_docs(self.r_session,
+                        '/'.join([self.database_url, '_all_docs']),
+                        self.client.encoder,
+                        **kwargs)
         return resp.json()
 
     @contextlib.contextmanager

--- a/src/cloudant/document.py
+++ b/src/cloudant/document.py
@@ -64,7 +64,7 @@ class Document(dict):
         self._document_id = document_id
         if self._document_id is not None:
             self['_id'] = self._document_id
-        self._encoder = self._client.encoder
+        self.encoder = self._client.encoder
 
     @property
     def document_url(self):
@@ -112,7 +112,7 @@ class Document(dict):
 
         :returns: Encoded JSON string containing the document data
         """
-        return json.dumps(dict(self), cls=self._encoder)
+        return json.dumps(dict(self), cls=self.encoder)
 
     def create(self):
         """
@@ -132,7 +132,7 @@ class Document(dict):
         resp = self.r_session.post(
             self._database.database_url,
             headers=headers,
-            data=json.dumps(doc, cls=self._encoder)
+            data=json.dumps(doc, cls=self.encoder)
         )
         resp.raise_for_status()
         data = resp.json()

--- a/src/cloudant/view.py
+++ b/src/cloudant/view.py
@@ -17,10 +17,9 @@ API module for interacting with a view in a design document.
 """
 import contextlib
 import posixpath
-import json
 
 from ._2to3 import STRTYPE
-from ._common_util import python_to_couch, codify
+from ._common_util import codify, get_docs
 from .result import Result
 from .error import CloudantArgumentError, CloudantException
 
@@ -225,15 +224,10 @@ class View(dict):
 
         :returns: View result data in JSON format
         """
-        params = python_to_couch(kwargs)
-        keys_list = params.pop('keys', None)
-        resp = None
-        if keys_list:
-            keys = json.dumps({'keys': keys_list})
-            resp = self._r_session.post(self.url, params=params, data=keys)
-        else:
-            resp = self._r_session.get(self.url, params=params)
-        resp.raise_for_status()
+        resp = get_docs(self._r_session,
+                        self.url,
+                        self.design_doc.encoder,
+                        **kwargs)
         return resp.json()
 
     @contextlib.contextmanager


### PR DESCRIPTION
## What

There's an almost identical block of code in `View.__call__` and `database.all_docs` that's been moved into `get_docs` method in the common_util module.
The new common util `get_docs` method also accepts `encoder` for use with a custom ``JSONEncoder`` subclass.
## How

- Moved duplicated code for GET/POST request to internal method `get_docs`
- Changed visibility of `Document` attribute `encoder` for use in  `View.__call__`

## Testing

No new test cases required. 

## Reviewers

## Issues

fixes #182 
fixes #170 