### PR TITLE
237 add Python 2 long type support to argument types

### DIFF
--- a/src/cloudant/_2to3.py
+++ b/src/cloudant/_2to3.py
@@ -29,6 +29,8 @@ STRTYPE = basestring if PY2 else str
 # pylint: disable=undefined-variable
 UNITYPE = unicode if PY2 else str
 
+# pylint: disable=undefined-variable
+LONGTYPE = long if PY2 else int
 
 if PY2:
     # pylint: disable=wrong-import-position,no-name-in-module,import-error,unused-import

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -23,7 +23,7 @@ from collections import Sequence
 import json
 from requests import Session
 
-from ._2to3 import STRTYPE, NONETYPE, UNITYPE, iteritems_, url_parse
+from ._2to3 import LONGTYPE, STRTYPE, NONETYPE, UNITYPE, iteritems_, url_parse
 from .error import CloudantArgumentError, CloudantException
 
 # Library Constants
@@ -50,19 +50,19 @@ SPECIAL_INDEX_TYPE = 'special'
 
 RESULT_ARG_TYPES = {
     'descending': (bool,),
-    'endkey': (int, STRTYPE, Sequence,),
+    'endkey': (int, LONGTYPE, STRTYPE, Sequence,),
     'endkey_docid': (STRTYPE,),
     'group': (bool,),
-    'group_level': (int, NONETYPE,),
+    'group_level': (int, LONGTYPE, NONETYPE,),
     'include_docs': (bool,),
     'inclusive_end': (bool,),
-    'key': (int, STRTYPE, Sequence,),
+    'key': (int, LONGTYPE, STRTYPE, Sequence,),
     'keys': (list,),
-    'limit': (int, NONETYPE,),
+    'limit': (int, LONGTYPE, NONETYPE,),
     'reduce': (bool,),
-    'skip': (int, NONETYPE,),
+    'skip': (int, LONGTYPE, NONETYPE,),
     'stale': (STRTYPE,),
-    'startkey': (int, STRTYPE, Sequence,),
+    'startkey': (int, LONGTYPE, STRTYPE, Sequence,),
     'startkey_docid': (STRTYPE,),
 }
 
@@ -75,6 +75,7 @@ TYPE_CONVERTERS = {
     list: lambda x: json.dumps(x),
     tuple: lambda x: json.dumps(list(x)),
     int: lambda x: x,
+    LONGTYPE: lambda x: x,
     bool: lambda x: 'true' if x else 'false',
     NONETYPE: lambda x: x
 }
