### PR TITLE
259 improve error handling design

### DIFF
--- a/src/cloudant/_messages.py
+++ b/src/cloudant/_messages.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# Copyright (c) 2016 IBM. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Module that contains exception messages for the Cloudant Python client
+library.
+"""
+CLIENT = {
+    100: 'A general Cloudant client exception was raised.',
+    101: 'Value must be set to a Database object. Found type: {0}.',
+    102: 'You must provide a url or an account.',
+    404: 'Database {0} does not exist. Verify that the client is valid and try again.',
+    409: 'Database {0} already exists.'
+}
+
+DATABASE = {
+    100: 'A general Cloudant database exception was raised.',
+    101: 'Unexpected index type. Found: {0}.',
+    400: 'Invalid database name during creation. Found: {0}',
+    401: 'Unauthorized to create database {0}.',
+    409: 'Document with id {0} already exists.'
+}
+
+DESIGN_DOCUMENT = {
+    100: 'A general Cloudant design document exception was raised.',
+    101: 'Cannot add a MapReduce view to a design document for query indexes.',
+    102: 'Cannot update a query index view using this method.',
+    103: 'Cannot delete a query index view using this method.',
+    104: 'View {0} must be of type View.',
+    105: 'View {0} must be of type QueryIndexView.',
+    106: 'Function for search index {0} must be of type string.',
+    107: 'Definition for query text index {0} must be of type dict.'
+}
+
+DOCUMENT = {
+    100: 'A general Cloudant document exception was raised.',
+    101: 'A document id is required to fetch document contents. '
+         'Add an _id key and value to the document and re-try.',
+    102: 'The field {0} is not a list.',
+    103: 'Attempting to delete a doc with no _rev. Try running .fetch and re-try.'
+}
+
+FEED = {
+    100: 'A general Cloudant feed exception was raised.',
+    101: 'Infinite _db_updates feed not supported for CouchDB.'
+}
+
+INDEX = {
+    100: 'A general Cloudant index exception was raised.',
+    101: 'Creating the \"special\" index is not allowed.',
+    102: 'Deleting the \"special\" index is not allowed.'
+}
+
+REPLICATOR = {
+    100: 'A general Cloudant replicator exception was raised.',
+    101: 'You must specify either a source_db Database object or a manually composed'
+         ' \'source\' string/dict.',
+    102: 'You must specify either a target_db Database object or a manually composed'
+         ' \'target\' string/dict.',
+    404: 'Replication with id {0} not found.'
+}
+
+RESULT = {
+    100: 'A general result exception was raised.',
+    101: 'Failed to interpret the argument {0} as a valid key value or as a valid slice.',
+    102: 'Cannot use {0} when performing key access or key slicing. Found {1}.',
+    103: 'Cannot use {0} for iteration. Found {1}.',
+    104: 'Invalid page_size: {0}'
+}

--- a/src/cloudant/document.py
+++ b/src/cloudant/document.py
@@ -21,7 +21,8 @@ import requests
 from requests.exceptions import HTTPError
 
 from ._2to3 import url_quote, url_quote_plus
-from .error import CloudantException
+from .error import CloudantDocumentException
+
 
 class Document(dict):
     """
@@ -161,10 +162,7 @@ class Document(dict):
         the locally cached Document object.
         """
         if self.document_url is None:
-            raise CloudantException(
-                'A document id is required to fetch document contents.  '
-                'Add an _id key and value to the document and re-try.'
-            )
+            raise CloudantDocumentException(101)
         resp = self.r_session.get(self.document_url)
         resp.raise_for_status()
         self.clear()
@@ -210,9 +208,7 @@ class Document(dict):
         if doc.get(field) is None:
             doc[field] = []
         if not isinstance(doc[field], list):
-            raise CloudantException(
-                'The field {0} is not a list.'.format(field)
-            )
+            raise CloudantDocumentException(102, field)
         if value is not None:
             doc[field].append(value)
 
@@ -227,9 +223,7 @@ class Document(dict):
         :param value: Value to remove from the field list.
         """
         if not isinstance(doc[field], list):
