### PR TITLE
Skip view cleanup test when running against Cloudant

### DIFF
--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -596,6 +596,8 @@ class DatabaseTests(UnitTestDbBase):
         self.assertNotEqual(new_limit, limit)
         self.assertEqual(new_limit, 1234)
 
+    @unittest.skipIf(os.environ.get('RUN_CLOUDANT_TESTS'),
+        'Skipping since view cleanup is automatic in Cloudant.')
     def test_view_clean_up(self):
         """
         Test cleaning up old view files


### PR DESCRIPTION
## What

View cleanup is now automatically done in Cloudant.  When running tests against Cloudant, the test case `test_view_clean_up` should be skipped.

## How

- Added `@unittest.skipIf` to skip the test case when running against Cloudant

## Testing

No new test cases required.

## Issues

fixes #215 

