### PR TITLE
Fix q parameter search query bug

### DIFF
--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -124,6 +124,7 @@ SEARCH_INDEX_ARGS = {
     'include_docs': bool,
     'limit': (int, NONETYPE),
     'query': (STRTYPE, int),
+    'q': (STRTYPE, int),
     'ranges': dict,
     'sort': (STRTYPE, list),
     'stale': STRTYPE,

--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -1374,7 +1374,7 @@ class CloudantDatabaseTests(UnitTestDbBase):
         resp = self.db.get_search_result(
             'searchddoc001',
             'searchindex001',
-            query='julia*',
+            q='julia*',
             sort='_id<string>',
             limit=1
         )


### PR DESCRIPTION
## What

Added `q` entry into `SEARCH_INDEX_ARGS` so that `q` would be recognized as a valid search parameter by the database `get_search_results` method.

## How

- Added `'q': (STRTYPE, int)` to _common_util.py `SEARCH_INDEX_ARGS` dictionary.

## Testing

- Fixed the `test_get_search_result_executes_search_q` database test to use `q` instead of `query`.

## Issues

#225 