### PR TITLE
228 remove misleading admin party docstring

### DIFF
--- a/tests/unit/unit_t_db_base.py
+++ b/tests/unit/unit_t_db_base.py
@@ -77,10 +77,6 @@ class UnitTestDbBase(unittest.TestCase):
     def setUpClass(cls):
         """
         If targeting CouchDB, Set up a CouchDB instance otherwise do nothing.
-          
-        Note: Admin Party is currently unsupported so we must create a 
-          CouchDB user for tests to function with a CouchDB instance if one is
-          not provided.
         """
         if os.environ.get('RUN_CLOUDANT_TESTS') is None:
             if os.environ.get('DB_URL') is None:


### PR DESCRIPTION
## What
Admin party is now supported by the library and the docstring [here](https://github.com/cloudant/python-cloudant/blob/master/tests/unit/unit_t_db_base.py#L80-L82) should be removed.

## How
- Removed admin party docstring in `unit_t_db_base.py`

## Testing
No new tests.

## Issues
#228 