### PR TITLE
142 existence twice check

### DIFF
--- a/src/cloudant/client.py
+++ b/src/cloudant/client.py
@@ -224,10 +224,8 @@ class CouchDB(dict):
         :returns: The newly created database object
         """
         new_db = self._DATABASE_CLASS(self, dbname)
-        if new_db.exists():
-            if kwargs.get('throw_on_exists', True):
-                raise CloudantClientException(409, dbname)
-        new_db.create()
+        if new_db.create(none_on_exists=kwargs.get('throw_on_exists', True)) is None:
+            raise CloudantClientException(409, dbname)
         super(CouchDB, self).__setitem__(dbname, new_db)
         return new_db
 

--- a/src/cloudant/client.py
+++ b/src/cloudant/client.py
@@ -224,8 +224,8 @@ class CouchDB(dict):
         :returns: The newly created database object
         """
         new_db = self._DATABASE_CLASS(self, dbname)
-        if (new_db.create(none_on_exists = kwargs.get('throw_on_exists', True))
-            is None):
+        none_on_exists = kwargs.get('throw_on_exists', True)
+        if new_db.create(none_on_exists=none_on_exists) is None:
             raise CloudantClientException(409, dbname)
         super(CouchDB, self).__setitem__(dbname, new_db)
         return new_db

--- a/src/cloudant/client.py
+++ b/src/cloudant/client.py
@@ -224,7 +224,8 @@ class CouchDB(dict):
         :returns: The newly created database object
         """
         new_db = self._DATABASE_CLASS(self, dbname)
-        if new_db.create(none_on_exists=kwargs.get('throw_on_exists', True)) is None:
+        if (new_db.create(none_on_exists = kwargs.get('throw_on_exists', True))
+            is None):
             raise CloudantClientException(409, dbname)
         super(CouchDB, self).__setitem__(dbname, new_db)
         return new_db

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -329,16 +329,21 @@ class CouchDatabase(dict):
         else:
             return view.result
 
-    def create(self):
+    def create(self, **kwargs):
         """
         Creates a database defined by the current database object, if it
         does not already exist and raises a CloudantException if the operation
         fails.  If the database already exists then this method call is a no-op.
 
+        :param bool none_on_exists: Boolean flag dictating whether or
+            not to return None object when the database already exists.
         :returns: The database object
         """
         if self.exists():
-            return self
+            if kwargs.get('none_on_exists', True):
+                return None
+            else:
+                return self
 
         resp = self.r_session.put(self.database_url)
         if resp.status_code == 201 or resp.status_code == 202:


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [ ] You have signed the CLA as per the instructions in [CONTRIBUTING.rst] (https://github.com/cloudant/python-cloudant/blob/master/CONTRIBUTING.rst#contributor-license-agreement) **_(not applicable, IBMer)._**
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.rst](https://github.com/cloudant/python-cloudant/blob/master/CHANGES.rst) 
- [x] You have completed the PR template below:

## What

In this current PR, the method `create_database()` on `Client.CouchDB` doesn't double check if the database already exists (`new_db.exists()`). 
## How

The method sends a `none_on_exists` keyword argument to `create()`. 

- If `none_on_exists` is `True`, it will return None (and it will raise the `CloudantClientException`).
- If `none_on_exists` is `False`, it will return the already existing database.

*The default `none_on_exists` is set to `True` if there are no `none_on_exists` keyword argument.*


## Testing

Find below the test:

```python
from cloudant import Cloudant
from cloudant.error import CloudantClientException
import unittest


class TestTwiceCheck(unittest.TestCase):

    database = 'foobar-test'

    # creating new database. Expecting {} of the new database.
    def test_create(self):
        self.assertEqual(client.create_database(TestTwiceCheck.database), {})

    # now that the database already exists,
    # it will raise the CludantClientException
    def test_exists(self):
        self.assertRaises(CloudantClientException,
                          client.create_database, TestTwiceCheck.database)

    # If we use throw_on_exists as False, it will return
    # the already created database. That way we won't
    # double check the exists() method.
    def test_exists_bypass(self):
        self.assertEqual(client.create_database(TestTwiceCheck.database,
                         throw_on_exists=False), {})


if __name__ == '__main__':
    global client
    client = Cloudant('user', 'pwd', account='user')
    client.connect()

    unittest.main(exit=False)
    # deleting the database so we can run the test again without
    # raising the CloudantClientException (database already exists.)
    client.delete_database(TestTwiceCheck.database)
```

## Issues
Related to issue #142.
