### PR TITLE
WIP 235 automatically handle session renewal

### DIFF
--- a/src/cloudant/_2to3.py
+++ b/src/cloudant/_2to3.py
@@ -35,6 +35,15 @@ if PY2:
     from urllib import quote as url_quote, quote_plus as url_quote_plus
     from ConfigParser import RawConfigParser
 
+    def im_self(func):
+        """
+        Retrieve the class object reference of a given function object.
+
+        :param func: function object
+        :return: class instance object
+        """
+        return func.im_self
+
     def iteritems_(adict):
         """
         iterate dict key, value tuples in a py2 and 3 compatible way
@@ -55,6 +64,15 @@ if PY2:
 else:
     from urllib.parse import quote as url_quote, quote_plus as url_quote_plus  # pylint: disable=wrong-import-position,no-name-in-module,import-error,ungrouped-imports
     from configparser import RawConfigParser  # pylint: disable=wrong-import-position,no-name-in-module,import-error
+
+    def im_self(func):
+        """
+        Retrieve the class object reference of a given function object.
+
+        :param func: function object
+        :return: class instance object
+        """
+        return func.__self__
 
     def iteritems_(adict):
         """

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -100,8 +100,8 @@ class CouchDatabase(dict):
         if self.admin_party:
             return None
         return {
-            "basic_auth": self.client.basic_auth_str(),
-            "user_ctx": self.client.session()['userCtx']
+            "basic_auth": self.client.r_session.basic_auth_str,
+            "user_ctx": self.client.r_session.get_session_info()['userCtx']
         }
 
     def exists(self):

--- a/src/cloudant/sessions.py
+++ b/src/cloudant/sessions.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python
+# Copyright (C) 2015, 2016 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This module provides a Session object to manage and persist settings across
+database requests.
+"""
+import base64
+
+from functools import wraps
+from requests import Session
+from urlparse import urljoin
+
+from ._2to3 import bytes_, im_self, unicode_
+from ._common_util import append_response_error_content
+
+
+class CouchSession(Session):
+    """
+    CouchSession manages and persists settings across all requests.
+
+    :param str username: username
+    :param str password: password
+    :param str server_url: URL of CouchDB server
+    :param object adapter: custom transport adapter
+    :param bool admin_party: enable admin party mode
+    :param dict headers: default headers to persist across all requests
+    """
+
+    def __new__(cls, *args, **kwargs):
+        couch_session = super(CouchSession, cls).__new__(cls, *args, **kwargs)
+
+        # CouchDB only renews the cookie if we're within 10% of the end of the
+        # timeout window. Failing to submit a request during this time will
+        # result in the cookie not being renewed. To avoid this we catch all
+        # 401 'unauthorized' responses and retry following a renewed session
+        # login.
+
+        for verb in ['DELETE', 'GET', 'HEAD', 'POST', 'PUT']:
+            setattr(couch_session, verb.lower(), cls.renew_cookie_decorator(
+                getattr(couch_session, verb.lower())
+            ))
+
+        return couch_session
+
+    def __init__(self,
+                 username,
+                 password,
+                 server_url,
+                 adapter=None,
+                 admin_party=False,
+                 headers=None):
+        super(CouchSession, self).__init__()
+
+        self.username = username
+        self.password = password
+
+        self.admin_party = admin_party
+        self.session_url = urljoin(server_url, '_session')
+
+        if headers:
+            self.headers.update(headers)
+
+        # If a Transport Adapter was supplied add it to the session
+        if adapter:
+            self.mount(server_url, adapter)
+
+        # Utilize an event hook to append to the response message
+        self.hooks['response'].append(append_response_error_content)
+
+    @property
+    def basic_auth_str(self):
+        """
+        Get Base64 authentication string.
+
+        :return: Base64 username:password encoding as string
+        """
+        if self.admin_party:
+            return None
+
+        # Base64 encode username:password
+        hash_ = base64.urlsafe_b64encode(bytes_('{username}:{password}'.format(
+            username=self.username,
+            password=self.password
+        )))
+        return 'Basic {0}'.format(unicode_(hash_))
+
+    @property
+    def cookie(self):
+        """
+        Session cookie.
+
+        :return: session cookie as string
+        """
+        return self.cookies.get('AuthSession')
+
+    def get_session_info(self):
+        """
+        Retrieves information about the current login session to verify data
+        related to sign in.
+
+        :returns: Dictionary of session info for the current session.
+        """
+        if self.admin_party:
+            return None
+
+        resp = self.get(self.session_url)
+        resp.raise_for_status()
+        return resp.json()
+
+    def is_authenticated(self):
+        """
+        Check the session cookie is authenticated.
+
+        :return: is authenticated as boolean
+        """
+        if self.admin_party:
+            return True
+
+        session_user = self.get_session_info().get('userCtx', {}).get('name')
+        return self.username == session_user
+
+    def login(self):
+        """ Session login. """
+        if self.admin_party:
+            return
+
+        self.cookies.clear()  # clear session cookies
+        resp = self.post(
+            self.session_url,
+            data={'name': self.username, 'password': self.password},
+            headers={'Content-Type': 'application/x-www-form-urlencoded'}
+        )
+        resp.raise_for_status()
+
+    def logout(self):
+        """ Session logout. """
+        if self.admin_party:
+            return
+
+        resp = self.delete(self.session_url)
+        resp.raise_for_status()
+
+    @classmethod
+    def renew_cookie_decorator(cls, function):
+        """
+        Decorator to renew authentication cookie on 401 response.
+
+        :param function: session function
+        """
+        @wraps(function)
+        def wrapper(*args, **kwargs):
+            session = im_self(function)
+            result = function(*args, **kwargs)
+
+            try:
+                if result.status_code == 401 and not session.is_authenticated():
+                    session.login()  # renew cookie
+                    result = function(*args, **kwargs)
+
+            except Exception:
+                pass  # ignore failure
+
+            finally:
+                return result
+
+        return wrapper

--- a/src/cloudant/sessions.py
+++ b/src/cloudant/sessions.py
@@ -17,10 +17,10 @@ This module provides a Session object to manage and persist settings across
 database requests.
 """
 import base64