-            raise CloudantException(
-                'The field {0} is not a list.'.format(field)
-            )
+            raise CloudantDocumentException(102, field)
         doc[field].remove(value)
 
     @staticmethod
@@ -314,10 +308,7 @@ class Document(dict):
         object.
         """
         if not self.get("_rev"):
-            raise CloudantException(
-                "Attempting to delete a doc with no _rev. Try running "
-                ".fetch first!"
-            )
+            raise CloudantDocumentException(103)
 
         del_resp = self.r_session.delete(
             self.document_url,

--- a/src/cloudant/error.py
+++ b/src/cloudant/error.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2015 IBM. All rights reserved.
+# Copyright (c) 2015, 2016 IBM. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,16 @@
 Module that contains common exception classes for the Cloudant Python client
 library.
 """
+from cloudant._messages import (
+    CLIENT,
+    DATABASE,
+    DESIGN_DOCUMENT,
+    DOCUMENT,
+    FEED,
+    INDEX,
+    REPLICATOR,
+    RESULT
+)
 
 class CloudantException(Exception):
     """
@@ -61,18 +71,115 @@ class ResultException(CloudantException):
     """
 
     def __init__(self, code=100, *args):
-        messages = {
-            100:'A general result exception was raised.',
-            101:'Failed to interpret the argument {0} as a valid key value or as a valid slice.',
-            102:'Cannot use {0} when performing key access or key slicing.  Found {1}.',
-            103:'Cannot use {0} for iteration.  Found {1}.',
-            104:'Invalid page_size: {0}'
-        }
-
         try:
-            msg = messages[code].format(*args)
-        # pylint: disable=broad-except
-        except Exception:
+            msg = RESULT[code].format(*args)
+        except (KeyError, IndexError):
             code = 100
-            msg = messages[code]
+            msg = RESULT[code]
         super(ResultException, self).__init__(msg, code)
+
+
+class CloudantClientException(CloudantException):
+    """
+    Provides a way to issue Cloudant library client specific exceptions.
+
+    :param int code: A code value used to identify the client exception.
+    :param args: A list of arguments used to format the exception message.
+    """
+    def __init__(self, code=100, *args):
+        try:
+            msg = CLIENT[code].format(*args)
+        except (KeyError, IndexError):
+            code = 100
+            msg = CLIENT[code]
+        super(CloudantClientException, self).__init__(msg, code)
+
+class CloudantDatabaseException(CloudantException):
+    """
+    Provides a way to issue Cloudant library database specific exceptions.
+
+    :param int code: A code value used to identify the database exception.
+    :param args: A list of arguments used to format the exception message.
+    """
+    def __init__(self, code=100, *args):
+        try:
+            msg = DATABASE[code].format(*args)
+        except (KeyError, IndexError):
+            code = 100
+            msg = DATABASE[code]
+        super(CloudantDatabaseException, self).__init__(msg, code)
+
+class CloudantDesignDocumentException(CloudantException):
+    """
+    Provides a way to issue Cloudant library design document exceptions.
+
+    :param int code: A code value used to identify the design doc exception.
+    :param args: A list of arguments used to format the exception message.
+    """
+    def __init__(self, code=100, *args):
+        try:
+            msg = DESIGN_DOCUMENT[code].format(*args)
+        except (KeyError, IndexError):
+            code = 100
+            msg = DESIGN_DOCUMENT[code]
+        super(CloudantDesignDocumentException, self).__init__(msg, code)
+
+class CloudantDocumentException(CloudantException):
+    """
+    Provides a way to issue Cloudant library document specific exceptions.
+
+    :param int code: A code value used to identify the document exception.
+    :param args: A list of arguments used to format the exception message.
+    """
+    def __init__(self, code=100, *args):
+        try:
+            msg = DOCUMENT[code].format(*args)
+        except (KeyError, IndexError):
+            code = 100
+            msg = DOCUMENT[code]
+        super(CloudantDocumentException, self).__init__(msg, code)
+
+class CloudantFeedException(CloudantException):
+    """
+    Provides a way to issue Cloudant library feed specific exceptions.
+
+    :param int code: A code value used to identify the feed exception.
+    :param args: A list of arguments used to format the exception message.
+    """
+    def __init__(self, code=100, *args):
+        try:
+            msg = FEED[code].format(*args)
+        except (KeyError, IndexError):
+            code = 100
+            msg = FEED[code]
+        super(CloudantFeedException, self).__init__(msg, code)
+
+class CloudantIndexException(CloudantException):
+    """
+    Provides a way to issue Cloudant library index specific exceptions.
+
+    :param int code: A code value used to identify the index exception.
+    :param args: A list of arguments used to format the exception message.
+    """
+    def __init__(self, code=100, *args):
+        try:
+            msg = INDEX[code].format(*args)
+        except (KeyError, IndexError):
+            code = 100
+            msg = INDEX[code]
+        super(CloudantIndexException, self).__init__(msg, code)
+
+class CloudantReplicatorException(CloudantException):
+    """
+    Provides a way to issue Cloudant library replicator specific exceptions.
+
+    :param int code: A code value used to identify the replicator exception.
+    :param args: A list of arguments used to format the exception message.
+    """
+    def __init__(self, code=100, *args):
+        try:
+            msg = REPLICATOR[code].format(*args)
+        except (KeyError, IndexError):
+            code = 100
+            msg = REPLICATOR[code]
+        super(CloudantReplicatorException, self).__init__(msg, code)

