### PR TITLE
257 timeout argument

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,6 @@
 2.4.0 (Unreleased)
 ==================
-
+- [NEW] Added ``timeout`` option to the client constructor for setting a timeout on a HTTP connection or a response.
 
 2.3.1 (2016-11-30)
 ==================

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -27,6 +27,10 @@ Note: If you require retrying requests after an HTTP 429 error, the
 ``Replay429Adapter`` can be added when constructing a ``Cloudant``
 client and configured with an initial back off and retry count.
 
+Note: Currently, the connect and read timeout will wait forever for
+a HTTP connection or a response on all requests.  A timeout can be
+set using the ``timeout`` argument when constructing a client.
+
 Connecting with a client
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -45,6 +49,10 @@ Connecting with a client
     # or with a 429 replay adapter that includes configured retries and initial backoff
     # client = Cloudant(USERNAME, PASSWORD, account=ACCOUNT_NAME,
     #                   adapter=Replay429Adapter(retries=10, initialBackoff=0.01))
+
+    # or with a connect and read timeout of 5 minutes
+    # client = Cloudant(USERNAME, PASSWORD, account=ACCOUNT_NAME,
+    #                   timeout=300)
 
     # Perform client tasks...
     session = client.session()

--- a/tests/unit/client_tests.py
+++ b/tests/unit/client_tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2015, 2016 IBM. All rights reserved.
+# Copyright (c) 2015, 2016, 2017 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,6 +27,8 @@ import base64
 import sys
 import os
 import datetime
+
+from requests import ConnectTimeout
 
 from cloudant import cloudant, couchdb, couchdb_admin_party
 from cloudant.client import Cloudant, CouchDB
@@ -535,6 +537,15 @@ class CloudantClientTests(UnitTestDbBase):
             self.assertEqual(ua_parts[5], os.uname()[4])
         finally:
             self.client.disconnect()
+
+    def test_connect_timeout(self):
+        """
+        Test that a connect timeout occurs when instantiating
+        a client object with a timeout of 10 ms.
+        """
+        with self.assertRaises(ConnectTimeout) as cm:
+            self.set_up_client(auto_connect=True, timeout=.01)
+        self.assertTrue(str(cm.exception).find('timed out.'))
 
     def test_db_updates_infinite_feed_call(self):
         """

--- a/tests/unit/unit_t_db_base.py
+++ b/tests/unit/unit_t_db_base.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2015 IBM. All rights reserved.
+# Copyright (c) 2015, 2016, 2017 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -131,7 +131,8 @@ class UnitTestDbBase(unittest.TestCase):
         """
         self.set_up_client()
 
-    def set_up_client(self, auto_connect=False, auto_renew=False, encoder=None):
+    def set_up_client(self, auto_connect=False, auto_renew=False, encoder=None,
+                      timeout=(30,300)):
         if os.environ.get('RUN_CLOUDANT_TESTS') is None:
             admin_party = False
             if (os.environ.get('ADMIN_PARTY') and
@@ -147,7 +148,8 @@ class UnitTestDbBase(unittest.TestCase):
                 url=self.url,
                 connect=auto_connect,
                 auto_renew=auto_renew,
-                encoder=encoder
+                encoder=encoder,
+                timeout=timeout
             )
         else:
             self.account = os.environ.get('CLOUDANT_ACCOUNT')
@@ -163,7 +165,8 @@ class UnitTestDbBase(unittest.TestCase):
                 x_cloudant_user=self.account,
                 connect=auto_connect,
                 auto_renew=auto_renew,
-                encoder=encoder
+                encoder=encoder,
+                timeout=timeout
             )
 
 


### PR DESCRIPTION
## What

Allow for a timeout argument in `client` construction to prevent python-cloudant waiting forever for a HTTP connection or a response on all requests.

## How

- ClientSession class to add timeout of to all requests

## Testing

New tests to assert that connect and read timeout exception occurs during client construction and replication.

## Issues

fixes #257 