### PR TITLE
Add security document management support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 2.3.0 (Unreleased)
 ==================
-- [FIXED] Issue where the custom JSON encoder was not used when transforming
-   data.
+- [FIXED] Resolved issue where the custom JSON encoder was not used when transforming data.
+- [NEW] Added support for managing the database security document through the SecurityDocument class and CouchDatabase convenience method ``get_security_document``.
 
 2.2.0 (2016-10-20)
 ==================

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,6 @@ def test_python(pythonVersion)
         sh """  virtualenv tmp -p /usr/local/lib/python${pythonVersion}/bin/${pythonVersion.startsWith('3') ? "python3" : "python"}
                 . ./tmp/bin/activate
                 echo \$DB_USER
-                export ADMIN_PARTY=true
                 export RUN_CLOUDANT_TESTS=1
                 export CLOUDANT_ACCOUNT=\$DB_USER
                 # Temporarily disable the _db_updates tests pending resolution of case 71610

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -8,6 +8,7 @@ Modules
    database
    document
    design_document
+   security_document
    view
    query
    module_index

--- a/docs/security_document.rst
+++ b/docs/security_document.rst
@@ -1,0 +1,7 @@
+security_document
+=================
+
+.. automodule:: cloudant.security_document
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -30,6 +30,7 @@ from ._common_util import (
     get_docs)
 from .document import Document
 from .design_document import DesignDocument
+from .security_document import SecurityDocument
 from .view import View
 from .index import Index, TextIndex, SpecialIndex
 from .query import Query
@@ -225,6 +226,19 @@ class CouchDatabase(dict):
                 raise
 
         return ddoc
+
+    def get_security_document(self):
+        """
+        Retrieves the database security document as a SecurityDocument object.
+        The returned object is useful for viewing as well as updating the
+        the database's security document.
+
+        :returns: A SecurityDocument instance representing the database
+            security document
+        """
+        sdoc = SecurityDocument(self)
+        sdoc.fetch()
+        return sdoc
 
     def get_view_result(self, ddoc_id, view_name, raw_result=False, **kwargs):
         """
@@ -930,11 +944,9 @@ class CloudantDatabase(CouchDatabase):
         containing information about the users that the database
         is shared with.
 
-        :returns: Security document in JSON format
+        :returns: Security document as a ``dict``
         """
-        resp = self.r_session.get(self.security_url)
-        resp.raise_for_status()
-        return resp.json()
+        return dict(self.get_security_document())
 
     @property
     def security_url(self):

--- a/src/cloudant/security_document.py
+++ b/src/cloudant/security_document.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+# Copyright (c) 2016 IBM. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+API module/class for interacting with a security document in a database.
+"""
+import json
+
+from ._2to3 import url_quote_plus
+
+class SecurityDocument(dict):
+    """
+    Encapsulates a JSON security document.  A SecurityDocument object is
+    instantiated with a reference to a database and used to manipulate security
+    document content in a CouchDB or Cloudant database instance.
+
+    In addition to basic read/write operations, a SecurityDocument object also
+    provides a convenient context manager.  This context manager removes having
+    to explicitly :func:`~cloudant.security_document.SecurityDocument.fetch`
+    the security document from the remote database before commencing work on it
+    as well as explicitly having to
+    :func:`~cloudant.security_document.SecurityDocument.save` the security
+    document once work is complete.
+
+    For example:
+
+    .. code-block:: python
+
+        # Upon entry into the security document context, fetches the security
+        # document from the remote database, if it exists. Upon exit from the
+        # context, saves the security document to the remote database with
+        # changes made within the context.
+        with SecurityDocument(database) as security_document:
+            # The security document is fetched from the remote database
+            # Changes are made locally
+            security_document['Cloudant']['julia'] = ['_reader', '_writer']
+            security_document['Cloudant']['ruby'] = ['_admin', '_replicator']
+            # The security document is saved to the remote database
+
+    :param database: A database instance used by the SecurityDocument.  Can be
+        either a ``CouchDatabase`` or ``CloudantDatabase`` instance.
+    """
+    def __init__(self, database):
+        super(SecurityDocument, self).__init__()
+        self._client = database.client
+        self._database = database
+        self._database_host = self._client.server_url
+        self._database_name = database.database_name
+        self.encoder = self._client.encoder
+
+    @property
+    def document_url(self):
+        """
+        Constructs and returns the security document URL.
+
+        :returns: Security document URL
+        """
+        return '/'.join([
+            self._database_host,
+            url_quote_plus(self._database_name),
+            '_security'
+        ])
+
+    @property
+    def r_session(self):
+        """
+        Returns the Python requests session used by the security document.
+
+        :returns: The Python requests session
+        """
+        return self._client.r_session
+
+    def json(self):
+        """
+        Retrieves the JSON string representation of the current locally cached
+        security document object, encoded by the encoder specified in the
+        associated client object.
+
+        :returns: Encoded JSON string containing the security document data
+        """
+        return json.dumps(dict(self), cls=self.encoder)
+
+    def fetch(self):
+        """
+        Retrieves the content of the current security document from the remote
+        database and populates the locally cached SecurityDocument object with
+        that content.  A call to fetch will overwrite any dictionary content
+        currently in the locally cached SecurityDocument object.
+        """
+        resp = self.r_session.get(self.document_url)
+        resp.raise_for_status()
+        self.clear()
+        self.update(resp.json())
+
+    def save(self):
+        """
+        Saves changes made to the locally cached SecurityDocument object's data
+        structures to the remote database.
+        """
+        resp = self.r_session.put(
+            self.document_url,
+            data=self.json(),
+            headers={'Content-Type': 'application/json'}
+        )
+        resp.raise_for_status()
+
+    def __enter__(self):
+        """
+        Supports context like editing of security document fields.
+        Handles context entry logic.  Executes a
+        :func:`~cloudant.security_document.SecurityDocument.fetch` upon entry.
+        """
+        self.fetch()
+        return self
+
+    def __exit__(self, *args):
+        """
+        Support context like editing of security document fields.
+        Handles context exit logic.  Executes a
+        :func:`~cloudant.security_document.SecurityDocument.save` upon exit.
+        """
+        self.save()

