### PR TITLE
Cloudant Geo property in design_document.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@
 - [NEW] Added support for Cloudant Search index management.
 - [NEW] Added support for managing and querying list functions.
 - [NEW] Added ``rewrites`` accessor property for URL rewriting.
+- [NEW] Added ``st_indexes`` accessor property for Cloudant Geospatial indexes.
 - [NEW] Added support for DesignDocument ``_info`` and ``_search_info`` endpoints.
 - [NEW] Added support for a custom ``requests.HTTPAdapter`` to be configured using an optional ``adapter`` arg e.g.
   ``Cloudant(USERNAME, PASSWORD, account=ACCOUNT_NAME, adapter=Replay429Adapter())``.

--- a/src/cloudant/design_document.py
+++ b/src/cloudant/design_document.py
@@ -49,6 +49,46 @@ class DesignDocument(Document):
             self.setdefault(prop, dict())
 
     @property
+    def st_indexes(self):
+        """
+        Provides an accessor property to the Cloudant Geospatial
+        (a.k.a. Cloudant Geo) indexes dictionary in the locally cached
+        DesignDocument.  Each Cloudant Geo index is a JSON object within the
+        ``st_indexes`` containing an index name and a javascript function.
+
+        Note: To make it easier to work with Cloudant Geo documents, it is best
+        practice to create a separate design document specifically for
+        Cloudant Geo indexes.
+
+        Geospatial index example:
+
+        .. code-block:: python
+
+            # Add the Cloudant Geo index to ``st_indexes`` and save the design document
+            ddoc = DesignDocument(self.db, '_design/ddoc001')
+            ddoc['st_indexes'] = {
+                'geoidx': {
+                    'index': 'function(doc) { '
+                             'if (doc.geometry && doc.geometry.coordinates) { '
+                             'st_index(doc.geometry);}} '
+                }
+            }
+            ddoc.save()
+
+        Once the Cloudant Geo index is saved to the remote database, you can
+        query the index with a GET request.  To issue a request against the
+        ``_geo`` endpoint, see the steps outlined in the `endpoint access
+        documentation <getting_started.html#endpoint-access>`_.
+
+        For more details, see the `Cloudant Geospatial
+        documentation <https://docs.cloudant.com/geo.html>`_.
+
+        :return: Dictionary containing Cloudant Geo names and index objects
+            as key/value
+        """
+        return self.get('st_indexes')
+
+    @property
     def lists(self):
         """
         Provides an accessor property to the lists dictionary in the locally


### PR DESCRIPTION
## What

Support geospatial indexes (Cloudant Geo) with ``st_indexes`` property in design document module.
Documentation and examples are included with the property accessor.

## How

- Added Cloudant Geo st_indexes property with documentation and example

## Testing

Added test case in DesignDocumentTests.
Created local sphinx build to review documentation.

## Reviewers
## Issues
fixes #188 