### PR TITLE
Add session auto-renewal option

### DIFF
--- a/src/cloudant/_2to3.py
+++ b/src/cloudant/_2to3.py
@@ -33,6 +33,7 @@ UNITYPE = unicode if PY2 else str
 if PY2:
     # pylint: disable=wrong-import-position,no-name-in-module,import-error,unused-import
     from urllib import quote as url_quote, quote_plus as url_quote_plus
+    from urlparse import urlparse as url_parse
     from ConfigParser import RawConfigParser
 
     def iteritems_(adict):
@@ -53,7 +54,9 @@ if PY2:
         """
         return itr.next()
 else:
-    from urllib.parse import quote as url_quote, quote_plus as url_quote_plus  # pylint: disable=wrong-import-position,no-name-in-module,import-error,ungrouped-imports
+    from urllib.parse import urlparse as url_parse  # pylint: disable=wrong-import-position,no-name-in-module,import-error,ungrouped-imports
+    from urllib.parse import quote as url_quote  # pylint: disable=wrong-import-position,no-name-in-module,import-error,ungrouped-imports
+    from urllib.parse import quote_plus as url_quote_plus  # pylint: disable=wrong-import-position,no-name-in-module,import-error,ungrouped-imports
     from configparser import RawConfigParser  # pylint: disable=wrong-import-position,no-name-in-module,import-error
 
     def iteritems_(adict):

--- a/tests/unit/auth_renewal_tests.py
+++ b/tests/unit/auth_renewal_tests.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+# Copyright (c) 2016 IBM. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for the renewal of cookie auth
+
+See configuration options for environment variables in unit_t_db_base
+module docstring.
+"""
+import unittest
+import os
+import requests
+import time
+
+from cloudant._common_util import InfiniteSession
+
+from .unit_t_db_base import UnitTestDbBase
+
+@unittest.skipIf(os.environ.get('ADMIN_PARTY') == 'true', 'Skipping - Admin Party mode')
+class AuthRenewalTests(UnitTestDbBase):
+    """
+    Auto renewal tests primarily testing the InfiniteSession functionality
+    """
+
+    def setUp(self):
+        """
+        Override UnitTestDbBase.setUp() with no set up
+        """
+        pass
+
+    def tearDown(self):
+        """
+        Override UnitTestDbBase.tearDown() with no tear down
+        """
+        pass
+        
+    def test_client_db_doc_stack_success(self):
+        """
+        Ensure that auto renewal of cookie auth happens as expected and applies
+        to all references of r_session throughout the library.
+        """
+        try:
+            self.set_up_client(auto_connect=True, auto_renew=True)
+            db = self.client._DATABASE_CLASS(self.client, self.dbname())
+            db.create()
+            db_2 = self.client._DATABASE_CLASS(self.client, self.dbname())
+            doc = db.create_document({'_id': 'julia001', 'name': 'julia'})
+
+            auth_session = self.client.r_session.cookies.get('AuthSession')
+            db_auth_session = db.r_session.cookies.get('AuthSession')
+            db_2_auth_session = db_2.r_session.cookies.get('AuthSession')
+            doc_auth_session = doc.r_session.cookies.get('AuthSession')
+            
+            self.assertIsInstance(self.client.r_session, InfiniteSession)
+            self.assertIsInstance(db.r_session, InfiniteSession)
+            self.assertIsInstance(db_2.r_session, InfiniteSession)
+            self.assertIsInstance(doc.r_session, InfiniteSession)
+            self.assertIsNotNone(auth_session)
+            self.assertTrue(
+                auth_session ==
+                db_auth_session ==
+                db_2_auth_session ==
+                doc_auth_session
+            )
+            self.assertTrue(db.exists())
+            self.assertTrue(doc.exists())
+
+            # Will cause a 401 response to be handled internally
+            self.client.r_session.cookies.clear()
+            self.assertIsNone(self.client.r_session.cookies.get('AuthSession'))
+            self.assertIsNone(db.r_session.cookies.get('AuthSession'))
+            self.assertIsNone(db_2.r_session.cookies.get('AuthSession'))
+            self.assertIsNone(doc.r_session.cookies.get('AuthSession'))
+
+            time.sleep(1) # Ensure a different cookie auth value
+
+            # 401 response handled by renew of cookie auth and retry of request
+            db_2.create()
+
+            new_auth_session = self.client.r_session.cookies.get('AuthSession')
+            new_db_auth_session = db.r_session.cookies.get('AuthSession')
+            new_db_2_auth_session = db_2.r_session.cookies.get('AuthSession')
+            new_doc_auth_session = doc.r_session.cookies.get('AuthSession')
+            self.assertIsNotNone(new_auth_session)
+            self.assertNotEqual(new_auth_session, auth_session)
+            self.assertTrue(
+                new_auth_session ==
+                new_db_auth_session ==
+                new_db_2_auth_session ==
+                new_doc_auth_session
+            )
+            self.assertTrue(db.exists())
+            self.assertTrue(doc.exists())
+        finally:
+            # Clean up
+            self.client.delete_database(db.database_name)
+            self.client.delete_database(db_2.database_name)
+            self.client.disconnect()
+            del self.client
+
+    def test_client_db_doc_stack_failure(self):
+        """
+        Ensure that when the regular requests.Session is used that
+        cookie auth renewal is not handled.
+        """
+        try:
+            self.set_up_client(auto_connect=True)
+            db = self.client._DATABASE_CLASS(self.client, self.dbname())
+            db.create()
+            
+            self.assertIsInstance(self.client.r_session, requests.Session)
+            self.assertIsInstance(db.r_session, requests.Session)
+
+            # Will cause a 401 response
+            self.client.r_session.cookies.clear()
+            
+            # 401 response expected to raised
+            with self.assertRaises(requests.HTTPError) as cm:
+                db.delete()
+            self.assertEqual(cm.exception.response.status_code, 401)
+        finally:
+            # Manual reconnect
+            self.client.disconnect()
+            self.client.connect()
+            # Clean up
+            self.client.delete_database(db.database_name)
+            self.client.disconnect()
+            del self.client
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/client_tests.py
+++ b/tests/unit/client_tests.py
@@ -32,6 +32,7 @@ from cloudant import cloudant, couchdb, couchdb_admin_party
 from cloudant.client import Cloudant, CouchDB
 from cloudant.error import CloudantException, CloudantArgumentError
 from cloudant.feed import Feed, InfiniteFeed