--- a/src/cloudant/feed.py
+++ b/src/cloudant/feed.py
@@ -20,7 +20,7 @@ continuous and non-continuous feeds like ``_changes`` and ``_db_updates``.
 import json
 
 from ._2to3 import iteritems_, next_, unicode_, STRTYPE, NONETYPE
-from .error import CloudantArgumentError, CloudantException
+from .error import CloudantArgumentError, CloudantFeedException
 from ._common_util import feed_arg_types, TYPE_CONVERTERS
 
 class Feed(object):
@@ -252,8 +252,7 @@ class InfiniteFeed(Feed):
         """
         while True:
             if self._source == 'CouchDB':
-                raise CloudantException(
-                    'Infinite _db_updates feed not supported for CouchDB.')
+                raise CloudantFeedException(101)
             if self._last_seq:
                 self._options.update({'since': self._last_seq})
                 self._resp = None

--- a/src/cloudant/index.py
+++ b/src/cloudant/index.py
@@ -24,7 +24,7 @@ from ._common_util import JSON_INDEX_TYPE
 from ._common_util import TEXT_INDEX_TYPE
 from ._common_util import SPECIAL_INDEX_TYPE
 from ._common_util import TEXT_INDEX_ARGS
-from .error import CloudantArgumentError, CloudantException
+from .error import CloudantArgumentError, CloudantIndexException
 
 class Index(object):
     """
