### PR TITLE
266 improve cloudant argument and exception

### DIFF
--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -174,33 +174,21 @@ def py_to_couch_validate(key, val):
     Validates the individual parameter key and value.
     """
     if key not in RESULT_ARG_TYPES:
-        msg = 'Invalid argument {0}'.format(key)
-        raise CloudantArgumentError(msg)
+        raise CloudantArgumentError(116, key)
     # pylint: disable=unidiomatic-typecheck
     # Validate argument values and ensure that a boolean is not passed in
     # if an integer is expected
     if (not isinstance(val, RESULT_ARG_TYPES[key]) or
             (type(val) is bool and int in RESULT_ARG_TYPES[key])):
-        msg = 'Argument {0} not instance of expected type: {1}'.format(
-            key,
-            RESULT_ARG_TYPES[key]
-        )
-        raise CloudantArgumentError(msg)
+        raise CloudantArgumentError(117, key, RESULT_ARG_TYPES[key])
     if key == 'keys':
         for key_list_val in val:
             if (not isinstance(key_list_val, RESULT_ARG_TYPES['key']) or
                     type(key_list_val) is bool):
-                msg = 'Key list element not of expected type: {0}'.format(
-                    RESULT_ARG_TYPES['key']
-                )
-                raise CloudantArgumentError(msg)
+                raise CloudantArgumentError(134, RESULT_ARG_TYPES['key'])
     if key == 'stale':
         if val not in ('ok', 'update_after'):
-            msg = (
-                'Invalid value for stale option {0} '
-                'must be ok or update_after'
-            ).format(val)
-            raise CloudantArgumentError(msg)
+            raise CloudantArgumentError(135, val)
 
 def _py_to_couch_translate(key, val):
     """
@@ -216,8 +204,7 @@ def _py_to_couch_translate(key, val):
             arg_converter = TYPE_CONVERTERS.get(type(val))
             return {key: arg_converter(val)}
     except Exception as ex:
-        msg = 'Error converting argument {0}: {1}'.format(key, ex)
-        raise CloudantArgumentError(msg)
+        raise CloudantArgumentError(136, key, ex)
 
 def type_or_none(typerefs, value):
     """

--- a/src/cloudant/_messages.py
+++ b/src/cloudant/_messages.py
@@ -16,9 +16,61 @@
 Module that contains exception messages for the Cloudant Python client
 library.
 """