+from cloudant._common_util import InfiniteSession
 
 from .unit_t_db_base import UnitTestDbBase
 from .. import bytes_, str_
@@ -120,6 +121,33 @@ class ClientTests(UnitTestDbBase):
             self.client.disconnect()
             self.assertIsNone(self.client.r_session)
 
+    def test_auto_renew_enabled(self):
+        """
+        Test that InfiniteSession is used when auto_renew is enabled.
+        """
+        try:
+            self.set_up_client(auto_renew=True)
+            self.client.connect()
+            if os.environ.get('ADMIN_PARTY') == 'true':
+                self.assertIsInstance(self.client.r_session, requests.Session)
+            else:
+                self.assertIsInstance(self.client.r_session, InfiniteSession)
+        finally:
+            self.client.disconnect()
+
+    def test_auto_renew_enabled_with_auto_connect(self):
+        """
+        Test that InfiniteSession is used when auto_renew is enabled along with
+        an auto_connect.
+        """
+        try:
+            self.set_up_client(auto_connect=True, auto_renew=True)
+            if os.environ.get('ADMIN_PARTY') == 'true':
+                self.assertIsInstance(self.client.r_session, requests.Session)
+            else:
+                self.assertIsInstance(self.client.r_session, InfiniteSession)
+        finally:
+            self.client.disconnect()
 
     def test_session(self):
         """

--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -1333,11 +1333,7 @@ class CloudantDatabaseTests(UnitTestDbBase):
             self.db.get_search_result('searchddoc001', 'searchindex001',
                                       query='julia*', q='julia*')
         err = cm.exception
-        self.assertEqual(
-            str(err),
-            'A single query/q parameter is required. '
-            'Found: {\'q\': \'julia*\', \'query\': \'julia*\'}'
-        )
+        self.assertTrue(str(err).startswith('A single query/q parameter is required.'))
 
     def test_get_search_result_with_invalid_value_types(self):
         """

--- a/tests/unit/unit_t_db_base.py
+++ b/tests/unit/unit_t_db_base.py
@@ -135,7 +135,7 @@ class UnitTestDbBase(unittest.TestCase):
         """
         self.set_up_client()
 
-    def set_up_client(self, auto_connect=False, encoder=None):
+    def set_up_client(self, auto_connect=False, auto_renew=False, encoder=None):
         if os.environ.get('RUN_CLOUDANT_TESTS') is None:
             admin_party = False
             if (os.environ.get('ADMIN_PARTY') and
@@ -150,6 +150,7 @@ class UnitTestDbBase(unittest.TestCase):
                 admin_party,
                 url=self.url,
                 connect=auto_connect,
+                auto_renew=auto_renew,
                 encoder=encoder
             )
         else:
@@ -165,6 +166,7 @@ class UnitTestDbBase(unittest.TestCase):
                 url=self.url,
                 x_cloudant_user=self.account,
                 connect=auto_connect,
+                auto_renew=auto_renew,
                 encoder=encoder
             )
 


### PR DESCRIPTION
## What

Add a session automatic renewal option to the `Session` object used by this library so that in the event of a request being made using expired session authentication credentials, the auth is renewed and the request is re-tried.

## How

- Sub-class `requests.Session` as `InfiniteSession` class and handle a 401 response as needed
- Add the auto_renew keyword argument to client constructor to allow for auto renewal of session auth

## Testing

- Current set of unit tests all pass
- Manual tests to validate functionality were successful against Cloudant
- Add client unit tests to test client auto renewal functionality
- Add additional auth renewal tests

## Issues

#235 