### PR TITLE
Additional error details appended to HTTPError exception 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@
   an ``adapter`` arg of a ``Replay429Adapter`` with the desired number of retries and initial backoff. To replicate
   the 2.0.0 behaviour use: ``adapter=Replay429Adapter(retries=10, initialBackoff=0.25)``. If ``retries`` or
   ``initialBackoff`` are not specified they will default to 3 retries and a 0.25 s initial backoff.
+- [IMPROVED] Additional error reason details appended to HTTP response message errors.
 - [FIX] ``415 Client Error: Unsupported Media Type`` when using keys with ``db.all_docs``.
 - [FIX] Allowed strings as well as lists for search ``group_sort`` arguments.
 

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -263,6 +263,20 @@ def get_docs(r_session, url, encoder=None, headers=None, **params):
     resp.raise_for_status()
     return resp
 
+#pylint: disable=unused-argument
+def append_response_error_content(response, **kwargs):
+    """
+    Provides a helper to add HTTP response error and reason messages.
+    """
+    try:
+        if response.status_code >= 400 and response.json():
+            reason = response.json().pop('reason', None)
+            error = response.json().pop('error', None)
+            response.reason += ' %s %s' % (error, reason)
+            return response
+    except ValueError:
+        return
+
 # Classes
 
 class _Code(str):

--- a/src/cloudant/client.py
+++ b/src/cloudant/client.py
@@ -25,7 +25,8 @@ from ._2to3 import bytes_, unicode_
 from .database import CloudantDatabase, CouchDatabase
 from .feed import Feed, InfiniteFeed
 from .error import CloudantException, CloudantArgumentError
-from ._common_util import USER_AGENT
+from ._common_util import USER_AGENT, append_response_error_content
+
 
 class CouchDB(dict):
     """
@@ -75,6 +76,9 @@ class CouchDB(dict):
             self.r_session.auth = (self._user, self._auth_token)
             self.session_login(self._user, self._auth_token)
         self._client_session = self.session()
+        # Utilize an event hook to append to the response message
+        # using :func:`~cloudant.common_util.append_response_error_content`
+        self.r_session.hooks['response'].append(append_response_error_content)
 
     def disconnect(self):
         """


### PR DESCRIPTION
## What

Appended error and reason message to HTTPError exception.

## How

- Utilized event hooks in requests to manipulate the response error message.
- New util method `append_response_error_content` that handles appending to the response message.

## Testing

Added unit test in DocumentTests.

## Issues

#65 
#195 