@@ -82,16 +83,16 @@ TYPE_CONVERTERS = {
 _COUCH_DB_UPDATES_ARG_TYPES = {
     'feed': (STRTYPE,),
     'heartbeat': (bool,),
-    'timeout': (int, NONETYPE,),
+    'timeout': (int, LONGTYPE, NONETYPE,),
 }
 
 _DB_UPDATES_ARG_TYPES = {
     'descending': (bool,),
-    'limit': (int, NONETYPE,),
-    'since': (int, STRTYPE,),
+    'limit': (int, LONGTYPE, NONETYPE,),
+    'since': (int, LONGTYPE, STRTYPE,),
 }
 _DB_UPDATES_ARG_TYPES.update(_COUCH_DB_UPDATES_ARG_TYPES)
-_DB_UPDATES_ARG_TYPES['heartbeat'] = (int, NONETYPE,)
+_DB_UPDATES_ARG_TYPES['heartbeat'] = (int, LONGTYPE, NONETYPE,)
 
 _CHANGES_ARG_TYPES = {
     'conflicts': (bool,),
@@ -104,11 +105,11 @@ _CHANGES_ARG_TYPES.update(_DB_UPDATES_ARG_TYPES)
 
 QUERY_ARG_TYPES = {
     'selector': dict,
-    'limit': (int, NONETYPE),
-    'skip': (int, NONETYPE),
+    'limit': (int, LONGTYPE, NONETYPE),
+    'skip': (int, LONGTYPE, NONETYPE),
     'sort': list,
     'fields': list,
-    'r': (int, NONETYPE),
+    'r': (int, LONGTYPE, NONETYPE),
     'bookmark': STRTYPE,
     'use_index': STRTYPE
 }
@@ -124,16 +125,16 @@ SEARCH_INDEX_ARGS = {
     'group_sort': (STRTYPE, list),
     'include_docs': bool,
     'limit': (int, NONETYPE),
-    'query': (STRTYPE, int),
-    'q': (STRTYPE, int),
+    'query': (STRTYPE, int, LONGTYPE),
+    'q': (STRTYPE, int, LONGTYPE),
     'ranges': dict,
     'sort': (STRTYPE, list),
     'stale': STRTYPE,
     'highlight_fields': list,
     'highlight_pre_tag': STRTYPE,
     'highlight_post_tag': STRTYPE,
-    'highlight_number': (int, NONETYPE),
-    'highlight_size': (int, NONETYPE),
+    'highlight_number': (int, LONGTYPE, NONETYPE),
+    'highlight_size': (int, LONGTYPE, NONETYPE),
     'include_fields': list
 }
 

--- a/tests/unit/_test_util.py
+++ b/tests/unit/_test_util.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+# Copyright (C) 2017 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Module containing miscellaneous functions, and constants
+used for unit testing.
+"""
+from cloudant._2to3 import PY2
+
+# Constants
+
+# Test long type in Python 2
+LONG_NUMBER = PY2 and long(1) or 1

--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -36,6 +36,7 @@ from cloudant.design_document import DesignDocument
 from cloudant.security_document import SecurityDocument
 from cloudant.index import Index, TextIndex, SpecialIndex
 from cloudant.feed import Feed, InfiniteFeed
+from tests.unit._test_util import LONG_NUMBER
 
 from .unit_t_db_base import UnitTestDbBase
 from .. import unicode_
@@ -441,6 +442,17 @@ class DatabaseTests(UnitTestDbBase):
         self.assertEqual(data['rows'][0]['key'], 'julia010')
         self.assertEqual(data['rows'][1]['key'], 'julia011')
         self.assertEqual(data['rows'][2]['key'], 'julia012')
+
+    def test_all_docs_get_with_long_type(self):
+        """
+        Test the all_docs GET request functionality
+        """
+        self.populate_db_with_documents()
+        data = self.db.all_docs(limit=LONG_NUMBER, skip=10)
+        self.assertEqual(len(data.get('rows')), 1)
+        self.assertEqual(data['rows'][0]['key'], 'julia010')
+        data = self.db.all_docs(limit=1, skip=LONG_NUMBER)
+        self.assertEqual(len(data.get('rows')), 1)
 
     def test_custom_result_context_manager(self):
         """

--- a/tests/unit/param_translation_tests.py
+++ b/tests/unit/param_translation_tests.py
@@ -19,6 +19,8 @@ import unittest
 
 from cloudant.error import CloudantArgumentError
 from cloudant._common_util import python_to_couch
+from tests.unit._test_util import LONG_NUMBER
+
 
 class PythonToCouchTests(unittest.TestCase):
     """
@@ -43,6 +45,8 @@ class PythonToCouchTests(unittest.TestCase):
         Test endkey translation is successful.
         """
         self.assertEqual(python_to_couch({'endkey': 10}), {'endkey': 10})
+        # Test with long type
+        self.assertEqual(python_to_couch({'endkey': LONG_NUMBER}), {'endkey': LONG_NUMBER})
         self.assertEqual(
             python_to_couch({'endkey': 'foo'}),
             {'endkey': '"foo"'}
@@ -75,6 +79,11 @@ class PythonToCouchTests(unittest.TestCase):
         self.assertEqual(
             python_to_couch({'group_level': 100}),
             {'group_level': 100}
+        )
+        # Test with long type
+        self.assertEqual(
+            python_to_couch({'group_level': LONG_NUMBER}),
+            {'group_level': LONG_NUMBER}
         )
         self.assertEqual(
             python_to_couch({'group_level': None}),
@@ -112,6 +121,8 @@ class PythonToCouchTests(unittest.TestCase):
         Test key translation is successful.
         """
         self.assertEqual(python_to_couch({'key': 10}), {'key': 10})
+        # Test with long type
+        self.assertEqual(python_to_couch({'key': LONG_NUMBER}), {'key': LONG_NUMBER})
         self.assertEqual(python_to_couch({'key': 'foo'}), {'key': '"foo"'})
         self.assertEqual(
             python_to_couch({'key': ['foo', 10]}),
@@ -125,6 +136,12 @@ class PythonToCouchTests(unittest.TestCase):
         self.assertEqual(
             python_to_couch({'keys': [100, 200]}),
             {'keys': [100, 200]}
+        )
+        # Test with long type
+        LONG_NUM_KEY = 92233720368547758071
+        self.assertEqual(
+            python_to_couch({'keys': [LONG_NUMBER, LONG_NUM_KEY]}),
+            {'keys': [LONG_NUMBER, LONG_NUM_KEY]}
         )
         self.assertEqual(
             python_to_couch({'keys': ['foo', 'bar']}),
@@ -140,6 +157,8 @@ class PythonToCouchTests(unittest.TestCase):
         Test limit translation is successful.
         """
         self.assertEqual(python_to_couch({'limit': 100}), {'limit': 100})
+        # Test with long type
+        self.assertEqual(python_to_couch({'limit': LONG_NUMBER}), {'limit': LONG_NUMBER})
         self.assertEqual(python_to_couch({'limit': None}), {'limit': None})
 
     def test_valid_reduce(self):
@@ -157,6 +176,8 @@ class PythonToCouchTests(unittest.TestCase):
         Test skip translation is successful.
         """
         self.assertEqual(python_to_couch({'skip': 100}), {'skip': 100})
+        # Test with long type
+        self.assertEqual(python_to_couch({'skip': LONG_NUMBER}), {'skip': LONG_NUMBER})
         self.assertEqual(python_to_couch({'skip': None}), {'skip': None})
 
     def test_valid_stale(self):
@@ -174,6 +195,8 @@ class PythonToCouchTests(unittest.TestCase):
         Test startkey translation is successful.
         """
         self.assertEqual(python_to_couch({'startkey': 10}), {'startkey': 10})
+        # Test with long type
+        self.assertEqual(python_to_couch({'startkey': LONG_NUMBER}), {'startkey': LONG_NUMBER})
         self.assertEqual(
             python_to_couch({'startkey': 'foo'}),
             {'startkey': '"foo"'}


### PR DESCRIPTION
## What

- Added `LONGTYPE` in `_2to3.py` to support `long` in `common_util` argument types

## Testing

- Added `long` testing in existing parameter translation tests
- Added `test_all_docs_get_with_long_type` test case 

## Issues

fixes #237 