### PR TITLE
Honour the custom encoder parameter for json encoding.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,7 @@
 2.3.0 (Unreleased)
 ==================
+- [FIXED] Issue where the custom JSON encoder was not used when transforming
+   data.
 
 2.2.0 (2016-10-20)
 ==================

--- a/src/cloudant/client.py
+++ b/src/cloudant/client.py
@@ -727,7 +727,7 @@ class Cloudant(CouchDB):
         )
         resp = self.r_session.put(
             endpoint,
-            data=json.dumps(config),
+            data=json.dumps(config, cls=self.encoder),
             headers={'Content-Type': 'application/json'}
         )
         resp.raise_for_status()

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -660,7 +660,7 @@ class CouchDatabase(dict):
         headers = {'Content-Type': 'application/json'}
         resp = self.r_session.post(
             url,
-            data=json.dumps(data),
+            data=json.dumps(data, cls=self.client.encoder),
             headers=headers
         )
         resp.raise_for_status()
@@ -684,7 +684,7 @@ class CouchDatabase(dict):
         resp = self.r_session.post(
             url,
             headers={'Content-Type': 'application/json'},
-            data=json.dumps(data)
+            data=json.dumps(data, cls=self.client.encoder)
         )
         resp.raise_for_status()
 
@@ -713,7 +713,7 @@ class CouchDatabase(dict):
         resp = self.r_session.post(
             url,
             headers={'Content-Type': 'application/json'},
-            data=json.dumps(data)
+            data=json.dumps(data, cls=self.client.encoder)
         )
         resp.raise_for_status()
 
@@ -752,7 +752,7 @@ class CouchDatabase(dict):
         """
         url = posixpath.join(self.database_url, '_revs_limit')
 
-        resp = self.r_session.put(url, data=json.dumps(limit))
+        resp = self.r_session.put(url, data=json.dumps(limit, self.client.encoder))
         resp.raise_for_status()
 
         return resp.json()
@@ -991,7 +991,7 @@ class CloudantDatabase(CouchDatabase):
         doc['cloudant'] = data
         resp = self.r_session.put(
             self.security_url,
-            data=json.dumps(doc),
+            data=json.dumps(doc, cls=self.client.encoder),
             headers={'Content-Type': 'application/json'}
         )
         resp.raise_for_status()
@@ -1016,7 +1016,7 @@ class CloudantDatabase(CouchDatabase):
         doc['cloudant'] = data
         resp = self.r_session.put(
             self.security_url,
-            data=json.dumps(doc),
+            data=json.dumps(doc, cls=self.client.encoder),
             headers={'Content-Type': 'application/json'}
         )
         resp.raise_for_status()

--- a/src/cloudant/index.py
+++ b/src/cloudant/index.py
@@ -144,7 +144,7 @@ class Index(object):
         headers = {'Content-Type': 'application/json'}
         resp = self._r_session.post(
             self.index_url,
-            data=json.dumps(payload),
+            data=json.dumps(payload, cls=self._database.client.encoder),
             headers=headers
         )
         resp.raise_for_status()

--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -67,6 +67,41 @@ class DatabaseTests(UnitTestDbBase):
         self.assertEqual(self.db.r_session, self.client.r_session)
         self.assertIsInstance(self.db.result, Result)
 
+    def test_bulk_docs_uses_custom_encoder(self):
+        """
+        Test that the bulk_docs method uses the custom encoder
+        """
+        self.set_up_client(auto_connect=True, encoder="AEncoder")
+        docs = [
+            {'_id': 'julia{0:03d}'.format(i), 'name': 'julia', 'age': i}
+            for i in range(3)
+        ]
+        database = self.client[self.test_dbname]
+        with self.assertRaises(TypeError):
+            # since the encoder is a str a type error should be thrown.
+            database.bulk_docs(docs)
+
+    def test_missing_revisions_uses_custom_encoder(self):
+        """
+        Test that missing_revisions uses the custom encoder.
+        """
+        revs = ['1-1', '2-1', '3-1']
+        self.set_up_client(auto_connect=True, encoder="AEncoder")
+        database = self.client[self.test_dbname]
+        with self.assertRaises(TypeError):
+            # since the encoder is a str a type error should be thrown.
+            database.missing_revisions('no-such-doc', *revs)
+
+    def test_revs_diff_uses_custom_encoder(self):
+        """
+        Test that revisions_diff uses the custom encoder.
+        """
+        revs = ['1-1', '2-1', '3-1']
+        self.set_up_client(auto_connect=True, encoder="AEncoder")
+        database = self.client[self.test_dbname]
+        with self.assertRaises(TypeError):
+            database.revisions_diff('no-such-doc', *revs)
+
     def test_retrieve_db_url(self):
         """
         Test retrieving the database URL
