### PR TITLE
205 cloudant tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@
   the 2.0.0 behaviour use: ``adapter=Replay429Adapter(retries=10, initialBackoff=0.25)``. If ``retries`` or
   ``initialBackoff`` are not specified they will default to 3 retries and a 0.25 s initial backoff.
 - [FIX] ``415 Client Error: Unsupported Media Type`` when using keys with ``db.all_docs``.
+- [FIX] Allowed strings as well as lists for search ``group_sort`` arguments.
 
 2.0.3 (2016-06-03)
 ==================

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -120,7 +120,7 @@ SEARCH_INDEX_ARGS = {
     'drilldown': list,
     'group_field': STRTYPE,
     'group_limit': (int, NONETYPE),
-    'group_sort': list,
+    'group_sort': (STRTYPE, list),
     'include_docs': bool,
     'limit': (int, NONETYPE),
     'query': (STRTYPE, int),

--- a/tests/unit/client_tests.py
+++ b/tests/unit/client_tests.py
@@ -26,7 +26,7 @@ import json
 import base64
 import sys
 import os
-from datetime import datetime
+import datetime
 
 from cloudant import cloudant, couchdb, couchdb_admin_party
 from cloudant.client import Cloudant, CouchDB
@@ -471,17 +471,19 @@ class CloudantClientTests(UnitTestDbBase):
         """
         try:
             self.client.connect()
+            now = datetime.datetime.now()
             expected = [
                 'data_volume',
                 'total',
                 'start',
                 'end',
                 'http_heavy',
-                'http_light'
+                'http_light',
+                'bill_type'
                 ]
             # Test using year and month
-            year = 2016
-            month = 1
+            year = now.year
+            month = now.month
             data = self.client.bill(year, month)
             self.assertTrue(all(x in expected for x in data.keys()))
             #Test without year and month arguments
@@ -563,6 +565,7 @@ class CloudantClientTests(UnitTestDbBase):
         """
         try:
             self.client.connect()
+            now = datetime.datetime.now()
             expected = [
                 'data_vol',
                 'granularity',
@@ -570,8 +573,8 @@ class CloudantClientTests(UnitTestDbBase):
                 'end'
                 ]
             # Test using year and month
-            year = 2016
-            month = 12
+            year = now.year
+            month = now.month
             data = self.client.volume_usage(year, month)
             self.assertTrue(all(x in expected for x in data.keys()))
             #Test without year and month arguments
@@ -653,6 +656,7 @@ class CloudantClientTests(UnitTestDbBase):
         """
         try:
             self.client.connect()
+            now = datetime.datetime.now()
             expected = [
                 'requests',
                 'granularity',
@@ -660,8 +664,8 @@ class CloudantClientTests(UnitTestDbBase):
                 'end'
                 ]
             # Test using year and month
-            year = 2016
-            month = 1
+            year = now.year
+            month = now.month
             data = self.client.requests_usage(year, month)
             self.assertTrue(all(x in expected for x in data.keys()))
             #Test without year and month arguments

--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -1278,6 +1278,7 @@ class CloudantDatabaseTests(UnitTestDbBase):
             'searchddoc001',
             'searchindex001',
             query='julia*',
+            sort='_id<string>',
             limit=5,
             include_docs=True
         )
@@ -1292,23 +1293,23 @@ class CloudantDatabaseTests(UnitTestDbBase):
             {'rows': [{'fields': {'name': 'julia'}, 'doc': {'_id': 'julia000',
                                                             'age': 0,
                                                             'name': 'julia'},
-                       'id': 'julia000', 'order': [1.0, 0]},
+                       'id': 'julia000', 'order': ['julia000', 0]},
                       {'fields': {'name': 'julia'}, 'doc': {'_id': 'julia001',
                                                             'age': 1,
                                                             'name': 'julia'},
-                       'id': 'julia001', 'order': [1.0, 0]},
+                       'id': 'julia001', 'order': ['julia001', 0]},
                       {'fields': {'name': 'julia'},'doc': {'_id': 'julia002',
                                                            'age': 2,
                                                            'name': 'julia'},
-                       'id': 'julia002', 'order': [1.0, 0]},
-                      {'fields': {'name': 'julia'}, 'doc': {'_id': 'julia004',
-                                                            'age': 4,
+                       'id': 'julia002', 'order': ['julia002', 0]},
+                      {'fields': {'name': 'julia'}, 'doc': {'_id': 'julia003',
+                                                            'age': 3,
                                                             'name': 'julia'},
-                       'id': 'julia004', 'order': [1.0, 1]},
+                       'id': 'julia003', 'order': ['julia003', 0]},
                       {'fields': {'name': 'julia'},
-                       'doc': {'_id': 'julia005', 'age': 5,
+                       'doc': {'_id': 'julia004', 'age': 4,
                                'name': 'julia'},
-                       'id': 'julia005', 'order': [1.0, 1]}], 'total_rows': 100}
+                       'id': 'julia004', 'order': ['julia004', 1]}], 'total_rows': 100}
         )
 
     def test_get_search_result_executes_search_query_with_group_option(self):
@@ -1322,7 +1323,8 @@ class CloudantDatabaseTests(UnitTestDbBase):
             'searchindex001',
             query='name:julia*',
             group_field='_id',
-            group_limit=5
+            group_limit=5,
+            group_sort='_id<string>'
         )
         # for group parameter options, 'rows' results are within 'groups' key
         self.assertEqual(len(resp['groups']), 5)
@@ -1332,18 +1334,18 @@ class CloudantDatabaseTests(UnitTestDbBase):
                 {'rows': [{'fields': {'name': 'julia'}, 'id': 'julia000',
                            'order': [1.0, 0]}], 'total_rows': 1,
                  'by': 'julia000'},
+                {'rows': [{'fields': {'name': 'julia'}, 'id': 'julia001',
+                           'order': [1.0, 0]}], 'total_rows': 1,
+                 'by': 'julia001'},
+                {'rows': [{'fields': {'name': 'julia'}, 'id': 'julia002',
+                           'order': [1.0, 0]}], 'total_rows': 1,
+                 'by': 'julia002'},
+                {'rows': [{'fields': {'name': 'julia'}, 'id': 'julia003',
+                           'order': [1.0, 0]}], 'total_rows': 1,
+                 'by': 'julia003'},
                 {'rows': [{'fields': {'name': 'julia'}, 'id': 'julia004',
                            'order': [1.0, 1]}], 'total_rows': 1,
-                 'by': 'julia004'},
-                {'rows': [{'fields': {'name': 'julia'}, 'id': 'julia008',
-                           'order': [1.0, 2]}], 'total_rows': 1,
-                 'by': 'julia008'},
-                {'rows': [{'fields': {'name': 'julia'}, 'id': 'julia010',
-                           'order': [1.0, 3]}], 'total_rows': 1,
-                 'by': 'julia010'},
-                {'rows': [{'fields': {'name': 'julia'}, 'id': 'julia014',
-                           'order': [1.0, 4]}], 'total_rows': 1,
-                 'by': 'julia014'}
+                 'by': 'julia004'}
             ]}
         )
 

--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -987,7 +987,7 @@ class CloudantDatabaseTests(UnitTestDbBase):
                                         'reduce': '_count',
                                         'options': {'def': {'fields': ['name',
                                                                        'age']},
-                                                    'w': 2}}}}
+                                                    }}}}
             )
 
     def test_create_text_index(self):
@@ -1078,7 +1078,7 @@ class CloudantDatabaseTests(UnitTestDbBase):
                                         'reduce': '_count',
                                         'options': {'def': {'fields': ['name',
                                                                        'age']},
-                                                    'w': 2}}},
+                                                    }}},
                  'indexes': {'text-index-001': {
                                 'index': {'index_array_lengths': True,
                                 'fields': [{'name': 'name', 'type': 'string'},

--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -1217,7 +1217,7 @@ class CloudantDatabaseTests(UnitTestDbBase):
             {'drilldown': 'blah'},              # Should be a list
             {'group_field': ['blah']},          # Should be a STRTYPE
             {'group_limit': 'int'},             # Should be an int
-            {'group_sort': 'blah'},             # Should be a list
+            {'group_sort': 3},                  # Should be a STRTYPE or list
             {'include_docs': 'blah'},           # Should be a boolean
             {'limit': 'blah'},                  # Should be an int
             {'ranges': 1},                      # Should be a dict

--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -1175,7 +1175,8 @@ class CloudantDatabaseTests(UnitTestDbBase):
                          'default_field': {},
                          'default_analyzer': 'keyword',
                          'selector': {}}}
-            ]}
+            ],
+            'total_rows' : 3}
         )
 
     def test_get_query_indexes(self):

--- a/tests/unit/index_tests.py
+++ b/tests/unit/index_tests.py
@@ -145,7 +145,7 @@ class IndexTests(UnitTestDbBase):
                                         'reduce': '_count',
                                         'options': {'def': {'fields': ['name',
                                                                        'age']},
-                                                    'w': 2}}},
+                                                   }}},
                  'lists': {},
                  'shows': {}
                  }
@@ -175,7 +175,7 @@ class IndexTests(UnitTestDbBase):
                                         'reduce': '_count',
                                         'options': {'def': {'fields': ['name',
                                                                        'age']},
-                                                    'w': 2}}},
+                                                   }}},
                  'lists': {},
                  'shows': {}
                  }
@@ -205,7 +205,7 @@ class IndexTests(UnitTestDbBase):
                                         'reduce': '_count',
                                         'options': {'def': {'fields': ['name',
                                                                        'age']},
-                                                    'w': 2}}},
+                                                   }}},
                  'lists': {},
                  'shows': {}
                  }
@@ -235,7 +235,7 @@ class IndexTests(UnitTestDbBase):
                                         'reduce': '_count',
                                         'options': {'def': {'fields': ['name',
                                                                        'age']},
-                                                    'w': 2}}},
+                                                   }}},
                  'lists': {},
                  'shows': {}
                  }

--- a/tests/unit/index_tests.py
+++ b/tests/unit/index_tests.py
@@ -351,20 +351,15 @@ class IndexTests(UnitTestDbBase):
 
     def test_index_usage_via_query(self):
         """
-        Test that a query will fail if the indexes that exist do not satisfy the
+        Test that a query will warn if the indexes that exist do not satisfy the
         query selector.
         """
         index = Index(self.db, 'ddoc001', 'index001', fields=['name'])
         index.create()
         self.populate_db_with_documents(100)
-        query = Query(self.db)
-        with self.assertRaises(requests.HTTPError) as cm:
-            resp = query(
-                fields=['name', 'age'],
-                selector={'age': {'$eq': 6}}
-            )
-        err = cm.exception
-        self.assertEqual(err.response.status_code, 400)
+        result = self.db.get_query_result(fields=['name', 'age'],
+                selector={'age': {'$eq': 6}}, raw_result=True)
+        self.assertTrue(str(result['warning']).startswith("no matching index found"))
 
 @unittest.skipUnless(
     os.environ.get('RUN_CLOUDANT_TESTS') is not None,

--- a/tests/unit/result_tests.py
+++ b/tests/unit/result_tests.py
@@ -463,22 +463,14 @@ class ResultTests(UnitTestDbBase):
     def test_get_item_key_slice_start_greater_than_stop(self):
         """
         Test getting a key slice by using start value greater than stop value.
-        The behavior when using CouchDB is to return an HTTP 400 Bad Request
-        error whereas with Cloudant an empty result collection is returned.
-        Unfortunately a 400 response cannot definitively be attributed to a
-        startkey value being greater than an endkey value so the decision to
-        leave this CouchDB/Cloudant behavior inconsistency as is.  We have an
-        "if-else" branch as part of the test to handle the two differing
-        behaviors.
+        The behavior when using CouchDB and newer versions of Cloudant
+        is to return an HTTP 400 Bad Request.
         """
         result = Result(self.view001)
-        if os.environ.get('RUN_CLOUDANT_TESTS') is None:
-            with self.assertRaises(HTTPError) as cm:
-                invalid_result = result['foo': 'bar']
-            self.assertTrue(
-                str(cm.exception).startswith('400 Client Error: Bad Request'))
-        else:
-            self.assertEqual(result['foo': 'bar'], [])
+        with self.assertRaises(HTTPError) as cm:
+            invalid_result = result['foo': 'bar']
+        self.assertTrue(
+            str(cm.exception).startswith('400 Client Error: Bad Request'))
 
     def test_get_item_key_slice_using_start_only(self):
         """


### PR DESCRIPTION
## What

Resolved Cloudant service test issues.

## How

* Fixed allowed types for group_sort

## Testing

* Updated billing tests
    * Used the current month as a data range to prevent any issues with no data with future test account changes.
    * Added new `bill_type` field.
* Used sort for search tests because the results need to be in a guaranteed order to be able to assert they are the same as expected, that means we need a sort or group_sort. 
* Fixed design document tests for newer Cloudant version
    * test_get_info: Removed Cloudant/Couch 2 fields from comparison & removed Cloudant design doc name change that is not needed.
    * test_geospatial_index: Removed `rev` property from row result before comparison.
* Removed `w` parameter from index creation test request options (we don't know how many nodes we will be testing against).
* Fixed index tests to not expect `w` parameter in response.
* Fixed test_get_query_indexes_raw to expect `total_rows` in result.
* Fixed test_get_item_key_slice_start_greater_than_stop to always expect 400 (old behaviour was an empty array on Cloudant, new behaviour is 500, but I think should be 400 see case 71810. This test will still fail until that is resolved.
* Refactored test_index_usage_via_query: Changed to assert that a warning is returned with the result rather than expecting an exception.

## Issues

Fixes #205
