### PR TITLE
Made 429 replays optional and configurable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,12 @@
 - [NEW] Added support for Cloudant Search execution.
 - [NEW] Added support for Cloudant Search index management.
 - [NEW] Added ``rewrites`` accessor property for URL rewriting.
+- [NEW] Added support for a custom ``requests.HTTPAdapter`` to be configured using an optional ``adapter`` arg e.g.
+  ``Cloudant(USERNAME, PASSWORD, account=ACCOUNT_NAME, adapter=Replay429Adapter())``.
+- [IMPROVED] Made the 429 response code backoff optional and configurable. To enable the backoff add
+  an ``adapter`` arg of a ``Replay429Adapter`` with the desired number of retries and initial backoff. To replicate
+  the 2.0.0 behaviour use: ``adapter=Replay429Adapter(retries=10, initialBackoff=0.25)``. If ``retries`` or
+  ``initialBackoff`` are not specified they will default to 3 retries and a 0.25 s initial backoff.
 
 2.0.3 (2016-06-03)
 ==================

--- a/docs/adapters.rst
+++ b/docs/adapters.rst
@@ -1,0 +1,8 @@
+adapters
+========
+
+.. automodule:: cloudant.adapters
+    :members:
+    :undoc-members:
+    :special-members: __getitem__, __iter__
+    :show-inheritance:

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -15,3 +15,4 @@ Modules
    replicator
    feed
    error
+   adapters

--- a/src/cloudant/adapters.py
+++ b/src/cloudant/adapters.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright © 2016 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Module that contains default transport adapters for use with requests.
+"""
+from requests.adapters import HTTPAdapter
+
+from requests.packages.urllib3.util import Retry
+
+class Replay429Adapter(HTTPAdapter):
+    """
+    A requests TransportAdapter that extends the default HTTPAdapter with configuration
+    to replay requests that receive a 429 Too Many Requests response from the server.
+    The duration of the sleep between requests will be doubled for each 429 response
+    received.
+
+    Parameters can be passed in to control behavior:
+
+    :param int retries: the number of times the request can be replayed before failing.
+    :param float initialBackoff: time in seconds for the first backoff.
+    """
+    def __init__(self, retries=3, initialBackoff=0.25):
+        super(Replay429Adapter, self).__init__(max_retries=Retry(
+            # Configure the number of retries for status codes
+            total=retries,
+            # No retries for connect|read errors
+            connect=0,
+            read=0,
+            # Allow retries for all the CouchDB HTTP method types
+            method_whitelist=frozenset(['GET', 'HEAD', 'PUT', 'POST',
+                                        'DELETE', 'COPY']),
+            # Only retry for a 429 too many requests status code
+            status_forcelist=[429],
+            # Configure the start value of the doubling backoff
+            backoff_factor=initialBackoff))

--- a/tests/unit/adapter_tests.py
+++ b/tests/unit/adapter_tests.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright © 2016 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from cloudant.client import CouchDB
+from cloudant.adapters import Replay429Adapter
+from requests.packages.urllib3.util import Retry
+from .unit_t_db_base import UnitTestDbBase
+
+class AdapterTests(UnitTestDbBase):
+    """
+    Unit tests for transport adapters
+    """
+
+    def test_new_Replay429Adapter(self):
+        """
+        Test that a new Replay429Adapter is accepted as a parameter for a client.
+        """
+        self.client = CouchDB(
+            self.user,
+            self.pwd,
+            url=self.url,
+            adapter=Replay429Adapter())
+
+    def test_retries_arg_Replay429Adapter(self):
+        """
+        Test constructing a new Replay429Adapter with a configured number of retries.
+        """
+        self.client = CouchDB(
+            self.user,
+            self.pwd,
+            url=self.url,
+            adapter=Replay429Adapter(retries=10))
+
+
+
+    def test_backoff_arg_Replay429Adapter(self):
+        """
+        Test constructing a new Replay429Adapter with a configured initial backoff.
+        """
+        self.client = CouchDB(
+            self.user,
+            self.pwd,
+            url=self.url,
+            adapter=Replay429Adapter(initialBackoff=0.1))
+
+    def test_args_Replay429Adapter(self):
+        """
+        Test constructing a new Replay429Adapter with configured retries and initial backoff.
+        """
+        self.client = CouchDB(
+            self.user,
+            self.pwd,
+            url=self.url,
+            adapter=Replay429Adapter(retries=10, initialBackoff=0.01))


### PR DESCRIPTION
## What

Made 429 replays optional and configurable.

## Why

Some users would prefer to receive an error earlier than the current 429 replay behaviour.

## How

Added support for `adapter` argument on client constructors.
Moved 429 `HTTPAdapter` configuration into `Replay429Adapter` class in
`cloudant.adapters`.
Added `retries` and `initialBackoff` args to `Replay429Adapter`.
Updated docs including `CHANGES.rst` and for new `adapters` module.

## Testing
Added tests for init and adding adapter with `Replay429Adapter` and args.
Manually tested that the behaviour is as expected with a 429 response.

