### PR TITLE
Fix request session so all requests fail after client is disconnected

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,6 @@
-2.2.0 (Unreleased)
+2.1.2 (Unreleased)
 ==================
+- [FIXED] Requests session is no longer valid after disconnect.
 
 2.1.1 (2016-10-03)
 ==================

--- a/src/cloudant/client.py
+++ b/src/cloudant/client.py
@@ -80,9 +80,7 @@ class CouchDB(dict):
             self.r_session.mount(self.server_url, self.adapter)
         if self._client_user_header is not None:
             self.r_session.headers.update(self._client_user_header)
-        if not self.admin_party:
-            self.r_session.auth = (self._user, self._auth_token)
-            self.session_login(self._user, self._auth_token)
+        self.session_login(self._user, self._auth_token)
         self._client_session = self.session()
         # Utilize an event hook to append to the response message
         # using :func:`~cloudant.common_util.append_response_error_content`

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -54,9 +54,17 @@ class CouchDatabase(dict):
         self.client = client
         self._database_host = client.server_url
         self.database_name = database_name
-        self.r_session = client.r_session
         self._fetch_limit = fetch_limit
         self.result = Result(self.all_docs)
+
+    @property
+    def r_session(self):
+        """
+        Returns the ``r_session`` from the client instance used by the database.
+
+        :returns: Client ``r_session``
+        """
+        return self.client.r_session
 
     @property
     def admin_party(self):

--- a/src/cloudant/document.py
+++ b/src/cloudant/document.py
@@ -60,11 +60,19 @@ class Document(dict):
         self._database = database
         self._database_host = self._client.server_url
         self._database_name = database.database_name
-        self.r_session = database.r_session
         self._document_id = document_id
         if self._document_id is not None:
             self['_id'] = self._document_id
         self.encoder = self._client.encoder
+
+    @property
+    def r_session(self):
+        """
+        Returns the database instance ``r_session`` used by the document.
+
+        :returns: Client ``r_session``
+        """
+        return self._client.r_session
 
     @property
     def document_url(self):

--- a/tests/unit/client_tests.py
+++ b/tests/unit/client_tests.py
@@ -54,7 +54,6 @@ class ClientTests(UnitTestDbBase):
             with couchdb(self.user, self.pwd, url=self.url) as c:
                 self.assertIsInstance(c, CouchDB)
                 self.assertIsInstance(c.r_session, requests.Session)
-                self.assertEqual(c.r_session.auth, (self.user, self.pwd))
         except Exception as err:
             self.fail('Exception {0} was raised.'.format(str(err)))
 
@@ -88,17 +87,10 @@ class ClientTests(UnitTestDbBase):
     def test_connect(self):
         """
         Test connect and disconnect functionality.
-        Client r_session_auth is not set in CouchDB Admin Party mode.
         """
         try:
             self.client.connect()
             self.assertIsInstance(self.client.r_session, requests.Session)
-            if self.client.admin_party:
-                self.assertIsNone(self.client.r_session.auth)
-            else:
-                self.assertEqual(
-                    self.client.r_session.auth, (self.user, self.pwd)
-                )
         finally:
             self.client.disconnect()
             self.assertIsNone(self.client.r_session)
@@ -110,12 +102,6 @@ class ClientTests(UnitTestDbBase):
         try:
             self.set_up_client(auto_connect=True)
             self.assertIsInstance(self.client.r_session, requests.Session)
-            if self.client.admin_party:
-                self.assertIsNone(self.client.r_session.auth)
-            else:
-                self.assertEqual(
-                    self.client.r_session.auth, (self.user, self.pwd)
-                )
         finally:
             self.client.disconnect()
             self.assertIsNone(self.client.r_session)
@@ -130,12 +116,6 @@ class ClientTests(UnitTestDbBase):
             self.set_up_client(auto_connect=True)
             self.client.connect()
             self.assertIsInstance(self.client.r_session, requests.Session)
-            if self.client.admin_party:
-                self.assertIsNone(self.client.r_session.auth)
-            else:
-                self.assertEqual(
-                    self.client.r_session.auth, (self.user, self.pwd)
-                )
         finally:
             self.client.disconnect()
             self.assertIsNone(self.client.r_session)
@@ -447,7 +427,6 @@ class CloudantClientTests(UnitTestDbBase):
             with cloudant(self.user, self.pwd, account=self.account) as c:
                 self.assertIsInstance(c, Cloudant)
                 self.assertIsInstance(c.r_session, requests.Session)
-                self.assertEqual(c.r_session.auth, (self.user, self.pwd))
         except Exception as err:
             self.fail('Exception {0} was raised.'.format(str(err)))
     

--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -785,6 +785,20 @@ class DatabaseTests(UnitTestDbBase):
             data={'message': 'hello'},
             params={'field': 'new_field', 'value': 'new_value'})
 
+    def test_database_request_fails_after_client_disconnects(self):
+        """
+        Test that after disconnecting from a client any objects created based
+        on that client are not able to make requests.
+        """
+        self.client.disconnect()
+
+        try:
+            with self.assertRaises(AttributeError):
+                self.db.metadata()
+            self.assertIsNone(self.db.r_session)
+        finally:
+            self.client.connect()
+
 @unittest.skipUnless(
     os.environ.get('RUN_CLOUDANT_TESTS') is not None,
     'Skipping Cloudant specific Database tests'

--- a/tests/unit/document_tests.py
+++ b/tests/unit/document_tests.py
@@ -722,5 +722,22 @@ class DocumentTests(UnitTestDbBase):
         finally:
             attachment.close()
 
+    def test_document_request_fails_after_client_disconnects(self):
+        """
+        Test that after disconnecting from a client any objects created based
+        on that client are not able to make requests.
+        """
+        self.client.connect()
+        doc = Document(self.db, 'julia001')
+        doc.save()
+        self.client.disconnect()
+
+        try:
+            with self.assertRaises(AttributeError):
+                doc.fetch()
+            self.assertIsNone(doc.r_session)
+        finally:
+            self.client.connect()
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/replicator_tests.py
+++ b/tests/unit/replicator_tests.py
@@ -26,7 +26,6 @@ import unittest
 import uuid
 import time
 import requests
-import os
 
 from cloudant.replicator import Replicator
 from cloudant.document import Document


### PR DESCRIPTION
## What

After disconnecting from a client any objects created based on that client like Database or Document objects are still able to make requests to Cloudant/CouchDB.

## How

- Removed auth attribute from r_session so objects created based on the client are not able to make requests
- Added `r_session` property in `database.py` and `document.py`

## Testing

Added test to assert a 401 status code when trying to access a databases's document count after disconnecting from the client.

## Issues
fixes #218 