### PR TITLE
Added support for update validators

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@
 - [NEW] Added ``rewrites`` accessor property for URL rewriting.
 - [NEW] Added ``st_indexes`` accessor property for Cloudant Geospatial indexes.
 - [NEW] Added support for DesignDocument ``_info`` and ``_search_info`` endpoints.
+- [NEW] Added ``validate_doc_update`` accessor property for update validators.
 - [NEW] Added support for a custom ``requests.HTTPAdapter`` to be configured using an optional ``adapter`` arg e.g.
   ``Cloudant(USERNAME, PASSWORD, account=ACCOUNT_NAME, adapter=Replay429Adapter())``.
 - [IMPROVED] Made the 429 response code backoff optional and configurable. To enable the backoff add

--- a/src/cloudant/design_document.py
+++ b/src/cloudant/design_document.py
@@ -49,6 +49,32 @@ class DesignDocument(Document):
             self.setdefault(prop, dict())
 
     @property
+    def validate_doc_update(self):
+        """
+        Provides an accessor property to the update validators dictionary in
+        the locally cached DesignDocument.  Update validators evaluate whether a
+        document should be written to disk when insertions and updates are attempted.
+
+        Update validator example:
+
+        .. code-block:: python
+
+            # Add the update validator to ``validate_doc_update`` and save the design document
+            ddoc = DesignDocument(self.db, '_design/ddoc001')
+            ddoc['validate_doc_update'] = (
+                'function(newDoc, oldDoc, userCtx, secObj) { '
+                'if (newDoc.address === undefined) { '
+                'throw({forbidden: \'Document must have an address.\'}); }}')
+            ddoc.save()
+
+        For more details, see the `Update Validators documentation
+        <https://docs.cloudant.com/design_documents.html#update-validators>`_.
+
+        :returns: Dictionary containing update validator functions
+        """
+        return self.get('validate_doc_update')
+
+    @property
     def updates(self):
         """
         Provides an accessor property to the updates dictionary in the locally


### PR DESCRIPTION
## What

Support update validators with ``validate_doc_update`` property in design document module.
Documentation and an example are included with the property accessor.

## How

- Added ``validate_doc_update`` property with documentation

## Testing

Added unit test in DesignDocumentTests.

## Reviewers
## Issues
fixes #197 