--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -33,6 +33,7 @@ from cloudant.result import Result, QueryResult
 from cloudant.error import CloudantException, CloudantArgumentError
 from cloudant.document import Document
 from cloudant.design_document import DesignDocument
+from cloudant.security_document import SecurityDocument
 from cloudant.index import Index, TextIndex, SpecialIndex
 from cloudant.feed import Feed, InfiniteFeed
 
@@ -314,6 +315,15 @@ class DatabaseTests(UnitTestDbBase):
         # Get the recently created design document that now exists remotely
         ddoc = self.db.get_design_document('_design/ddoc01')
         self.assertEqual(ddoc, local_ddoc)
+
+    def test_get_security_document(self):
+        """
+        Test retrieving the database security document
+        """
+        self.load_security_document_data()
+        sdoc = self.db.get_security_document()
+        self.assertIsInstance(sdoc, SecurityDocument)
+        self.assertDictEqual(sdoc, self.sdoc)
 
     def test_retrieve_view_results(self):
         """
@@ -878,7 +888,7 @@ class CloudantDatabaseTests(UnitTestDbBase):
         with self.assertRaises(TypeError):
             database.unshare_database(share)
 
-    def test_get_security_document(self):
+    def test_security_document(self):
         """
         Test the retrieval of the security document.
         """

--- a/tests/unit/security_document_tests.py
+++ b/tests/unit/security_document_tests.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+# Copyright (c) 2016 IBM. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+security_document module - Unit tests for the SecurityDocument class
+
+See configuration options for environment variables in unit_t_db_base
+module docstring.
+"""
+
+import unittest
+import requests
+import json
+import os
+
+from cloudant.security_document import SecurityDocument
+
+from .unit_t_db_base import UnitTestDbBase
+
+
+class SecurityDocumentTests(UnitTestDbBase):
+    """
+    SecurityDocument unit tests
+    """
+
+    def setUp(self):
+        """
+        Set up test attributes
+        """
+        super(SecurityDocumentTests, self).setUp()
+        self.db_set_up()
+        self.load_security_document_data()
+
+    def tearDown(self):
+        """
+        Reset test attributes
+        """
+        self.db_tear_down()
+        super(SecurityDocumentTests, self).tearDown()
+
+    def test_constructor(self):
+        """
+        Test constructing a SecurityDocument
+        """
+        sdoc = SecurityDocument(self.db)
+        self.assertIsInstance(sdoc, SecurityDocument)
+        self.assertEqual(sdoc.r_session, self.db.r_session)
+
+    def test_document_url(self):
+        """
+        Test that the document url is populated correctly
+        """
+        sdoc = SecurityDocument(self.db)
+        self.assertEqual(
+            sdoc.document_url,
+            '/'.join([self.db.database_url, '_security'])
+        )
+
+    def test_json(self):
+        """
+        Test the security document dictionary renders as a JSON string
+        """
+        sdoc = SecurityDocument(self.db)
+        sdoc.fetch()
+        sdoc_as_json_string = sdoc.json()
+        self.assertIsInstance(sdoc_as_json_string, str)
+        sdoc_as_a_dict = json.loads(sdoc_as_json_string)
+        self.assertDictEqual(sdoc_as_a_dict, sdoc)
+
+    def test_fetch(self):
+        """
+        Test that the security document is retrieved as expected
+        """
+        sdoc = SecurityDocument(self.db)
+        sdoc.fetch()
+        self.assertDictEqual(sdoc, self.sdoc)
+
+    def test_save(self):
+        """
+        Test that the security document is updated correctly
+        """
+        sdoc = SecurityDocument(self.db)
+        sdoc.fetch()
+        sdoc.update(self.mod_sdoc)
+        sdoc.save()
+        mod_sdoc = SecurityDocument(self.db)
+        mod_sdoc.fetch()
+        self.assertDictEqual(mod_sdoc, self.mod_sdoc)
+
+    def test_context_manager(self):
+        """
+        Test that the context SecurityDocument context manager enter and exit
+        routines work as expected.
+        """
+        with SecurityDocument(self.db) as sdoc:
+            self.assertDictEqual(sdoc, self.sdoc)
+            sdoc.update(self.mod_sdoc)
+        mod_sdoc = SecurityDocument(self.db)
+        mod_sdoc.fetch()
+        self.assertDictEqual(mod_sdoc, self.mod_sdoc)
+    
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Added the ability to retrieve a security document from a specific database and to update that document as necessary.

## How

- Add a SecurityDocument class that can: 
  - fetch the security document content remotely
  - save updated content to the server
  - a context manager is also provided
- Add the database convenience method get_security_document

## Testing

- Add security document tests
- Add get_security_document database test
- Fix Jenkinsfile to remove unnecessary ADMIN_PARTY export which fixes the security document tests

## Issues

#52 
#227 