### PR TITLE
Iterate over skipped changes lines

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 ==================
 - [FIXED] Resolved issue where generated UUIDs for replication documents would
   not be converted to strings.
+- [FIXED] Resolved issue where database.infinite_changes() method can cause a stack overflow.
 
 2.3.0 (2016-11-02)
 ==================


### PR DESCRIPTION
## What

Changed Feed.next() and InfiniteFeed.next() to iterate over skipped lines rather than recursing over them.

## How

Use a while loop in Feed.next() and InfiniteFeed.next(). This unfortunately results in a few lines of duplicated code as there was no clear way to make use of calling the superclass method.

## Testing

Functionality does not change, other than to tidy up stack traces and prevent overflow, so no tests are altered.

## Issues

This fixes issue #245 where recursion can cause a stack overflow.