### PR TITLE
249 add note and example for 429 adapter in getting_started.rst

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -23,6 +23,10 @@ then disconnecting from the server.
 Later in the `Context managers`_ section we will see how to 
 simplify this process through the use of the Python *with* statement.
 
+Note: If you require retrying requests after an HTTP 429 error, the
+``Replay429Adapter`` can be added when constructing a ``Cloudant``
+client and configured with an initial back off and retry count.
+
 Connecting with a client
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -37,6 +41,10 @@ Connecting with a client
     client = Cloudant(USERNAME, PASSWORD, account=ACCOUNT_NAME, connect=True)
     # or using url
     # client = Cloudant(USERNAME, PASSWORD, url='https://acct.cloudant.com')
+
+    # or with a 429 replay adapter that includes configured retries and initial backoff
+    # client = Cloudant(USERNAME, PASSWORD, account=ACCOUNT_NAME,
+    #                   adapter=Replay429Adapter(retries=10, initialBackoff=0.01))
 
     # Perform client tasks...
     session = client.session()


### PR DESCRIPTION
## What

- Added a note to use `Replay429Adapter` if retrying requests is needed after a 429 error
- Added `client` construction example that's configured with 429 adapter

## Testing

No tests added.

## Issues

fixes #249 
