### PR TITLE
Added Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,17 +7,17 @@ def test_python(pythonVersion)
     // Set up the environment and test
     withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'clientlibs-test', usernameVariable: 'DB_USER', passwordVariable: 'DB_PASSWORD']]) {
       try {
-        sh """virtualenv tmp -p /usr/local/lib/python${pythonVersion}/bin/${pythonVersion.startsWith('3') ? "python3" : "python"}
-. ./tmp/bin/activate
-echo \$DB_USER
-export ADMIN_PARTY=true
-export RUN_CLOUDANT_TESTS=1
-export CLOUDANT_ACCOUNT=\$DB_USER
-# Temporarily disable the _db_updates tests pending resolution of case 71610
-export SKIP_DB_UPDATES=1
-pip install -r requirements.txt
-pip install -r test-requirements.txt
-nosetests -w ./tests/unit --with-xunit"""
+        sh """  virtualenv tmp -p /usr/local/lib/python${pythonVersion}/bin/${pythonVersion.startsWith('3') ? "python3" : "python"}
+                . ./tmp/bin/activate
+                echo \$DB_USER
+                export ADMIN_PARTY=true
+                export RUN_CLOUDANT_TESTS=1
+                export CLOUDANT_ACCOUNT=\$DB_USER
+                # Temporarily disable the _db_updates tests pending resolution of case 71610
+                export SKIP_DB_UPDATES=1
+                pip install -r requirements.txt
+                pip install -r test-requirements.txt
+                nosetests -w ./tests/unit --with-xunit"""
       } finally {
         // Load the test results
         junit 'nosetests.xml'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,43 @@
+// Define the test routine for different python versions
+def test_python(pythonVersion)
+{
+  node {
+    // Unstash the source on this node
+    unstash name: 'source'
+    // Set up the environment and test
+    withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'clientlibs-test', usernameVariable: 'DB_USER', passwordVariable: 'DB_PASSWORD']]) {
+      try {
+        sh """virtualenv tmp -p /usr/local/lib/python${pythonVersion}/bin/${pythonVersion.startsWith('3') ? "python3" : "python"}
+. ./tmp/bin/activate
+echo \$DB_USER
+export ADMIN_PARTY=true
+export RUN_CLOUDANT_TESTS=1
+export CLOUDANT_ACCOUNT=\$DB_USER
+# Temporarily disable the _db_updates tests pending resolution of case 71610
+export SKIP_DB_UPDATES=1
+pip install -r requirements.txt
+pip install -r test-requirements.txt
+nosetests -w ./tests/unit --with-xunit"""
+      } finally {
+        // Load the test results
+        junit 'nosetests.xml'
+      }
+    }
+  }
+}
+
+// Start of build
+stage('Checkout'){
+  // Checkout and stash the source
+  node{
+    checkout scm
+    stash name: 'source'
+  }
+}
+stage('Test'){
+  // Run tests in parallel for multiple python versions
+  parallel(
+    Python2: {test_python('2.7.12')},
+    Python3: {test_python('3.5.2')}
+  )
+}


### PR DESCRIPTION
## What

Added a `Jenkinsfile` for CI that runs tests on 2 python versions.

## How

Added a `Jenkinsfile`.
`Jenkinsfile` defines a test routine to be used by any python version.
The test routine is called for python versions `2.7.12` and `3.5.2` which run in parallel.

## Testing

Build status for this branch has Jenkins result produced by the new `Jenkinsfile`.

