### PR TITLE
Added support for show functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 - [NEW] Added support for Cloudant Search execution.
 - [NEW] Added support for Cloudant Search index management.
 - [NEW] Added support for managing and querying list functions.
+- [NEW] Added support for managing and querying show functions.
 - [NEW] Added ``rewrites`` accessor property for URL rewriting.
 - [NEW] Added ``st_indexes`` accessor property for Cloudant Geospatial indexes.
 - [NEW] Added support for DesignDocument ``_info`` and ``_search_info`` endpoints.

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -805,6 +805,43 @@ class CouchDatabase(dict):
                         **kwargs)
         return resp.text
 
+    def get_show_function_result(self, ddoc_id, show_name, doc_id):
+        """
+        Retrieves a formatted document from the specified database
+        based on the show function provided.  Show functions, for example,
+        are used when you want to access Cloudant directly from a browser,
+        and need data to be returned in a different format, such as HTML.
+
+        For example:
+
+        .. code-block:: python
+
+            # Assuming that 'view001' exists as part of the
+            # 'ddoc001' design document in the remote database...
+            # Retrieve a formatted 'doc001' document where the show function is 'show001'
+            resp = db.get_show_function_result('ddoc001', 'show001', 'doc001')
+            for row in resp['rows']:
+                # Process data (in text format).
+
+        For more detail on show functions, refer to the
+        `Cloudant documentation <https://docs.cloudant.com/
+        design_documents.html#show-functions>`_.
+
+        :param str ddoc_id: Design document id used to get the result.
+        :param str show_name: Name used in part to identify the
+            show function.
+        :param str doc_id: The ID of the document to show.
+
+        :return: Formatted document result data in text format
+        """
+        ddoc = DesignDocument(self, ddoc_id)
+        headers = {'Content-Type': 'application/json'}
+        resp = get_docs(self.r_session,
+                        '/'.join([ddoc.document_url, '_show', show_name, doc_id]),
+                        self.client.encoder,
+                        headers)
+        return resp.text
+
 class CloudantDatabase(CouchDatabase):
     """
     Encapsulates a Cloudant database.  A CloudantDatabase object is

--- a/tests/unit/index_tests.py
+++ b/tests/unit/index_tests.py
@@ -146,7 +146,8 @@ class IndexTests(UnitTestDbBase):
                                         'options': {'def': {'fields': ['name',
                                                                        'age']},
                                                     'w': 2}}},
-                 'lists': {}
+                 'lists': {},
+                 'shows': {}
                  }
             )
 
@@ -175,7 +176,8 @@ class IndexTests(UnitTestDbBase):
                                         'options': {'def': {'fields': ['name',
                                                                        'age']},
                                                     'w': 2}}},
-                 'lists': {}
+                 'lists': {},
+                 'shows': {}
                  }
             )
 
@@ -204,7 +206,8 @@ class IndexTests(UnitTestDbBase):
                                         'options': {'def': {'fields': ['name',
                                                                        'age']},
                                                     'w': 2}}},
-                 'lists': {}
+                 'lists': {},
+                 'shows': {}
                  }
             )
 
@@ -233,7 +236,8 @@ class IndexTests(UnitTestDbBase):
                                         'options': {'def': {'fields': ['name',
                                                                        'age']},
                                                     'w': 2}}},
-                 'lists': {}
+                 'lists': {},
+                 'shows': {}
                  }
             )
 
@@ -436,7 +440,8 @@ class TextIndexTests(UnitTestDbBase):
                       'analyzer': {'name': 'perfield',
                                    'default': 'keyword',
                                    'fields': {'$default': 'standard'}}}},
-                 'lists': {}
+                 'lists': {},
+                 'shows': {}
                  }
             )
 
@@ -475,7 +480,8 @@ class TextIndexTests(UnitTestDbBase):
                       'analyzer': {'name': 'perfield',
                                    'default': 'keyword',
                                    'fields': {'$default': 'german'}}}},
-                 'lists': {}
+                 'lists': {},
+                 'shows': {}
                  }
             )
 


### PR DESCRIPTION
## What

Add support for managing and querying show functions.

## How

- Handled show function execution against the _show endpoint in `CouchDatabase.get_show_function_result`
- Added support for managing show functions in design document

## Testing

Unit test cases to assert show function management in DesignDocumentTests.
Unit test cases to assert `get_show_function_result` in DatabaseTests.

## Reviewers

## Issues
fixes #186 