### PR TITLE
Add auto connect feature to client

### DIFF
--- a/src/cloudant/client.py
+++ b/src/cloudant/client.py
@@ -40,12 +40,15 @@ class CouchDB(dict):
 
     :param str user: Username used to connect to CouchDB.
     :param str auth_token: Authentication token used to connect to CouchDB.
-    :param str url: URL for CouchDB server.
     :param bool admin_party: Setting to allow the use of Admin Party mode in
         CouchDB.  Defaults to ``False``.
+    :param str url: URL for CouchDB server.
     :param str encoder: Optional json Encoder object used to encode
         documents for storage.  Defaults to json.JSONEncoder.
-    :param requests.HTTPAdapter adapter: Optional adapter to use for configuring requests.
+    :param requests.HTTPAdapter adapter: Optional adapter to use for
+        configuring requests.
+    :param bool connect: Keyword argument, if set to True performs the call to
+        connect as part of client construction.  Default is False.
     """
     _DATABASE_CLASS = CouchDatabase
 
@@ -60,12 +63,17 @@ class CouchDB(dict):
         self.encoder = kwargs.get('encoder') or json.JSONEncoder
         self.adapter = kwargs.get('adapter')
         self.r_session = None
+        if kwargs.get('connect', False):
+            self.connect()
 
     def connect(self):
         """
         Starts up an authentication session for the client using cookie
-        authentication.
+        authentication if necessary.
         """
+        if self.r_session:
+            return
+
         self.r_session = requests.Session()
         # If a Transport Adapter was supplied add it to the session
         if self.adapter is not None:

--- a/tests/unit/client_tests.py
+++ b/tests/unit/client_tests.py
@@ -103,6 +103,44 @@ class ClientTests(UnitTestDbBase):
             self.client.disconnect()
             self.assertIsNone(self.client.r_session)
 
+    def test_auto_connect(self):
+        """
+        Test connect during client instantiation option.
+        """
+        try:
+            self.set_up_client(auto_connect=True)
+            self.assertIsInstance(self.client.r_session, requests.Session)
+            if self.client.admin_party:
+                self.assertIsNone(self.client.r_session.auth)
+            else:
+                self.assertEqual(
+                    self.client.r_session.auth, (self.user, self.pwd)
+                )
+        finally:
+            self.client.disconnect()
+            self.assertIsNone(self.client.r_session)
+
+    def test_multiple_connect(self):
+        """
+        Test that issuing a connect call to an already connected client does
+        not cause any issue.
+        """
+        try:
+            self.client.connect()
+            self.set_up_client(auto_connect=True)
+            self.client.connect()
+            self.assertIsInstance(self.client.r_session, requests.Session)
+            if self.client.admin_party:
+                self.assertIsNone(self.client.r_session.auth)
+            else:
+                self.assertEqual(
+                    self.client.r_session.auth, (self.user, self.pwd)
+                )
+        finally:
+            self.client.disconnect()
+            self.assertIsNone(self.client.r_session)
+
+
     def test_session(self):
         """
         Test getting session information.  

--- a/tests/unit/unit_t_db_base.py
+++ b/tests/unit/unit_t_db_base.py
@@ -132,6 +132,9 @@ class UnitTestDbBase(unittest.TestCase):
         """
         Set up test attributes for unit tests targeting a database
         """
+        self.set_up_client()
+
+    def set_up_client(self, auto_connect=False):
         if os.environ.get('RUN_CLOUDANT_TESTS') is None:
             admin_party = False
             if (os.environ.get('ADMIN_PARTY') and
@@ -140,7 +143,13 @@ class UnitTestDbBase(unittest.TestCase):
             self.user = os.environ.get('DB_USER', None)
             self.pwd = os.environ.get('DB_PASSWORD', None)
             self.url = os.environ['DB_URL']
-            self.client = CouchDB(self.user, self.pwd, admin_party, url=self.url)
+            self.client = CouchDB(
+                self.user,
+                self.pwd,
+                admin_party,
+                url=self.url,
+                connect=auto_connect
+            )
         else:
             self.account = os.environ.get('CLOUDANT_ACCOUNT')
             self.user = os.environ.get('DB_USER')
@@ -152,7 +161,10 @@ class UnitTestDbBase(unittest.TestCase):
                 self.user,
                 self.pwd,
                 url=self.url,
-                x_cloudant_user=self.account)
+                x_cloudant_user=self.account,
+                connect=auto_connect
+            )
+
 
     def tearDown(self):
         """


### PR DESCRIPTION
## What

Added the auto connect feature to the client constructor.

## How

Added the `connect` keyword argument to the client `__init__`.  If `True` then perform the `connect` logic.  Default behavior is not to perform `connect` so current behavior is not compromised.

## Testing

- Added auto connect tests to client_tests.py

## Issues

- #230 
