### PR TITLE
248 some test not cleaning of databases

### DIFF
--- a/tests/unit/unit_t_db_base.py
+++ b/tests/unit/unit_t_db_base.py
@@ -196,7 +196,7 @@ class UnitTestDbBase(unittest.TestCase):
         del self.db
 
     def dbname(self, database_name='db'):
-        return '{0}-{1}'.format(database_name, unicode_(uuid.uuid4()))
+        return '{0}-{1}-{2}'.format(database_name, self._testMethodName, unicode_(uuid.uuid4()))
 
     def populate_db_with_documents(self, doc_count=100, **kwargs):
         off_set = kwargs.get('off_set', 0)


### PR DESCRIPTION
## What

It's hard to tell which test case are failing with the current test database naming scheme when databases are left behind in the test account from a failing test.  We should include the test case method in the test database name.

## How

- Included test method name to test database name

## Testing

No new tests.

## Issues

fixes #248  