@@ -252,13 +252,11 @@ class SpecialIndex(Index):
         A "special" index cannot be created.  This method is disabled for a
         SpecialIndex object.
         """
-        msg = 'Creating the \"special\" index is not allowed.'
-        raise CloudantException(msg)
+        raise CloudantIndexException(101)
 
     def delete(self):
         """
         A "special" index cannot be deleted.  This method is disabled for a
         SpecialIndex object.
         """
-        msg = 'Deleting the \"special\" index is not allowed.'
-        raise CloudantException(msg)
+        raise CloudantIndexException(102)

--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -30,7 +30,7 @@ import os
 import uuid
 
 from cloudant.result import Result, QueryResult
-from cloudant.error import CloudantException, CloudantArgumentError
+from cloudant.error import CloudantArgumentError, CloudantDatabaseException
 from cloudant.document import Document
 from cloudant.design_document import DesignDocument
 from cloudant.security_document import SecurityDocument
@@ -39,6 +39,44 @@ from cloudant.feed import Feed, InfiniteFeed
 
 from .unit_t_db_base import UnitTestDbBase
 from .. import unicode_
+
+class CloudantDatabaseExceptionTests(unittest.TestCase):
+    """
+    Ensure CloudantDatabaseException functions as expected.
+    """
+
+    def test_raise_without_code(self):
+        """
+        Ensure that a default exception/code is used if none is provided.
+        """
+        with self.assertRaises(CloudantDatabaseException) as cm:
+            raise CloudantDatabaseException()
+        self.assertEqual(cm.exception.status_code, 100)
+
+    def test_raise_using_invalid_code(self):
+        """
+        Ensure that a default exception/code is used if invalid code is provided.
+        """
+        with self.assertRaises(CloudantDatabaseException) as cm:
+            raise CloudantDatabaseException('foo')
+        self.assertEqual(cm.exception.status_code, 100)
+
+    def test_raise_without_args(self):
+        """
+        Ensure that a default exception/code is used if the message requested
+        by the code provided requires an argument list and none is provided.
+        """
+        with self.assertRaises(CloudantDatabaseException) as cm:
+            raise CloudantDatabaseException(400)
+        self.assertEqual(cm.exception.status_code, 100)
+
+    def test_raise_with_proper_code_and_args(self):
+        """
+        Ensure that the requested exception is raised.
+        """
+        with self.assertRaises(CloudantDatabaseException) as cm:
+            raise CloudantDatabaseException(400, 'foo')
+        self.assertEqual(cm.exception.status_code, 400)
 
 class DatabaseTests(UnitTestDbBase):
     """
@@ -217,10 +255,10 @@ class DatabaseTests(UnitTestDbBase):
         try:
             self.db.create_document(data, throw_on_exists=True)
             self.fail('Above statement should raise a CloudantException')
-        except CloudantException as err:
+        except CloudantDatabaseException as err:
             self.assertEqual(
                 str(err),
-                'Error - Document with id julia06 already exists.'
+                'Document with id julia06 already exists.'
                 )
 
     def test_create_document_without_id(self):

--- a/tests/unit/design_document_tests.py
+++ b/tests/unit/design_document_tests.py
@@ -30,9 +30,47 @@ import requests
 from cloudant.document import Document 
 from cloudant.design_document import DesignDocument
 from cloudant.view import View, QueryIndexView
-from cloudant.error import CloudantArgumentError, CloudantException
+from cloudant.error import CloudantArgumentError, CloudantDesignDocumentException
 
 from .unit_t_db_base import UnitTestDbBase
+
+class CloudantDesignDocumentExceptionTests(unittest.TestCase):
+    """
+    Ensure CloudantDesignDocumentException functions as expected.
+    """
+
+    def test_raise_without_code(self):
+        """
+        Ensure that a default exception/code is used if none is provided.
+        """
+        with self.assertRaises(CloudantDesignDocumentException) as cm:
+            raise CloudantDesignDocumentException()
+        self.assertEqual(cm.exception.status_code, 100)
+
+    def test_raise_using_invalid_code(self):
+        """
+        Ensure that a default exception/code is used if invalid code is provided.
+        """
+        with self.assertRaises(CloudantDesignDocumentException) as cm:
+            raise CloudantDesignDocumentException('foo')
+        self.assertEqual(cm.exception.status_code, 100)
+
+    def test_raise_without_args(self):
+        """
+        Ensure that a default exception/code is used if the message requested
+        by the code provided requires an argument list and none is provided.
+        """
+        with self.assertRaises(CloudantDesignDocumentException) as cm:
+            raise CloudantDesignDocumentException(104)
+        self.assertEqual(cm.exception.status_code, 100)
+
+    def test_raise_with_proper_code_and_args(self):
+        """
+        Ensure that the requested exception is raised.
+        """
+        with self.assertRaises(CloudantDesignDocumentException) as cm:
+            raise CloudantDesignDocumentException(104, 'foo')
+        self.assertEqual(cm.exception.status_code, 104)
 
 class DesignDocumentTests(UnitTestDbBase):
     """
@@ -173,7 +211,7 @@ class DesignDocumentTests(UnitTestDbBase):
         """
         ddoc = DesignDocument(self.db, '_design/ddoc001')
         ddoc['language'] = 'query'
