### PR TITLE
Correctly specify custom JSON encoder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,6 @@
 2.5.0 (Unreleased)
 ==================
+- [FIXED] Fixed ``TypeError`` when setting revision limits on Python>=3.6.
 
 2.4.0 (2017-02-14)
 ==================

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -758,7 +758,7 @@ class CouchDatabase(dict):
         """
         url = posixpath.join(self.database_url, '_revs_limit')
 
-        resp = self.r_session.put(url, data=json.dumps(limit, self.client.encoder))
+        resp = self.r_session.put(url, data=json.dumps(limit, cls=self.client.encoder))
         resp.raise_for_status()
 
         return resp.json()


### PR DESCRIPTION
## What
Correctly specify the custom JSON encoder.

## How
To use a custom JSONEncoder subclass (e.g. one that overrides the default() method to serialize additional types), specify it with the cls kwarg; otherwise JSONEncoder is used.

Note, as of Python 3.6 the `json.dump` optional parameters are keyword-only. In earlier versions the additional argument was silently ignored.

## Issues
Fixes #282.