@@ -821,6 +856,27 @@ class CloudantDatabaseTests(UnitTestDbBase):
         """
         self.db_tear_down()
         super(CloudantDatabaseTests, self).tearDown()
+
+    def test_share_database_uses_custom_encoder(self):
+        """
+        Test that share_database uses custom encoder
+        """
+        share = 'user-{0}'.format(unicode_(uuid.uuid4()))
+        self.set_up_client(auto_connect=True, encoder="AEncoder")
+        database = self.client[self.test_dbname]
+        with self.assertRaises(TypeError):
+            database.share_database(share)
+
+
+    def test_unshare_database_uses_custom_encoder(self):
+        """
+        Test that unshare_database uses custom encoder
+        """
+        share = 'user-{0}'.format(unicode_(uuid.uuid4()))
+        self.set_up_client(auto_connect=True, encoder="AEncoder")
+        database = self.client[self.test_dbname]
+        with self.assertRaises(TypeError):
+            database.unshare_database(share)
 
     def test_get_security_document(self):
         """

--- a/tests/unit/index_tests.py
+++ b/tests/unit/index_tests.py
@@ -241,6 +241,17 @@ class IndexTests(UnitTestDbBase):
                  }
             )
 
+    def test_create_uses_custom_encoder(self):
+        """
+        Test that the create method uses the custom encoder
+        """
+        self.set_up_client(auto_connect=True, encoder="AEncoder")
+        database = self.client[self.test_dbname]
+        index = Index(database, '_design/ddoc001', 'index001', fields=['name', 'age'])
+        with self.assertRaises(TypeError):
+            index.create()
+
+
     def test_create_fails_due_to_ddocid_validation(self):
         """
         Ensure that if the design doc id is not a string the create call fails.

--- a/tests/unit/unit_t_db_base.py
+++ b/tests/unit/unit_t_db_base.py
@@ -134,7 +134,7 @@ class UnitTestDbBase(unittest.TestCase):
         """
         self.set_up_client()
 
-    def set_up_client(self, auto_connect=False):
+    def set_up_client(self, auto_connect=False, encoder=None):
         if os.environ.get('RUN_CLOUDANT_TESTS') is None:
             admin_party = False
             if (os.environ.get('ADMIN_PARTY') and
@@ -148,7 +148,8 @@ class UnitTestDbBase(unittest.TestCase):
                 self.pwd,
                 admin_party,
                 url=self.url,
-                connect=auto_connect
+                connect=auto_connect,
+                encoder=encoder
             )
         else:
             self.account = os.environ.get('CLOUDANT_ACCOUNT')
@@ -162,7 +163,8 @@ class UnitTestDbBase(unittest.TestCase):
                 self.pwd,
                 url=self.url,
                 x_cloudant_user=self.account,
-                connect=auto_connect
+                connect=auto_connect,
+                encoder=encoder
             )
 
 


### PR DESCRIPTION
## What

Honour the JSON encoder passed to the client at construction when transforming data into JSON.

## How

Specify the `cls` parameter for `json.dumps` calls which omitted it.

## Testing

Tests added which use a string for encoder to force a `TypeError` to be thrown.
## Issues

Fixes #221