-        with self.assertRaises(CloudantException) as cm:
+        with self.assertRaises(CloudantDesignDocumentException) as cm:
             ddoc.add_view('view001', {'foo': 'bar'})
         err = cm.exception
         self.assertEqual(
@@ -239,7 +277,7 @@ class DesignDocumentTests(UnitTestDbBase):
         self.db.create_document(data)
         ddoc = DesignDocument(self.db, '_design/ddoc001')
         ddoc.fetch()
-        with self.assertRaises(CloudantException) as cm:
+        with self.assertRaises(CloudantDesignDocumentException) as cm:
             ddoc.update_view(
                 'view001',
                 'function (doc) {\n  emit(doc._id, 1);\n}'
@@ -283,7 +321,7 @@ class DesignDocumentTests(UnitTestDbBase):
         self.db.create_document(data)
         ddoc = DesignDocument(self.db, '_design/ddoc001')
         ddoc.fetch()
-        with self.assertRaises(CloudantException) as cm:
+        with self.assertRaises(CloudantDesignDocumentException) as cm:
             ddoc.delete_view('view001')
         err = cm.exception
         self.assertEqual(
@@ -504,7 +542,7 @@ class DesignDocumentTests(UnitTestDbBase):
             'analyzer': {'name': 'perfield','default': 'keyword',
                          'fields': {'$default': 'german'}}}
         self.assertIsInstance(ddoc['indexes']['index001']['index'], dict)
-        with self.assertRaises(CloudantException) as cm:
+        with self.assertRaises(CloudantDesignDocumentException) as cm:
             ddoc.save()
         err = cm.exception
         self.assertEqual(
@@ -539,7 +577,7 @@ class DesignDocumentTests(UnitTestDbBase):
             'analyzer': {'name': 'perfield','default': 'keyword',
                          'fields': {'$default': 'german'}}}
         self.assertIsInstance(ddoc_remote['indexes']['index001']['index'], dict)
-        with self.assertRaises(CloudantException) as cm:
+        with self.assertRaises(CloudantDesignDocumentException) as cm:
             ddoc_remote.save()
         err = cm.exception
         self.assertEqual(
@@ -558,7 +596,7 @@ class DesignDocumentTests(UnitTestDbBase):
         db_copy = '{0}-copy'.format(self.db.database_name)
         ddoc.add_view('view001', view_map, view_reduce)
         ddoc['language'] = 'query'
-        with self.assertRaises(CloudantException) as cm:
+        with self.assertRaises(CloudantDesignDocumentException) as cm:
             ddoc.save()
         err = cm.exception
         self.assertEqual(
@@ -600,13 +638,13 @@ class DesignDocumentTests(UnitTestDbBase):
         self.db.create_document(data)
         ddoc = DesignDocument(self.db, '_design/ddoc001')
         ddoc.fetch()
-        with self.assertRaises(CloudantException) as cm:
+        with self.assertRaises(CloudantDesignDocumentException) as cm:
             ddoc['language'] = 'not-query'
             ddoc.save()
         err = cm.exception
         self.assertEqual(str(err), 'View view001 must be of type View.')
 
-        with self.assertRaises(CloudantException) as cm:
+        with self.assertRaises(CloudantDesignDocumentException) as cm:
             del ddoc['language']
             ddoc.save()
         err = cm.exception
@@ -1043,7 +1081,7 @@ class DesignDocumentTests(UnitTestDbBase):
                      '{"store": true}); }\n}',
             'analyzer': 'standard'}
         self.assertIsInstance(ddoc['indexes']['search001']['index'], str)
-        with self.assertRaises(CloudantException) as cm:
+        with self.assertRaises(CloudantDesignDocumentException) as cm:
             ddoc.save()
         err = cm.exception
         self.assertEqual(
@@ -1076,7 +1114,7 @@ class DesignDocumentTests(UnitTestDbBase):
         self.assertIsInstance(
             ddoc['indexes']['search001']['index'], str
         )
-        with self.assertRaises(CloudantException) as cm:
+        with self.assertRaises(CloudantDesignDocumentException) as cm:
             ddoc.save()
         err = cm.exception
         self.assertEqual(

--- a/tests/unit/index_tests.py
+++ b/tests/unit/index_tests.py
@@ -33,10 +33,39 @@ from cloudant.query import Query
 from cloudant.view import QueryIndexView
 from cloudant.design_document import DesignDocument
 from cloudant.document import Document
-from cloudant.error import CloudantArgumentError, CloudantException
+from cloudant.error import CloudantArgumentError, CloudantIndexException
 
 from .. import PY2
 from .unit_t_db_base import UnitTestDbBase
+
+class CloudantIndexExceptionTests(unittest.TestCase):
+    """
+    Ensure CloudantIndexException functions as expected.
+    """
+
+    def test_raise_without_code(self):
+        """
+        Ensure that a default exception/code is used if none is provided.
+        """
+        with self.assertRaises(CloudantIndexException) as cm:
+            raise CloudantIndexException()
+        self.assertEqual(cm.exception.status_code, 100)
+
+    def test_raise_using_invalid_code(self):
+        """
+        Ensure that a default exception/code is used if invalid code is provided.
+        """
+        with self.assertRaises(CloudantIndexException) as cm:
+            raise CloudantIndexException('foo')
+        self.assertEqual(cm.exception.status_code, 100)
+
+    def test_raise_with_proper_code_and_args(self):
+        """
+        Ensure that the requested exception is raised.
+        """
+        with self.assertRaises(CloudantIndexException) as cm:
+            raise CloudantIndexException(101)
+        self.assertEqual(cm.exception.status_code, 101)
 
 @unittest.skipUnless(
     os.environ.get('RUN_CLOUDANT_TESTS') is not None,
@@ -591,7 +620,7 @@ class SpecialIndexTests(unittest.TestCase):
         Test that the SpecialIndex create method is disabled.
         """
         index = SpecialIndex(self.db, fields=[{'_id': 'asc'}])
-        with self.assertRaises(CloudantException) as cm:
+        with self.assertRaises(CloudantIndexException) as cm:
             index.create()
         err = cm.exception
         self.assertEqual(
@@ -604,7 +633,7 @@ class SpecialIndexTests(unittest.TestCase):
         Test that the SpecialIndex delete method is disabled.
         """
         index = SpecialIndex(self.db, fields=[{'_id': 'asc'}])
-        with self.assertRaises(CloudantException) as cm:
+        with self.assertRaises(CloudantIndexException) as cm:
             index.delete()
         err = cm.exception
         self.assertEqual(

--- a/tests/unit/replicator_tests.py
+++ b/tests/unit/replicator_tests.py
@@ -29,10 +29,48 @@ import requests
 
 from cloudant.replicator import Replicator
 from cloudant.document import Document
-from cloudant.error import CloudantException
+from cloudant.error import CloudantReplicatorException, CloudantClientException
 
 from .unit_t_db_base import UnitTestDbBase
 from .. import unicode_
+
+class CloudantReplicatorExceptionTests(unittest.TestCase):
+    """
+    Ensure CloudantReplicatorException functions as expected.
+    """
+
+    def test_raise_without_code(self):
+        """
+        Ensure that a default exception/code is used if none is provided.
+        """
+        with self.assertRaises(CloudantReplicatorException) as cm:
+            raise CloudantReplicatorException()
+        self.assertEqual(cm.exception.status_code, 100)
+
+    def test_raise_using_invalid_code(self):
+        """
+        Ensure that a default exception/code is used if invalid code is provided.
+        """
+        with self.assertRaises(CloudantReplicatorException) as cm:
+            raise CloudantReplicatorException('foo')
+        self.assertEqual(cm.exception.status_code, 100)
+
+    def test_raise_without_args(self):
+        """
+        Ensure that a default exception/code is used if the message requested
+        by the code provided requires an argument list and none is provided.
+        """
+        with self.assertRaises(CloudantReplicatorException) as cm:
+            raise CloudantReplicatorException(404)
+        self.assertEqual(cm.exception.status_code, 100)
+
+    def test_raise_with_proper_code_and_args(self):
+        """
+        Ensure that the requested exception is raised.
+        """
+        with self.assertRaises(CloudantReplicatorException) as cm:
+            raise CloudantReplicatorException(404, 'foo')
+        self.assertEqual(cm.exception.status_code, 404)
 
 class ReplicatorTests(UnitTestDbBase):
     """
@@ -102,10 +140,10 @@ class ReplicatorTests(UnitTestDbBase):
             self.client.disconnect()
             repl = Replicator(self.client)
             self.fail('Above statement should raise a CloudantException')
-        except CloudantException as err:
+        except CloudantClientException as err:
             self.assertEqual(
                 str(err),
-                'Unable to acquire _replicator database.  '
+                'Database _replicator does not exist. '
                 'Verify that the client is valid and try again.'
             )
         finally:
@@ -177,7 +215,7 @@ class ReplicatorTests(UnitTestDbBase):
         try:
             repl_doc = self.replicator.create_replication()
             self.fail('Above statement should raise a CloudantException')
-        except CloudantException as err:
+        except CloudantReplicatorException as err:
             self.assertEqual(
                 str(err),
                 'You must specify either a source_db Database '
@@ -192,7 +230,7 @@ class ReplicatorTests(UnitTestDbBase):
         try:
             repl_doc = self.replicator.create_replication(self.db)
             self.fail('Above statement should raise a CloudantException')
-        except CloudantException as err:
+        except CloudantReplicatorException as err:
             self.assertEqual(
                 str(err),
                 'You must specify either a target_db Database '
@@ -252,10 +290,10 @@ class ReplicatorTests(UnitTestDbBase):
         try:
             self.replicator.replication_state(repl_id)
             self.fail('Above statement should raise a CloudantException')
-        except CloudantException as err:
+        except CloudantReplicatorException as err:
             self.assertEqual(
                 str(err),
-                'Replication {} not found'.format(repl_id)
+                'Replication with id {} not found.'.format(repl_id)
             )
             self.assertIsNone(repl_state)
 
@@ -288,10 +326,10 @@ class ReplicatorTests(UnitTestDbBase):
         try:
             self.replicator.stop_replication(repl_id)
             self.fail('Above statement should raise a CloudantException')
-        except CloudantException as err:
+        except CloudantReplicatorException as err:
             self.assertEqual(
                 str(err),
-                'Could not find replication with id {}'.format(repl_id)
+                'Replication with id {} not found.'.format(repl_id)
             )
 
     def test_follow_replication(self):


### PR DESCRIPTION
## What
Using `ResultException` as an example, we can improve the error handling design by having class exceptions for modules that currently contain `CloudantException`, and by moving the error messages from `error.py` and other moduless to an internal `messages.py` module to reduce clutter.

## How
- New exception classes for client, database, design document, document, feed, index, replicator modules
- All CloudantException and ResultException messages moved to _messages.py module
- Added status codes to all exception messages.
   - 4xx for status codes that resembles a typical response code and 1xx for other status codes.  
- Removed duplicate error message in `Client._usage_endpoint` by using boolean
- Fixed up exception messages in modules

## Testing
Fixed up exception messages in test cases.
Added new test cases for exception classes

## Issues
fixes #259 
#65 