### PR TITLE
Added Content-Type header for keys POST cases.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@
   an ``adapter`` arg of a ``Replay429Adapter`` with the desired number of retries and initial backoff. To replicate
   the 2.0.0 behaviour use: ``adapter=Replay429Adapter(retries=10, initialBackoff=0.25)``. If ``retries`` or
   ``initialBackoff`` are not specified they will default to 3 retries and a 0.25 s initial backoff.
+- [FIX] ``415 Client Error: Unsupported Media Type`` when using keys with ``db.all_docs``.
 
 2.0.3 (2016-06-03)
 ==================

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -251,9 +251,12 @@ def get_docs(r_session, url, encoder=None, headers=None, **params):
     if keys_list:
         keys = json.dumps({'keys': keys_list}, cls=encoder)
     f_params = python_to_couch(params)
-
     resp = None
     if keys:
+        # If we're using POST we are sending JSON so add the header
+        if headers is None:
+            headers = {}
+        headers['Content-Type'] = 'application/json'
         resp = r_session.post(url, headers=headers, params=f_params, data=keys)
     else:
         resp = r_session.get(url, headers=headers, params=f_params)


### PR DESCRIPTION
## What

Added Content-Type header to requests using POST for the keys param.

## How

Added `Content-Type: application/json` to `headers` in `src.cloudant._common_util.get_docs`.

## Testing

This is covered by existing tests:
`tests.unit.database_tests.DatabaseTests#test_all_docs_post`
`tests.unit.database_tests.DatabaseTests#test_all_docs_post_multiple_params`

## Issues

Fixes #177