### PR TITLE
Added raise_for_status to improve error handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,6 @@
 2.2.0 (Unreleased)
 ==================
+- [FIXED] HTTPError is raised when 4xx or 5xx codes are encountered
 
 2.1.0 (2016-08-31)
 ==================

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -101,7 +101,10 @@ class CouchDatabase(dict):
 
         :returns: Boolean True if the database exists, False otherwise
         """
-        resp = self.r_session.get(self.database_url)
+        resp = self.r_session.head(self.database_url)
+        if resp.status_code not in [200, 404]:
+            resp.raise_for_status()
+
         return resp.status_code == 200
 
     def metadata(self):
@@ -891,6 +894,7 @@ class CouchDatabase(dict):
             resp = self.r_session.post(
                 '/'.join([ddoc.document_url, '_update', handler_name]),
                 params=params, data=data)
+        resp.raise_for_status()
         return resp.text
 
 class CloudantDatabase(CouchDatabase):

--- a/src/cloudant/design_document.py
+++ b/src/cloudant/design_document.py
@@ -715,6 +715,7 @@ class DesignDocument(Document):
         """
         ddoc_info = self.r_session.get(
             '/'.join([self.document_url, '_info']))
+        ddoc_info.raise_for_status()
         return ddoc_info.json()
 
     def search_info(self, search_index):
@@ -726,4 +727,5 @@ class DesignDocument(Document):
         """
         ddoc_search_info = self.r_session.get(
             '/'.join([self.document_url, '_search_info', search_index]))
+        ddoc_search_info.raise_for_status()
         return ddoc_search_info.json()

--- a/src/cloudant/document.py
+++ b/src/cloudant/document.py
@@ -101,7 +101,11 @@ class Document(dict):
         """
         if self._document_id is None:
             return False
-        resp = self.r_session.get(self.document_url)
+        else:
+            resp = self.r_session.head(self.document_url)
+            if resp.status_code not in [200, 404]:
+                resp.raise_for_status()
+
         return resp.status_code == 200
 
     def json(self):


### PR DESCRIPTION
## What
- `exists()` methods for both CouchDatabase and Document return `False` if response code is not 200.  Logic was added to call `raise_for_status()` for HTTP errors that are not 200 or 404.
- Added `raise_for_status()` for methods using `requests` that did not include this statement 

## How

- Called `raise_for_status` when status code is not 200 or 404
- Added missing instances of `raise_for_status` in `database.py` and `design_document.py`

## Testing

Added unit tests for asserting a bad request is raised when calling `Document.exists()` and `Database.exists()` methods.

## Issues
#65 
fixes #216 
fixes #219 


