### PR TITLE
251 fix tests

### DIFF
--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -1378,11 +1378,11 @@ class CloudantDatabaseTests(UnitTestDbBase):
             self.db.get_search_result('searchddoc001', 'searchindex001',
                                       limit=10, include_docs=True)
         err = cm.exception
-        self.assertEqual(
-            str(err),
-            'A single query/q parameter is required. '
-            'Found: {\'limit\': 10, \'include_docs\': True}'
-        )
+        # Validate that the error message starts as expected
+        self.assertTrue(str(err).startswith('A single query/q parameter is required.'))
+        # Validate that the error message includes the supplied parameters (in an order independent way)
+        self.assertTrue(str(err).find("'limit': 10") >= 0)
+        self.assertTrue(str(err).find("'include_docs': True") >= 0)
 
     def test_get_search_result_with_invalid_query_type(self):
         """

--- a/tests/unit/design_document_tests.py
+++ b/tests/unit/design_document_tests.py
@@ -790,14 +790,18 @@ class DesignDocumentTests(UnitTestDbBase):
         ddoc.save()
         ddoc_remote = DesignDocument(self.db, '_design/ddoc001')
         ddoc_remote.fetch()
+
         search_info = ddoc_remote.search_info('search001')
-        search_info['search_index'].pop('disk_size')
-        self.assertEqual(
-            search_info,
-            {'name': '_design/ddoc001/search001',
-             'search_index': {'doc_del_count': 0, 'doc_count': 100,
-                              'pending_seq': 101, 'committed_seq': 0},
-             })
+        # Check the search index name
+        self.assertEqual(search_info['name'], '_design/ddoc001/search001', 'The search index name should be correct.')
+        # Validate the metadata
+        search_index_metadata = search_info['search_index']
+        self.assertIsNotNone(search_index_metadata)
+        self.assertEquals(search_index_metadata['doc_del_count'], 0, 'There should be no deleted docs.')
+        self.assertTrue(search_index_metadata['doc_count'] <= 100, 'There should be 100 or fewer docs.')
+        self.assertEquals(search_index_metadata['committed_seq'], 0, 'The committed_seq should be 0.')
+        self.assertTrue(search_index_metadata['pending_seq'] <= 101, 'The pending_seq should be 101 or fewer.')
+        self.assertTrue(search_index_metadata['disk_size'] >0, 'The disk_size should be greater than 0.')
 
     @unittest.skipUnless(
         os.environ.get('RUN_CLOUDANT_TESTS') is not None,

--- a/tests/unit/document_tests.py
+++ b/tests/unit/document_tests.py
@@ -282,10 +282,6 @@ class DocumentTests(UnitTestDbBase):
                 str(err.response.reason),
                 'Internal Server Error doc_validation Bad special document member: _invalid_key'
             )
-            self.assertEqual(
-                err.response.status_code,
-                500
-            )
         else:
             self.assertEqual(
                 str(err.response.reason),


### PR DESCRIPTION
## What

Fixed tests that failed because of ordering issues or behaviour differences between CouchDB 1.6 and newer versions.

## Testing

* Fixed `test_appended_error_message_using_save_with_invalid_key` to check for `400 Bad Request`, but allowed to continue passing with 500 for CouchDB 1.6.x.
* Make test_get_search_result_without_query assertions order independent 
* Made test_get_search_info checks not rely on indexing completion

## Issues

Fixes #251