+import posixpath
 
 from functools import wraps
 from requests import Session
-from urlparse import urljoin
 
 from ._2to3 import bytes_, im_self, unicode_
 from ._common_util import append_response_error_content
@@ -67,7 +67,7 @@ class CouchSession(Session):
         self.password = password
 
         self.admin_party = admin_party
-        self.session_url = urljoin(server_url, '_session')
+        self.session_url = posixpath.join(server_url, '_session')
 
         if headers:
             self.headers.update(headers)

--- a/tests/unit/client_tests.py
+++ b/tests/unit/client_tests.py
@@ -128,7 +128,7 @@ class ClientTests(UnitTestDbBase):
         """
         try:
             self.client.connect()
-            session = self.client.session()
+            session = self.client.r_session.get_session_info()
             if self.client.admin_party:
                 self.assertIsNone(session)
             else:
@@ -144,9 +144,9 @@ class ClientTests(UnitTestDbBase):
         try:
             self.client.connect()
             if self.client.admin_party:
-                self.assertIsNone(self.client.session_cookie())
+                self.assertIsNone(self.client.r_session.cookie)
             else:
-                self.assertIsNotNone(self.client.session_cookie())
+                self.assertIsNotNone(self.client.r_session.cookie)
         finally:
             self.client.disconnect()
 
@@ -158,14 +158,14 @@ class ClientTests(UnitTestDbBase):
         try:
             self.client.connect()
             if self.client.admin_party:
-                self.assertIsNone(self.client.basic_auth_str())
+                self.assertIsNone(self.client.r_session.basic_auth_str)
             else:
                 expected = 'Basic {0}'.format(
                     str_(base64.urlsafe_b64encode(bytes_("{0}:{1}".format(
                         self.user, self.pwd
                     ))))
                 )
-                self.assertEqual(self.client.basic_auth_str(), expected)
+                self.assertEqual(expected, self.client.r_session.basic_auth_str)
         finally:
             self.client.disconnect()
 


### PR DESCRIPTION
Hi,
I ran into this bug last week and started on a fix. Let me know if the implementation is worth pursuing. I'm happy to do any followup work etc if you think this can be made mergable.
Thanks.
## What

Adds a `CouchSession` module to manage the session with the additional 'renew expired cookie' feature.
## How

All requests (i.e. 'DELETE', 'GET', 'HEAD', 'POST', 'PUT') are passed through a wrapper. Any `401` responses are caught. If the cookie is deemed expired then the request is retried following a `.login()` call.
## Testing

Additional testing required.
## Issues
- https://github.com/cloudant/python-cloudant/issues/235
