### PR TITLE
Fix unreliable unit tests

### DIFF
--- a/tests/unit/client_tests.py
+++ b/tests/unit/client_tests.py
@@ -264,14 +264,21 @@ class ClientTests(UnitTestDbBase):
         """
         Test retrieving the list of database names
         """
+        dbs = []
         try:
             self.client.connect()
             self.assertEqual(list(self.client.keys()), [])
-            self.assertEqual(
-                self.client.keys(remote=True),
-                self.client.all_dbs()
-                )
+
+            # create 10 new test dbs
+            for _ in range(10):
+                dbs.append(self.client.create_database(self.dbname()).database_name)
+
+            self.assertTrue(set(dbs).issubset(set(self.client.keys(remote=True))))
+            self.assertTrue(set(dbs).issubset(set(self.client.all_dbs())))
+
         finally:
+            for db in dbs:
+                self.client.delete_database(db)  # remove test db
             self.client.disconnect()
 
     def test_get_non_existing_db_via_getitem(self):


### PR DESCRIPTION
## What
Fixes a couple of unreliable unit tests:
- _ClientTests.test_keys_
Mismatch results from`/_all_dbs` due to multiple test runners sharing the same CouchDB instance.
- _ReplicatorTests.test_list_replications_ (see #256)
Failing to delete a replication document. Document receives multiple updates from the replicator often causing delete attempts to _409_.

## How
- _ClientTests.test_keys_
Assert keys contains 10 new test databases.
- _ReplicatorTests.test_list_replications_
Implement retrying on replication document deletion failures.

## Issues
Fixes #256.