+ARGUMENT_ERROR = {
+    100: 'A general Cloudant argument error was raised.',
+    # Client
+    101: 'Invalid year and/or month supplied.  Found: year - {0}, month - {1}',
+    # Database
+    102: 'Invalid role(s) provided: {0}.  Valid roles are: {1}',
+    103: 'Invalid index type: {0}.  Index type must be '
+         'either \"json\" or \"text\".',
+    104: 'A single query/q parameter is required.  Found: {0}',
+    105: 'Invalid argument: {0}',
+    106: 'Argument {0} is not an instance of expected type: {1}',
+    # Design document
+    107: 'View {0} already exists in this design doc.',
+    108: 'An index with name {0} already exists in this design doc.',
+    109: 'A list with name {0} already exists in this design doc.',
+    110: 'A show function with name {0} already exists in this design doc.',
+    111: 'View {0} does not exist in this design doc.',
+    112: 'An index with name {0} does not exist in this design doc.',
+    113: 'A list with name {0} does not exist in this design doc.',
+    114: 'A show function with name {0} does not exist in this design doc.',
+    # Feed
+    115: 'Error converting argument {0}: {1}',
+    116: 'Invalid argument {0}',
+    117: 'Argument {0} not instance of expected type: {1}',
+    118: 'Argument {0} must be > 0.  Found: {1}',
+    119: 'Invalid value ({0}) for feed option.  Must be one of {1}',
+    120: 'Invalid value ({0}) for style option.  Must be main_only, '
+         'or all_docs.',
+    121: 'Invalid infinite feed option: {0}.  Must be set to continuous.',
+    # Index
+    122: 'The design document id: {0} is not a string.',
+    123: 'The index name: {0} is not a string.',
+    124: '{0} provided as argument(s).  A JSON index requires that '
+         'only a \'fields\' argument is provided.',
+    125: 'Deleting an index requires a design document id be provided.',
+    126: 'Deleting an index requires an index name be provided.',
+    127: 'Invalid argument: {0}',
+    128: 'Argument {0} is not an instance of expected type: {1}',
+    # Query
+    129: 'Invalid argument: {0}',
+    130: 'Argument {0} is not an instance of expected type: {1}',
+    131: 'No selector in the query or the selector was empty.  '
+         'Add a selector to define the query and retry.',
+    # View
+    132: 'The map property must be a dictionary.',
+    133: 'The reduce property must be a string.',
+    # Common_util
+    134: 'Key list element not of expected type: {0}',
+    135: 'Invalid value for stale option {0} must be ok or update_after.',
+    136: 'Error converting argument {0}: {1}'
+}
+
 CLIENT = {
     100: 'A general Cloudant client exception was raised.',
-    101: 'Value must be set to a Database object. Found type: {0}.',
+    101: 'Value must be set to a Database object. Found type: {0}',
     102: 'You must provide a url or an account.',
     404: 'Database {0} does not exist. Verify that the client is valid and try again.',
     409: 'Database {0} already exists.'
@@ -26,9 +78,9 @@ CLIENT = {
 
 DATABASE = {
     100: 'A general Cloudant database exception was raised.',
-    101: 'Unexpected index type. Found: {0}.',
+    101: 'Unexpected index type. Found: {0}',
     400: 'Invalid database name during creation. Found: {0}',
-    401: 'Unauthorized to create database {0}.',
+    401: 'Unauthorized to create database {0}',
     409: 'Document with id {0} already exists.'
 }
 
@@ -74,7 +126,16 @@ REPLICATOR = {
 RESULT = {
     100: 'A general result exception was raised.',
     101: 'Failed to interpret the argument {0} as a valid key value or as a valid slice.',
-    102: 'Cannot use {0} when performing key access or key slicing. Found {1}.',
-    103: 'Cannot use {0} for iteration. Found {1}.',
+    102: 'Cannot use {0} when performing key access or key slicing. Found {1}',
+    103: 'Cannot use {0} for iteration. Found {1}',
     104: 'Invalid page_size: {0}'
+}
+
+VIEW = {
+    100: 'A general view exception was raised.',
+    101: 'A QueryIndexView is not callable.  If you wish to execute a query '
+         'use the database \'get_query_result\' convenience method.',
+    102: 'Cannot create a custom result context manager using a '
+         'QueryIndexView.  If you wish to execute a query use the '
+         'database \'get_query_result\' convenience method instead.'
 }

--- a/src/cloudant/client.py
+++ b/src/cloudant/client.py
@@ -549,9 +549,7 @@ class Cloudant(CouchDB):
                 err = True
 
         if err:
-            msg = ('Invalid year and/or month supplied.  '
-                   'Found: year - {0}, month - {1}').format(year, month)
-            raise CloudantArgumentError(msg)
+            raise CloudantArgumentError(101, year, month)
         else:
             resp.raise_for_status()
             return resp.json()

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -986,10 +986,7 @@ class CloudantDatabase(CouchDatabase):
             perms = list(set(roles))
 
         if not perms:
-            msg = (
-                'Invalid role(s) provided: {0}.  Valid roles are: {1}.'
-            ).format(roles, valid_roles)
-            raise CloudantArgumentError(msg)
+            raise CloudantArgumentError(102, roles, valid_roles)
 
         data[username] = perms
         doc['cloudant'] = data
@@ -1131,11 +1128,7 @@ class CloudantDatabase(CouchDatabase):
         elif index_type == TEXT_INDEX_TYPE:
             index = TextIndex(self, design_document_id, index_name, **kwargs)
         else:
-            msg = (
-                'Invalid index type: {0}.  '
-                'Index type must be either \"json\" or \"text\"'
-            ).format(index_type)
-            raise CloudantArgumentError(msg)
+            raise CloudantArgumentError(103, index_type)
         index.create()
         return index
 
@@ -1155,11 +1148,7 @@ class CloudantDatabase(CouchDatabase):
         elif index_type == TEXT_INDEX_TYPE:
             index = TextIndex(self, design_document_id, index_name)
         else:
-            msg = (
-                'Invalid index type: {0}.  '
-                'Index type must be either \"json\" or \"text\"'
-            ).format(index_type)
-            raise CloudantArgumentError(msg)
+            raise CloudantArgumentError(103, index_type)
         index.delete()
 
     def get_query_result(self, selector, fields=None, raw_result=False,
@@ -1346,20 +1335,14 @@ class CloudantDatabase(CouchDatabase):
         param_query = query_params.get('query')
         # Either q or query parameter is required
         if bool(param_q) == bool(param_query):
-            raise CloudantArgumentError(
-                'A single query/q parameter is required. '
-                'Found: {0}'.format(query_params))
+            raise CloudantArgumentError(104, query_params)
 
         # Validate query arguments and values
         for key, val in iteritems_(query_params):
             if key not in list(SEARCH_INDEX_ARGS.keys()):
-                msg = 'Invalid argument: {0}'.format(key)
-                raise CloudantArgumentError(msg)
+                raise CloudantArgumentError(105, key)
             if not isinstance(val, SEARCH_INDEX_ARGS[key]):
-                msg = (
-                    'Argument {0} is not an instance of expected type: {1}'
-                ).format(key, SEARCH_INDEX_ARGS[key])
-                raise CloudantArgumentError(msg)
+                raise CloudantArgumentError(106, key, SEARCH_INDEX_ARGS[key])
         # Execute query search
         headers = {'Content-Type': 'application/json'}
         ddoc = DesignDocument(self, ddoc_id)

--- a/src/cloudant/design_document.py
+++ b/src/cloudant/design_document.py
@@ -282,8 +282,7 @@ class DesignDocument(Document):
         :param str reduce_func: Optional Javascript reduce function.
         """
         if self.get_view(view_name) is not None:
-            msg = "View {0} already exists in this design doc".format(view_name)
-            raise CloudantArgumentError(msg)
+            raise CloudantArgumentError(107, view_name)
         if self.get('language', None) == QUERY_LANGUAGE:
             raise CloudantDesignDocumentException(101)
 
@@ -300,9 +299,7 @@ class DesignDocument(Document):
         :param analyzer: Optional analyzer for this search index.
         """
         if self.get_index(index_name) is not None:
-            msg = ('An index with name {0} already exists in this design doc'
-                   .format(index_name))
-            raise CloudantArgumentError(msg)
+            raise CloudantArgumentError(108, index_name)
         if analyzer is not None:
             search = {'index': codify(search_func), 'analyzer': analyzer}
         else:
@@ -319,9 +316,7 @@ class DesignDocument(Document):
         :param str list_func: Javascript list function.
         """
         if self.get_list_function(list_name) is not None:
-            msg = ('A list with name {0} already exists in this design doc'
-                   .format(list_name))
-            raise CloudantArgumentError(msg)
+            raise CloudantArgumentError(109, list_name)
 
         self.lists.__setitem__(list_name, codify(list_func))
 
@@ -334,9 +329,7 @@ class DesignDocument(Document):
         :param show_func: Javascript show function.
         """
         if self.get_show_function(show_name) is not None:
-            msg = ('A show function with name {0} already exists in this design doc'
-                   .format(show_name))
-            raise CloudantArgumentError(msg)
+            raise CloudantArgumentError(110, show_name)
 
         self.shows.__setitem__(show_name, show_func)
 
@@ -356,8 +349,7 @@ class DesignDocument(Document):
         """
         view = self.get_view(view_name)
         if view is None:
-            msg = "View {0} does not exist in this design doc".format(view_name)
-            raise CloudantArgumentError(msg)
+            raise CloudantArgumentError(111, view_name)
         if isinstance(view, QueryIndexView):
             raise CloudantDesignDocumentException(102)
 
@@ -375,9 +367,7 @@ class DesignDocument(Document):
         """
         search = self.get_index(index_name)
         if search is None:
-            msg = ('An index with name {0} does not exist in this design doc'
-                   .format(index_name))
-            raise CloudantArgumentError(msg)
+            raise CloudantArgumentError(112, index_name)
         if analyzer is not None:
             search = {'index': codify(search_func), 'analyzer': analyzer}
         else:
@@ -394,9 +384,7 @@ class DesignDocument(Document):
         :param str list_func: Javascript list function.
         """
         if self.get_list_function(list_name) is None:
-            msg = ('A list with name {0} does not exist in this design doc'
-                   .format(list_name))
-            raise CloudantArgumentError(msg)
+            raise CloudantArgumentError(113, list_name)
 
         self.lists.__setitem__(list_name, codify(list_func))
 
@@ -409,9 +397,7 @@ class DesignDocument(Document):
         :param show_func: Javascript show function.
         """
         if self.get_show_function(show_name) is None:
-            msg = ('A show function with name {0} does not exist in this design doc'
-                   .format(show_name))
-            raise CloudantArgumentError(msg)
+            raise CloudantArgumentError(114, show_name)
 
         self.shows.__setitem__(show_name, show_func)
 

--- a/src/cloudant/error.py
+++ b/src/cloudant/error.py
@@ -17,6 +17,7 @@ Module that contains common exception classes for the Cloudant Python client
 library.
 """
 from cloudant._messages import (
+    ARGUMENT_ERROR,
     CLIENT,
     DATABASE,
     DESIGN_DOCUMENT,
@@ -24,8 +25,8 @@ from cloudant._messages import (
     FEED,
     INDEX,
     REPLICATOR,
-    RESULT
-)
+    RESULT,
+    VIEW)
 
 class CloudantException(Exception):
     """
@@ -46,18 +47,21 @@ class CloudantException(Exception):
 class CloudantArgumentError(CloudantException):
     """
     Provides a way to issue Cloudant Python client library specific exceptions
-    that pertain to invalid argument errors.  A CloudantArgumentError object is
-    instantiated with a message and optional code where the code defaults to
-    400.
+    that pertain to invalid argument errors.
 
     Note:  The intended use for this class is internal to the Cloudant Python
     client library.
 
-    :param str msg: A message that describes the exception.
     :param int code: An optional code value used to identify the exception.
-        Defaults to 400.
+        Defaults to 100.
+    :param args: A list of arguments used to format the exception message.
     """
-    def __init__(self, msg, code=400):
+    def __init__(self, code=100, *args):
+        try:
+            msg = ARGUMENT_ERROR[code].format(*args)
+        except (KeyError, IndexError):
+            code = 100
+            msg = ARGUMENT_ERROR[code]
         super(CloudantArgumentError, self).__init__(msg, code)
 
 class ResultException(CloudantException):
@@ -183,3 +187,18 @@ class CloudantReplicatorException(CloudantException):
             code = 100
             msg = REPLICATOR[code]
         super(CloudantReplicatorException, self).__init__(msg, code)
+
+class CloudantViewException(CloudantException):
+    """
+    Provides a way to issue Cloudant library view specific exceptions.
+
+    :param int code: A code value used to identify the view exception.
+    :param args: A list of arguments used to format the exception message.
+    """
+    def __init__(self, code=100, *args):
+        try:
+            msg = VIEW[code].format(*args)
+        except (KeyError, IndexError):
+            code = 100
+            msg = VIEW[code]
+        super(CloudantViewException, self).__init__(msg, code)

--- a/src/cloudant/feed.py
+++ b/src/cloudant/feed.py
@@ -103,8 +103,7 @@ class Feed(object):
                     arg_converter = TYPE_CONVERTERS.get(type(val))
                     translation[key] = arg_converter(val)
             except Exception as ex:
-                msg = 'Error converting argument {0}: {1}'.format(key, ex)
-                raise CloudantArgumentError(msg)
+                raise CloudantArgumentError(115, key, ex)
         return translation
 
     def _validate(self, key, val, arg_types):
@@ -113,28 +112,20 @@ class Feed(object):
         the feed.
         """
         if key not in arg_types:
-            raise CloudantArgumentError('Invalid argument {0}'.format(key))
+            raise CloudantArgumentError(116, key)
         if (not isinstance(val, arg_types[key]) or
                 (isinstance(val, bool) and int in arg_types[key])):
-            msg = 'Argument {0} not instance of expected type: {1}'.format(
-                key, arg_types[key])
-            raise CloudantArgumentError(msg)
+            raise CloudantArgumentError(117, key, arg_types[key])
         if isinstance(val, int) and val <= 0 and not isinstance(val, bool):
-            msg = 'Argument {0} must be > 0.  Found: {1}'.format(key, val)
-            raise CloudantArgumentError(msg)
+            raise CloudantArgumentError(118, key, val)
         if key == 'feed':
             valid_vals = ('continuous', 'normal', 'longpoll')
             if self._source == 'CouchDB':
                 valid_vals = ('continuous', 'longpoll')
             if val not in valid_vals:
-                msg = (
-                    'Invalid value ({0}) for feed option.  Must be one of {1}.'
-                ).format(val, valid_vals)
-                raise CloudantArgumentError(msg)
+                raise CloudantArgumentError(119, val, valid_vals)
         if key == 'style' and val not in ('main_only', 'all_docs'):
-            msg = ('Invalid value ({0}) for style option.  Must be main_only, '
-                   'or all_docs.').format(val)
-            raise CloudantArgumentError(msg)
+            raise CloudantArgumentError(120, val)
 
     def __iter__(self):
         """
@@ -237,10 +228,7 @@ class InfiniteFeed(Feed):
         the feed.
         """
         if key == 'feed' and val != 'continuous':
-            msg = (
-                'Invalid infinite feed option: {0}.  Must be set to continuous.'
-            ).format(val)
-            raise CloudantArgumentError(msg)
+            raise CloudantArgumentError(121, val)
         super(InfiniteFeed, self)._validate(key, val, arg_types)
 
     def next(self):

--- a/src/cloudant/index.py
+++ b/src/cloudant/index.py
@@ -128,16 +128,12 @@ class Index(object):
                 else:
                     payload['ddoc'] = self._ddoc_id
             else:
-                msg = (
-                    'The design document id: {0} is not a string.'
-                ).format(self._ddoc_id)
-                raise CloudantArgumentError(msg)
+                raise CloudantArgumentError(122, self._ddoc_id)
         if self._name and self._name != '':
             if isinstance(self._name, STRTYPE):
                 payload['name'] = self._name
             else:
-                msg = 'The index name: {0} is not a string.'.format(self._name)
-                raise CloudantArgumentError(msg)
+                raise CloudantArgumentError(123, self._name)
         self._def_check()
         payload['index'] = self._def
 
@@ -157,22 +153,16 @@ class Index(object):
         Checks that the only definition provided is a "fields" definition.
         """
         if list(self._def.keys()) != ['fields']:
-            msg = (
-                '{0} provided as argument(s).  A JSON index requires that '
-                'only a \'fields\' argument is provided.'
-            ).format(self._def)
-            raise CloudantArgumentError(msg)
+            raise CloudantArgumentError(124, self._def)
 
     def delete(self):
         """
         Removes the current index from the remote database.
         """
         if not self._ddoc_id:
-            msg = 'Deleting an index requires a design document id be provided.'
-            raise CloudantArgumentError(msg)
+            raise CloudantArgumentError(125)
         if not self._name:
-            msg = 'Deleting an index requires an index name be provided.'
-            raise CloudantArgumentError(msg)
+            raise CloudantArgumentError(126)
         ddoc_id = self._ddoc_id
         if ddoc_id.startswith('_design/'):
             ddoc_id = ddoc_id[8:]
@@ -216,13 +206,9 @@ class TextIndex(Index):
         if self._def != dict():
             for key, val in iteritems_(self._def):
                 if key not in list(TEXT_INDEX_ARGS.keys()):
-                    msg = 'Invalid argument: {0}'.format(key)
-                    raise CloudantArgumentError(msg)
+                    raise CloudantArgumentError(127, key)
                 if not isinstance(val, TEXT_INDEX_ARGS[key]):
-                    msg = (
-                        'Argument {0} is not an instance of expected type: {1}'
-                    ).format(key, TEXT_INDEX_ARGS[key])
-                    raise CloudantArgumentError(msg)
+                    raise CloudantArgumentError(128, key, TEXT_INDEX_ARGS[key])
 
 class SpecialIndex(Index):
     """

--- a/src/cloudant/query.py
+++ b/src/cloudant/query.py
@@ -159,19 +159,11 @@ class Query(dict):
         # Validate query arguments and values
         for key, val in iteritems_(data):
             if key not in list(QUERY_ARG_TYPES.keys()):
-                msg = 'Invalid argument: {0}'.format(key)
-                raise CloudantArgumentError(msg)
+                raise CloudantArgumentError(129, key)
             if not isinstance(val, QUERY_ARG_TYPES[key]):
-                msg = (
-                    'Argument {0} is not an instance of expected type: {1}'
-                ).format(key, QUERY_ARG_TYPES[key])
-                raise CloudantArgumentError(msg)
+                raise CloudantArgumentError(130, key, QUERY_ARG_TYPES[key])
         if data.get('selector', None) is None or data.get('selector') == {}:
-            msg = (
-                'No selector in the query or the selector was empty.  '
-                'Add a selector to define the query and retry.'
-            )
-            raise CloudantArgumentError(msg)
+            raise CloudantArgumentError(131)
 
         # Execute query find
         headers = {'Content-Type': 'application/json'}

--- a/src/cloudant/view.py
+++ b/src/cloudant/view.py
@@ -21,7 +21,7 @@ import posixpath
 from ._2to3 import STRTYPE
 from ._common_util import codify, get_docs
 from .result import Result
-from .error import CloudantArgumentError, CloudantException
+from .error import CloudantArgumentError, CloudantViewException
 
 class View(dict):
     """
@@ -301,9 +301,9 @@ class QueryIndexView(View):
     """
     def __init__(self, ddoc, view_name, map_fields, reduce_func, **kwargs):
         if not isinstance(map_fields, dict):
-            raise CloudantArgumentError('The map property must be a dictionary')
+            raise CloudantArgumentError(132)
         if not isinstance(reduce_func, STRTYPE):
-            raise CloudantArgumentError('The reduce property must be a string.')
+            raise CloudantArgumentError(133)
         super(QueryIndexView, self).__init__(
             ddoc,
             view_name,
@@ -334,7 +334,7 @@ class QueryIndexView(View):
         if isinstance(map_func, dict):
             self['map'] = map_func
         else:
-            raise CloudantArgumentError('The map property must be a dictionary')
+            raise CloudantArgumentError(132)
 
     @property
     def reduce(self):
@@ -356,7 +356,7 @@ class QueryIndexView(View):
         if isinstance(reduce_func, STRTYPE):
             self['reduce'] = reduce_func
         else:
-            raise CloudantArgumentError('The reduce property must be a string')
+            raise CloudantArgumentError(133)
 
     def __call__(self, **kwargs):
         """
@@ -364,10 +364,7 @@ class QueryIndexView(View):
         using a query index, use
         :func:`~cloudant.database.CloudantDatabase.get_query_result` instead.
         """
-        raise CloudantException(
-            'A QueryIndexView is not callable.  If you wish to execute a query '
-            'use the database \'get_query_result\' convenience method.'
-        )
+        raise CloudantViewException(101)
 
     def custom_result(self, **options):
         """
@@ -378,8 +375,4 @@ class QueryIndexView(View):
         query using a query index, use
         :func:`~cloudant.database.CloudantDatabase.get_query_result` instead.
         """
-        raise CloudantException(
-            'Cannot create a custom result context manager using a '
-            'QueryIndexView.  If you wish to execute a query use the '
-            'database \'get_query_result\' convenience method instead.'
-        )
+        raise CloudantViewException(102)

--- a/tests/unit/client_tests.py
+++ b/tests/unit/client_tests.py
@@ -433,7 +433,7 @@ class ClientTests(UnitTestDbBase):
         except CloudantClientException as err:
             self.assertEqual(
                 str(err),
-                'Value must be set to a Database object. Found type: str.')
+                'Value must be set to a Database object. Found type: str')
         finally:
             self.client.disconnect()
 

--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -979,7 +979,7 @@ class CloudantDatabaseTests(UnitTestDbBase):
             'Invalid role(s) provided: '
             '[\'_writer\', \'_invalid_role\'].  Valid roles are: '
             '[\'_reader\', \'_writer\', \'_admin\', \'_replicator\', '
-            '\'_db_updates\', \'_design\', \'_shards\', \'_security\'].'
+            '\'_db_updates\', \'_design\', \'_shards\', \'_security\']'
         )
 
     def test_share_database_empty_role_list(self):
@@ -994,7 +994,7 @@ class CloudantDatabaseTests(UnitTestDbBase):
             str(err),
             'Invalid role(s) provided: [].  Valid roles are: '
             '[\'_reader\', \'_writer\', \'_admin\', \'_replicator\', '
-            '\'_db_updates\', \'_design\', \'_shards\', \'_security\'].'
+            '\'_db_updates\', \'_design\', \'_shards\', \'_security\']'
         )
 
     def test_unshare_database(self):
@@ -1263,7 +1263,7 @@ class CloudantDatabaseTests(UnitTestDbBase):
         self.assertEqual(
             str(err),
             'Invalid index type: special.  '
-            'Index type must be either \"json\" or \"text\"'
+            'Index type must be either \"json\" or \"text\".'
         )
 
     def test_delete_json_index(self):
@@ -1302,7 +1302,7 @@ class CloudantDatabaseTests(UnitTestDbBase):
         self.assertEqual(
             str(err),
             'Invalid index type: special.  '
-            'Index type must be either \"json\" or \"text\"'
+            'Index type must be either \"json\" or \"text\".'
         )
 
     def test_get_query_indexes_raw(self):

--- a/tests/unit/design_document_tests.py
+++ b/tests/unit/design_document_tests.py
@@ -202,7 +202,7 @@ class DesignDocumentTests(UnitTestDbBase):
         except CloudantArgumentError as err:
             self.assertEqual(
                 str(err),
-                'View view001 already exists in this design doc'
+                'View view001 already exists in this design doc.'
             )
 
     def test_adding_query_index_view(self):
@@ -254,7 +254,7 @@ class DesignDocumentTests(UnitTestDbBase):
         except CloudantArgumentError as err:
             self.assertEqual(
                 str(err),
-                'View view001 does not exist in this design doc'
+                'View view001 does not exist in this design doc.'
             )
 
     def test_update_query_index_view(self):
@@ -924,7 +924,7 @@ class DesignDocumentTests(UnitTestDbBase):
         err = cm.exception
         self.assertEqual(
             str(err),
-            'An index with name search001 already exists in this design doc'
+            'An index with name search001 already exists in this design doc.'
         )
 
     def test_update_a_search_index(self):
@@ -993,7 +993,7 @@ class DesignDocumentTests(UnitTestDbBase):
         err = cm.exception
         self.assertEqual(
             str(err),
-            'An index with name search001 does not exist in this design doc'
+            'An index with name search001 does not exist in this design doc.'
         )
 
     def test_delete_a_search_index(self):
@@ -1281,7 +1281,7 @@ class DesignDocumentTests(UnitTestDbBase):
         err = cm.exception
         self.assertEqual(
             str(err),
-            'A list with name list001 already exists in this design doc'
+            'A list with name list001 already exists in this design doc.'
         )
 
     def test_update_a_list_function(self):
@@ -1326,7 +1326,7 @@ class DesignDocumentTests(UnitTestDbBase):
         err = cm.exception
         self.assertEqual(
             str(err),
-            'A list with name list001 does not exist in this design doc'
+            'A list with name list001 does not exist in this design doc.'
         )
 
     def test_delete_a_list_function(self):
@@ -1585,7 +1585,7 @@ class DesignDocumentTests(UnitTestDbBase):
         err = cm.exception
         self.assertEqual(
             str(err),
-            'A show function with name show001 already exists in this design doc'
+            'A show function with name show001 already exists in this design doc.'
         )
 
     def test_update_a_show_function(self):
@@ -1630,7 +1630,7 @@ class DesignDocumentTests(UnitTestDbBase):
         err = cm.exception
         self.assertEqual(
             str(err),
-            'A show function with name show001 does not exist in this design doc'
+            'A show function with name show001 does not exist in this design doc.'
         )
 
     def test_delete_a_show_function(self):

--- a/tests/unit/infinite_feed_tests.py
+++ b/tests/unit/infinite_feed_tests.py
@@ -121,8 +121,10 @@ class InfiniteFeedTests(UnitTestDbBase):
         feed = InfiniteFeed(self.db, feed='longpoll')
         with self.assertRaises(CloudantArgumentError) as cm:
             invalid_feed = [x for x in feed]
-        self.assertEqual(str(cm.exception), 
-            'Invalid infinite feed option: longpoll.  Must be set to continuous.')
+        self.assertEqual(
+            str(cm.exception),
+            'Invalid infinite feed option: longpoll.  Must be set to continuous.'
+        )
 
     @unittest.skipIf(os.environ.get('RUN_CLOUDANT_TESTS'), 
         'Skipping since test is possible only when testing against CouchDB.')


### PR DESCRIPTION
## What

This is a continuation of PR #264 for improving the error handling design by moving CloudantArgumentError messages to `messages.py` module and adding CloudantViewException in `error.py`.

## How

- Added CloudantViewException to error.py and moved view exception messages to _messages.py
- Moved Cloudant argument messages to _messages.py
- Updated error messages in _messages.py and test cases for consistency

## Testing

Fixed up exception and error messages in test cases.
Added new test cases for CloudantViewException.

## Issues
fixes #65 
fixes #266 