### PR TITLE
Added support for list functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 ==================
 - [NEW] Added support for Cloudant Search execution.
 - [NEW] Added support for Cloudant Search index management.
+- [NEW] Added support for managing and querying list functions.
 - [NEW] Added ``rewrites`` accessor property for URL rewriting.
 - [NEW] Added support for a custom ``requests.HTTPAdapter`` to be configured using an optional ``adapter`` arg e.g.
   ``Cloudant(USERNAME, PASSWORD, account=ACCOUNT_NAME, adapter=Replay429Adapter())``.

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -234,7 +234,7 @@ def codify(code_or_str):
         return _Code(code_or_str)
     return code_or_str
 
-def get_docs(r_session, url, encoder=None, **params):
+def get_docs(r_session, url, encoder=None, headers=None, **params):
     """
     Provides a helper for functions that require GET or POST requests
     with a JSON, text, or raw response containing documents.
@@ -242,6 +242,7 @@ def get_docs(r_session, url, encoder=None, **params):
     :param r_session: Authentication session from the client
     :param str url: URL containing the endpoint
     :param JSONEncoder encoder: Custom encoder from the client
+    :param dict headers: Optional HTTP Headers to send with the request
 
     :returns: Raw response content from the specified endpoint
     """
@@ -253,9 +254,9 @@ def get_docs(r_session, url, encoder=None, **params):
 
     resp = None
     if keys:
-        resp = r_session.post(url, params=f_params, data=keys)
+        resp = r_session.post(url, headers=headers, params=f_params, data=keys)
     else:
-        resp = r_session.get(url, params=f_params)
+        resp = r_session.get(url, headers=headers, params=f_params)
     resp.raise_for_status()
     return resp
 

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -762,6 +762,49 @@ class CouchDatabase(dict):
 
         return resp.json()
 
+    def get_list_function_result(self, ddoc_id, list_name, view_name, **kwargs):
+        """
+        Retrieves a customized MapReduce view result from the specified
+        database based on the list function provided.  List functions are
+        used, for example,  when you want to access Cloudant directly
+        from a browser, and need data to be returned in a different
+        format, such as HTML.
+
+        Note: All query parameters for View requests are supported.
+        See :class:`~cloudant.database.get_view_result` for
+        all supported query parameters.
+
+        For example:
+
+        .. code-block:: python
+
+            # Assuming that 'view001' exists as part of the
+            # 'ddoc001' design document in the remote database...
+            # Retrieve documents where the list function is 'list1'
+            resp = db.get_list_result('ddoc001', 'list1', 'view001', limit=10)
+            for row in resp['rows']:
+                # Process data (in text format).
+
+        For more detail on list functions, refer to the
+        `Cloudant documentation <https://docs.cloudant.com/
+        design_documents.html#list-functions>`_.
+
+        :param str ddoc_id: Design document id used to get result.
+        :param str list_name: Name used in part to identify the
+            list function.
+        :param str view_name: Name used in part to identify the view.
+
+        :return: Formatted view result data in text format
+        """
+        ddoc = DesignDocument(self, ddoc_id)
+        headers = {'Content-Type': 'application/json'}
+        resp = get_docs(self.r_session,
+                        '/'.join([ddoc.document_url, '_list', list_name, view_name]),
+                        self.client.encoder,
+                        headers,
+                        **kwargs)
+        return resp.text
+
 class CloudantDatabase(CouchDatabase):
     """
     Encapsulates a Cloudant database.  A CloudantDatabase object is

--- a/tests/unit/index_tests.py
+++ b/tests/unit/index_tests.py
@@ -145,7 +145,9 @@ class IndexTests(UnitTestDbBase):
                                         'reduce': '_count',
                                         'options': {'def': {'fields': ['name',
                                                                        'age']},
-                                                    'w': 2}}}}
+                                                    'w': 2}}},
+                 'lists': {}
+                 }
             )
 
     def test_create_an_index_without_ddoc_index_name(self):
@@ -172,7 +174,9 @@ class IndexTests(UnitTestDbBase):
                                         'reduce': '_count',
                                         'options': {'def': {'fields': ['name',
                                                                        'age']},
-                                                    'w': 2}}}}
+                                                    'w': 2}}},
+                 'lists': {}
+                 }
             )
 
     def test_create_an_index_with_empty_ddoc_index_name(self):
@@ -199,7 +203,9 @@ class IndexTests(UnitTestDbBase):
                                         'reduce': '_count',
                                         'options': {'def': {'fields': ['name',
                                                                        'age']},
-                                                    'w': 2}}}}
+                                                    'w': 2}}},
+                 'lists': {}
+                 }
             )
 
     def test_create_an_index_using_design_prefix(self):
@@ -226,7 +232,9 @@ class IndexTests(UnitTestDbBase):
                                         'reduce': '_count',
                                         'options': {'def': {'fields': ['name',
                                                                        'age']},
-                                                    'w': 2}}}}
+                                                    'w': 2}}},
+                 'lists': {}
+                 }
             )
 
     def test_create_fails_due_to_ddocid_validation(self):
@@ -427,7 +435,9 @@ class TextIndexTests(UnitTestDbBase):
                                 'selector': {}},
                       'analyzer': {'name': 'perfield',
                                    'default': 'keyword',
-                                   'fields': {'$default': 'standard'}}}}}
+                                   'fields': {'$default': 'standard'}}}},
+                 'lists': {}
+                 }
             )
 
     def test_create_a_search_index_with_kwargs(self):
@@ -464,7 +474,9 @@ class TextIndexTests(UnitTestDbBase):
                                 'selector': {}},
                       'analyzer': {'name': 'perfield',
                                    'default': 'keyword',
-                                   'fields': {'$default': 'german'}}}}}
+                                   'fields': {'$default': 'german'}}}},
+                 'lists': {}
+                 }
             )
 
     def test_create_a_search_index_invalid_argument(self):


### PR DESCRIPTION
## What

Add support for managing and querying list functions.
Avoid repeating if statements for each property in design document’s `save` and `fetch` functions by looping through a set containing the properties.

## How

- Handled list function execution against the _list endpoint in CouchDatabase.get_list_result
- Added support for managing list functions in design document
- Added HTTP Headers argument to `get_docs` method signature
- Replaced repeating if statements for each property with for-loop over a set of all properties

## Testing

Unit test cases to assert new list function management in DesignDocumentTests.
Unit test cases to assert `get_list_result` in DatabaseTests.


## Reviewers

## Issues
fixes #178 