### PR TITLE
287 throw exception with 412 code when db exists 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 2.5.0 (Unreleased)
 ==================
 - [FIXED] Fixed ``TypeError`` when setting revision limits on Python>=3.6.
+- [FIXED] Fixed Cloudant exception code 409 with 412 when creating a database that already exists.
 
 2.4.0 (2017-02-14)
 ==================

--- a/src/cloudant/_messages.py
+++ b/src/cloudant/_messages.py
@@ -73,7 +73,7 @@ CLIENT = {
     101: 'Value must be set to a Database object. Found type: {0}',
     102: 'You must provide a url or an account.',
     404: 'Database {0} does not exist. Verify that the client is valid and try again.',
-    409: 'Database {0} already exists.'
+    412: 'Database {0} already exists.'
 }
 
 DATABASE = {
@@ -81,7 +81,8 @@ DATABASE = {
     101: 'Unexpected index type. Found: {0}',
     400: 'Invalid database name during creation. Found: {0}',
     401: 'Unauthorized to create database {0}',
-    409: 'Document with id {0} already exists.'
+    409: 'Document with id {0} already exists.',
+    412: 'Database {0} already exists.'
 }
 
 DESIGN_DOCUMENT = {

--- a/src/cloudant/client.py
+++ b/src/cloudant/client.py
@@ -226,7 +226,7 @@ class CouchDB(dict):
         new_db = self._DATABASE_CLASS(self, dbname)
         if new_db.exists():
             if kwargs.get('throw_on_exists', True):
-                raise CloudantClientException(409, dbname)
+                raise CloudantClientException(412, dbname)
         new_db.create()
         super(CouchDB, self).__setitem__(dbname, new_db)
         return new_db

--- a/tests/unit/client_tests.py
+++ b/tests/unit/client_tests.py
@@ -277,7 +277,7 @@ class ClientTests(UnitTestDbBase):
         self.client.create_database(dbname)
         with self.assertRaises(CloudantClientException) as cm:
             self.client.create_database(dbname, throw_on_exists=True)
-        self.assertEqual(cm.exception.status_code, 409)
+        self.assertEqual(cm.exception.status_code, 412)
 
         self.client.delete_database(dbname)
         self.client.disconnect()


### PR DESCRIPTION
## What

Replaced the existing exception error code of 409 with 412 when the database already exists.

## How

- Updated error code to 412 in `_messages` and `client.create_database`

## Testing

No new tests.
Updated existing `test_create_existing_database` test to assert the correct 412 exception.

## Issues

fixes #287 