### PR TITLE
Implement local cache limit

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -285,6 +285,31 @@ Delete a document
     # Delete the document
     my_document.delete()
 
+*************
+Local Caching
+*************
+
+Documents are cached locally as they are requested by the client. You can limit
+the cache to a fixed number of documents or choose to suppress this behaviour
+entirely. Note that by default the cache is not bound to a limit and can
+therefore grow indefinitely.
+
+The client uses a Least Recently Used (LRU) caching policy. The least recently
+accessed document is discarded first once the cache size limit is reached.
+
+.. code-block:: python
+
+    from cloudant.client import Cloudant
+
+    # no cache limit (default behaviour)
+    client1 = Cloudant(USERNAME, PASSWORD, account=ACCOUNT_NAME)
+
+    # limit the local cache to 100 documents
+    client2 = Cloudant(USERNAME, PASSWORD, account=ACCOUNT_NAME, cache_size=100)
+
+    # don't cache documents locally. always fetch from the remote server.
+    client3 = Cloudant(USERNAME, PASSWORD, account=ACCOUNT_NAME, cache_size=0)
+
 ********************
 Dealing with results
 ********************

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -61,6 +61,24 @@ class CouchDatabase(LRUDict):
         self._fetch_limit = fetch_limit
         self.result = Result(self.all_docs)
 
+    def __eq__(self, other):
+        """
+        Compare the equality of this database to another.
+
+        For two databases to be considered equal both the database host and
+        database name must match.
+
+        :param other: other database
+        :return: True if databases are equal, else False
+        """
+        if (hasattr(other, '_database_host') and
+                self._database_host == other._database_host):  # pylint: disable=protected-access
+
+            return hasattr(other, 'database_name') and \
+                   self.database_name == other.database_name
+
+        return False
+
     @property
     def r_session(self):
         """

--- a/src/cloudant/lru_dict.py
+++ b/src/cloudant/lru_dict.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+# Copyright (c) 2017 IBM. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+A simple `dict` like collection implementing a Least Recently Used (LRU)
+caching policy.
+"""
+
+from collections import MutableMapping, OrderedDict
+from threading import Lock
+
+
+class NullContext(object):
+    """
+    No-op context manager, executes block without doing any additional
+    processing.
+    """
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+
+class LRUDict(MutableMapping):
+    """
+    A fixed size `dict` like container which evicts Least Recently Used (LRU)
+    items once size limit is exceeded.
+
+    :param int max_size: Maximum size of dictionary. A negative value
+        implies the capacity is unbounded.
+    """
+    def __init__(self, *args, **kwargs):
+        self._max_size = kwargs.pop('max_size', -1)
+
+        if self._max_size <= 0:
+            self._lock = NullContext()  # don't lock for get/set/delete
+        else:
+            self._lock = Lock()
+
+        self._dict = OrderedDict(*args, **kwargs)
+
+    def __delitem__(self, key):
+        with self._lock:
+            self._dict.__getitem__(key).delete()
+
+    def __getitem__(self, key):
+        with self._lock:
+            value = self._dict.__getitem__(key)
+            if self._max_size > 1:
+                self._update_lru(key)
+
+            return value
+
+    def _update_lru(self, key):
+        """
+        Move key to the top of the LRU cache.
+
+        :param str key: dictionary key
+        """
+        move_to_end = getattr(self._dict, 'move_to_end', None)
+        if move_to_end:
+            move_to_end(key, last=True)  # >=Python3.2 only
+        else:
+            # ported from Python3.2
+            link_prev, link_next, key = link = \
+                getattr(self._dict, '_OrderedDict__map')[key]
+            link_prev[1] = link_next
+            link_next[0] = link_prev
+
+            root = getattr(self._dict, '_OrderedDict__root')
+            last = root[0]
+            link[0] = last
+            link[1] = root
+            last[1] = root[0] = link
+
+    def __iter__(self):
+        return self._dict.__iter__()
+
+    def __len__(self):
+        return len(self._dict)
+
+    def __setitem__(self, *args, **kwargs):
+        if self._max_size == 0:
+            return  # skip set
+
+        with self._lock:
+            if 0 < self._max_size <= len(self._dict):
+                self._dict.popitem(last=False)
+
+            self._dict.__setitem__(*args, **kwargs)
+
+    def keys(self):
+        """
+        Return a copy of the dictionary keys.
+
+        :return: list of dictionary keys
+        """
+        return self._dict.keys()  # override inherited Mapping method

--- a/tests/unit/lru_dict_tests.py
+++ b/tests/unit/lru_dict_tests.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+# Copyright (c) 2017 IBM. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for `LRUDict` type.
+"""
+import unittest
+
+from cloudant.lru_dict import LRUDict
+
+
+class LRUDictTests(unittest.TestCase):
+
+    def _add_keys(self, d, count):
+        for i in range(count):
+            d['foo-{0}'.format(i)] = 'bar'
+
+    def test_lru_dict_with_max_size_0(self):
+        lru = LRUDict(max_size=0)
+        self._add_keys(lru, 999)
+
+        self.assertEquals(0, len(lru))
+
+    def test_lru_dict_with_max_size_100(self):
+        lru = LRUDict(max_size=100)
+        self._add_keys(lru, 999)
+
+        self.assertEquals(100, len(lru))
+
+    def test_lru_removes_least_recently_added(self):
+        lru = LRUDict(max_size=5)
+        # fill lru
+        lru["first"]    = 1
+        lru["second"]   = 2
+        lru["third"]    = 3
+        lru["forth"]    = 4
+        lru["fifth"]    = 5
+
+        self.assertEquals(5, len(lru))
+
+        lru["sixth"]    = 6
+
+        self.assertEquals(5, len(lru))
+        self.assertTrue("first" not in lru)
+
+    def test_lru_removes_least_recently_accessed(self):
+        lru = LRUDict(max_size=5)
+        # fill lru
+        lru["first"]    = 1
+        lru["second"]   = 2
+        lru["third"]    = 3
+        lru["forth"]    = 4
+        lru["fifth"]    = 5
+
+        self.assertEquals(5, len(lru))
+        self.assertEquals(1, lru["first"])  # access first
+
+        lru["sixth"]    = 6
+
+        self.assertEquals(5, len(lru))
+        self.assertTrue("second" not in lru)


### PR DESCRIPTION
## What
Implement an LRU caching policy when storing documents locally.

By default the cache is not bound to a limit and can therefore grow indefinitely (thus copying the current behaviour).

_Example:_
```python
from cloudant.client import Cloudant

# no cache limit (default behaviour)
client1 = Cloudant(USERNAME, PASSWORD, account=ACCOUNT_NAME)

# limit the local cache to 100 documents
client2 = Cloudant(USERNAME, PASSWORD, account=ACCOUNT_NAME, cache_size=100)

# don't cache documents locally. always fetch from the remote server.
client3 = Cloudant(USERNAME, PASSWORD, account=ACCOUNT_NAME, cache_size=0)
```

## How
`CouchDatabase` types now inherit `LRUDict` which uses an `OrderedDict` under the hood to implement a simple LRU cache.

## Testing
Includes additional unit tests.

## Issues
See #67.
