### PR TITLE
Correctly transform UUID object into a string.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 2.4.0 (Unreleased)
 ==================
-
+- [FIXED] Resolved issue where generated UUIDs for replication documents would
+  not be converted to strings.
 
 2.3.0 (2016-11-02)
 ==================

--- a/src/cloudant/replicator.py
+++ b/src/cloudant/replicator.py
@@ -18,7 +18,6 @@ API module/class for handling database replications
 
 import uuid
 
-from ._2to3 import unicode_
 from .error import CloudantException
 from .document import Document
 
@@ -73,7 +72,7 @@ class Replicator(object):
         """
 
         data = dict(
-            _id=repl_id if repl_id else unicode_(uuid.uuid4()),
+            _id=repl_id if repl_id else str(uuid.uuid4()),
             **kwargs
         )
 

--- a/tests/unit/replicator_tests.py
+++ b/tests/unit/replicator_tests.py
@@ -98,6 +98,10 @@ class ReplicatorTests(UnitTestDbBase):
             self.assertIsNone(repl)
             self.client.connect()
 
+    def test_replication_with_generated_id(self):
+        clone = Replicator(self.client)
+        clone.create_replication(self.db, self.target_db)
+
     def test_create_replication(self):
         """
         Test that the replication document gets created and that the


### PR DESCRIPTION
## What

Correctly transform a UUID object into a string for replication documents.

## How

Transfer the UUID object into a string by using the `str` method,

## Testing

One test added `test_replication_with_generated_id`.

## Issues

Fixes #242