### PR TITLE
Add support for Cloudant _local documents

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 - [FIXED] Fixed ``TypeError`` when setting revision limits on Python>=3.6.
 - [FIXED] Fixed the ``exists()`` double check on ``client.py`` and ``database.py``.
 - [FIXED] Fixed Cloudant exception code 409 with 412 when creating a database that already exists.
+- [NEW] Added support for ``_local`` documents by adding the ``LocalDocument`` class.
 
 2.4.0 (2017-02-14)
 ==================

--- a/docs/local_document.rst
+++ b/docs/local_document.rst
@@ -1,0 +1,7 @@
+local_document
+=================
+
+.. automodule:: cloudant.local_document
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -9,6 +9,7 @@ Modules
    document
    design_document
    security_document
+   local_document
    view
    query
    module_index

--- a/src/cloudant/_messages.py
+++ b/src/cloudant/_messages.py
@@ -104,6 +104,12 @@ DOCUMENT = {
     103: 'Attempting to delete a doc with no _rev. Try running .fetch and re-try.'
 }
 
+LOCAL_DOCUMENT = {
+    100: 'A general Cloudant local document exception was raised.',
+    101: 'The _id is a required field for LocalDocument. '
+         'Add an _id key and value to the local document and re-try.'
+}
+
 FEED = {
     100: 'A general Cloudant feed exception was raised.',
     101: 'Infinite _db_updates feed not supported for CouchDB.'

--- a/src/cloudant/error.py
+++ b/src/cloudant/error.py
@@ -22,6 +22,7 @@ from cloudant._messages import (
     DATABASE,
     DESIGN_DOCUMENT,
     DOCUMENT,
+    LOCAL_DOCUMENT,
     FEED,
     INDEX,
     REPLICATOR,
@@ -142,6 +143,23 @@ class CloudantDocumentException(CloudantException):
             code = 100
             msg = DOCUMENT[code]
         super(CloudantDocumentException, self).__init__(msg, code)
+
+class CloudantLocalDocumentException(CloudantException):
+    """
+    Provides a way to issue Cloudant library local document specific
+    exceptions.
+
+    :param int code: A code value used to identify the local document
+        exception.
+    :param args: A list of arguments used to format the exception message.
+    """
+    def __init__(self, code=100, *args):
+        try:
+            msg = LOCAL_DOCUMENT[code].format(*args)
+        except (KeyError, IndexError):
+            code = 100
+            msg = LOCAL_DOCUMENT[code]
+        super(CloudantLocalDocumentException, self).__init__(msg, code)
 
 class CloudantFeedException(CloudantException):
     """

--- a/src/cloudant/local_document.py
+++ b/src/cloudant/local_document.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python
+# Copyright (c) 2017 IBM. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+API module/class for interacting with a local document in a database.
+"""
+import json
+from requests.exceptions import HTTPError
+
+from ._2to3 import url_quote, url_quote_plus
+from .error import CloudantLocalDocumentException
+
+
+class LocalDocument(dict):
+    """
+    Encapsulates a local document.  Local documents are not replicated to other
+    databases, the local document identifier must be known for the local
+    document to be accessed, and local documents are not output by views so it
+    is impossible to obtain a list of local documents in a database.
+
+    A LocalDocument object is instantiated with a reference to a database and
+    used to manipulate local document content in a Cloudant database instance.
+
+    In addition to basic CRUD style operations, a LocalDocument object also
+    provides a convenient context manager.  This context manager removes having
+    to explicitly :func:`~cloudant.local_document.LocalDocument.fetch` the
+    local document from the remote database before commencing work on it as
+    well as explicitly having to
+    :func:`~cloudant.local_document.LocalDocument.save` the local document once
+    work is complete.
+
+    For example:
+
+    .. code-block:: python
+
+        # Upon entry into the local document context, fetches the local
+        # document from the remote database, if it exists. Upon exit from the
+        # context, saves the local document to the remote database with changes
+        # made within the context.
+        with LocalDocument(database, '_local/julia006') as local_document:
+            # The local document is fetched from the remote database
+            # Changes are made locally
+            local_document['name'] = 'Julia'
+            local_document['age'] = 6
+            # The local document is saved to the remote database
+
+    :param database: A ``CloudantDatabase`` instance used by the LocalDocument.
+    :param str document_id: Document id used to identify the local document.
+    """
+    def __init__(self, database, document_id):
+        super(LocalDocument, self).__init__()
+        self._client = database.client
+        self._database = database
+        self._database_host = self._client.server_url
+        self._database_name = database.database_name
+        if not document_id.startswith('_local/'):
+            self['_id'] = '_local/{0}'.format(document_id)
+        else:
+            self['_id'] = document_id
+        self.encoder = self._client.encoder
+
+    @property
+    def r_session(self):
+        """
+        Returns the database instance ``requests`` session used by the local
+        document.
+
+        :returns: The current ``requests`` session
+        """
+        return self._client.r_session
+
+    @property
+    def document_url(self):
+        """
+        Constructs and returns the local document URL.
+
+        :returns: Local document URL
+        """
+        if self.get('_id') is None:
+            raise CloudantLocalDocumentException(101)
+
+        return '/'.join(
+            [
+                self._database_host,
+                url_quote_plus(self._database_name),
+                '_local',
+                url_quote(self['_id'][7:], safe='')
+            ]
+        )
+
+    def exists(self):
+        """
+        Retrieves whether the local document exists in the remote database or
+        not.
+
+        :returns: True if the local document exists in the remote database,
+            otherwise False
+        """
+        exists = self.r_session.get(self.document_url)
+        if exists.status_code not in [200, 404]:
+            exists.raise_for_status()
+
+        return exists.status_code == 200
+
+    def json(self):
+        """
+        Retrieves the JSON string representation of the current locally cached
+        local document object, encoded by the encoder specified in the
+        associated client object.
+
+        :returns: Encoded JSON string containing the local document data
+        """
+        return json.dumps(dict(self), cls=self.encoder)
+
+    def create(self):
+        """
+        Creates or overwrites the current local document in the remote database
+        and if successful, updates the locally cached LocalDocument object with
+        the ``_rev`` returned as part of the successful response.  Using this
+        method guarantees that the local document ``_rev`` will be ``0-1``.
+        """
+        self.save(reset_revision=True)
+
+    def fetch(self):
+        """
+        Retrieves the content of the current local document from the remote
+        database and populates the locally cached LocalDocument object with
+        that content.  A call to fetch will overwrite any dictionary content
+        currently in the locally cached LocalDocument object.
+        """
+        resp = self.r_session.get(self.document_url)
+        resp.raise_for_status()
+        self.clear()
+        self.update(resp.json())
+
+    def save(self, reset_revision=False):
+        """
+        Saves changes made to the locally cached LocalDocument object's data
+        structures to the remote database.  If the local document does not
+        exist remotely then it is created in the remote database.  By default
+        the revision number of the local document is incremented unless the
+        overwrite functionality is requested.
+
+        :param bool reset_revision: Dictates whether the local document
+            revision is incremented or reset to ``0-1``.  Default is ``False``
+            which is to increment.
+        """
+        if reset_revision and '_rev' in self.keys():
+            self.__delitem__('_rev')
+        elif not reset_revision and '_rev' not in self.keys():
+            resp = self.r_session.get(self.document_url)
+            if resp.status_code == 200:
+                data = resp.json()
+                self['_rev'] = data['_rev']
+            elif resp.status_code != 404:
+                resp.raise_for_status()
+
+        put_resp = self.r_session.put(
+            self.document_url,
+            data=self.json(),
+            headers={'Content-Type': 'application/json'}
+        )
+        put_resp.raise_for_status()
+        data = put_resp.json()
+        self['_rev'] = data['rev']
+
+    def delete(self):
+        """
+        Removes the local document from the remote database and clears the
+        content of the locally cached LocalDocument object with the exception
+        of the ``_id`` field.
+        """
+        del_resp = self.r_session.delete(self.document_url)
+        del_resp.raise_for_status()
+        data = del_resp.json()
+        self.clear()
+        self['_id'] = data['id']
+
+    def __enter__(self):
+        """
+        Supports context like editing of local document fields.  Handles
+        context entry logic.  Executes a LocalDocument.fetch() upon entry.
+        """
+
+        # We don't want to raise an exception if the document is not found
+        # because upon __exit__ the save() call will create the local document
+        # if necessary.
+        try:
+            self.fetch()
+        except HTTPError as err:
+            if err.response.status_code != 404:
+                raise
+
+        return self
+
+    def __exit__(self, *args):
+        """
+        Support context like editing of local document fields.  Handles context
+        exit logic.  Executes a LocalDocument.save() upon exit.
+        """
+        self.save()

--- a/tests/unit/local_document_tests.py
+++ b/tests/unit/local_document_tests.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python
+# Copyright (c) 2017 IBM. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+local document module - Unit tests for the LocalDocument class
+
+See configuration options for environment variables in unit_t_db_base
+module docstring.
+"""
+
+import unittest
+import mock
+import json
+import requests
+import os
+
+from cloudant.local_document import LocalDocument
+from cloudant.error import CloudantLocalDocumentException
+
+from .unit_t_db_base import UnitTestDbBase
+
+class CloudantLocalDocumentExceptionTests(unittest.TestCase):
+    """
+    Ensure CloudantLocalDocumentException functions as expected.
+    """
+
+    def test_raise_without_code(self):
+        """
+        Ensure that a default exception/code is used if none is provided.
+        """
+        with self.assertRaises(CloudantLocalDocumentException) as cm:
+            raise CloudantLocalDocumentException()
+        self.assertEqual(cm.exception.status_code, 100)
+
+    def test_raise_using_invalid_code(self):
+        """
+        Ensure that a default exception/code is used if invalid code is provided.
+        """
+        with self.assertRaises(CloudantLocalDocumentException) as cm:
+            raise CloudantLocalDocumentException('foo')
+        self.assertEqual(cm.exception.status_code, 100)
+
+
+class LocalDocumentTests(UnitTestDbBase):
+    """
+    LocalDocument unit tests
+    """
+
+    def setUp(self):
+        """
+        Set up test attributes
+        """
+        super(LocalDocumentTests, self).setUp()
+        self.db_set_up()
+
+    def tearDown(self):
+        """
+        Reset test attributes
+        """
+        self.db_tear_down()
+        super(LocalDocumentTests, self).tearDown()
+
+    def test_constructor(self):
+        """
+        Test instantiating a LocalDocument
+        """
+        doc = LocalDocument(self.db, 'julia006')
+        self.assertIsInstance(doc, LocalDocument)
+        self.assertEqual(doc.r_session, self.db.r_session)
+        self.assertEqual(doc.get('_id'), '_local/julia006')
+
+    def test_constructor_local(self):
+        """
+        Test instantiating a LocalDocument with _local in the docid
+        """
+        doc = LocalDocument(self.db, 'julia006')
+        self.assertIsInstance(doc, LocalDocument)
+        self.assertEqual(doc.r_session, self.db.r_session)
+        self.assertEqual(doc.get('_id'), '_local/julia006')
+
+    def test_document_url(self):
+        """
+        Test that the document url is populated correctly
+        """
+        doc = LocalDocument(self.db, 'julia006')
+        self.assertEqual(
+            doc.document_url, '/'.join(
+                [self.db.database_url, '_local', 'julia006']
+            )
+        )
+
+    def test_document_url_encodes_correctly(self):
+        """
+        Test that the document url is populated and encoded correctly
+        """
+        doc = LocalDocument(self.db, 'http://example.com')
+        self.assertEqual(
+            doc.document_url, '/'.join(
+                [self.db.database_url, '_local', 'http%3A%2F%2Fexample.com']
+            )
+        )
+    
+    @unittest.skipUnless(
+        os.environ.get('RUN_CLOUDANT_TESTS') is not None, 'Skipping Cloudant test'
+    )
+    def test_exists(self):
+        """
+        Test if local document does not exists and if local document exists
+        """
+        doc = LocalDocument(self.db, 'julia006')
+        self.assertFalse(doc.exists())
+        self.db.r_session.put(
+            doc.document_url,
+            data=json.dumps({'_id': '_local/julia006'})
+        )
+        self.assertTrue(doc.exists())
+
+    def test_exists_raises_error(self):
+        """
+        Test local document exists raises an HTTPError.
+        """
+        resp = requests.Response()
+        resp.status_code = 400
+        self.client.r_session.get = mock.Mock(return_value=resp)
+        doc = LocalDocument(self.db, 'julia006')
+        with self.assertRaises(requests.HTTPError) as cm:
+            doc.exists()
+        err = cm.exception
+        self.assertEqual(err.response.status_code, 400)
+        self.client.r_session.get.assert_called_with(doc.document_url)
+
+    def test_json(self):
+        """
+        Test the local document dictionary renders as json appropriately
+        """
+        doc = LocalDocument(self.db, 'julia006')
+        doc['name'] = 'julia'
+        doc['age'] = 6
+        doc_as_json = doc.json()
+        self.assertIsInstance(doc_as_json, str)
+        self.assertEqual(json.loads(doc_as_json), doc)
+
+    @unittest.skipUnless(
+        os.environ.get('RUN_CLOUDANT_TESTS') is not None, 'Skipping Cloudant test'
+    )
+    def test_create(self):
+        """
+        Test creating a local document and overwrites it if it already exists
+        """
+        doc = LocalDocument(self.db, 'julia006')
+        exists = self.db.r_session.get(doc.document_url)
+        self.assertEqual(exists.status_code, 404)
+        self.assertFalse('_rev' in doc.keys())
+        doc['name'] = 'julia'
+        doc['age'] = 6
+        doc.create()
+        self.assertEqual(doc['_rev'], '0-1')
+        new_doc = self.db.r_session.get(doc.document_url)
+        new_doc_data = new_doc.json()
+        self.assertEqual(
+            new_doc.json(),
+            {'_id': '_local/julia006', '_rev': '0-1', 'name': 'julia', 'age': 6}
+        )
+        doc['name'] = 'jules'
+        doc.create()
+        overwritten_doc = self.db.r_session.get(doc.document_url)
+        overwritten_doc_data = new_doc.json()
+        self.assertEqual(
+            overwritten_doc.json(),
+            {'_id': '_local/julia006', '_rev': '0-1', 'name': 'jules', 'age': 6}
+        )
+
+    @unittest.skipUnless(
+        os.environ.get('RUN_CLOUDANT_TESTS') is not None, 'Skipping Cloudant test'
+    )
+    def test_fetch_success(self):
+        """
+        Test fetching a local document
+        """
+        doc = LocalDocument(self.db, 'julia006')
+        self.db.r_session.put(
+            doc.document_url,
+            data=json.dumps(
+                {'_id': '_local/julia006', 'name': 'julia', 'age': 6}
+            )
+        )
+        doc.fetch()
+        self.assertEqual(
+            doc,
+            {'_id': '_local/julia006', '_rev': '0-1', 'name': 'julia', 'age': 6}
+        )
+
+    @unittest.skipUnless(
+        os.environ.get('RUN_CLOUDANT_TESTS') is not None, 'Skipping Cloudant test'
+    )
+    def test_fetch_not_found(self):
+        """
+        Test fetching a non-existing local document
+        """
+        doc = LocalDocument(self.db, 'julia006')
+        with self.assertRaises(requests.HTTPError) as cm:
+            doc.fetch()
+        err = cm.exception
+        self.assertEqual(err.response.status_code, 404)
+
+    @unittest.skipUnless(
+        os.environ.get('RUN_CLOUDANT_TESTS') is not None, 'Skipping Cloudant test'
+    )
+    def test_save_reset_revision(self):
+        """
+        Test that a local document is overwritten and an explicitly set _rev is
+        reset
+        """
+        doc = LocalDocument(self.db, 'julia006')
+        self.db.r_session.put(
+            doc.document_url,
+            data=json.dumps(
+                {'_id': '_local/julia006', '_rev': '0-6', 'name': 'julia', 'age': 6}
+            )
+        )
+        doc.fetch()
+        self.assertEqual(
+            doc,
+            {'_id': '_local/julia006', '_rev': '0-7', 'name': 'julia', 'age': 6}
+        )
+        doc.save(reset_revision=True)
+        self.assertEqual(
+            doc,
+            {'_id': '_local/julia006', '_rev': '0-1', 'name': 'julia', 'age': 6}
+        )
+
+    @unittest.skipUnless(
+        os.environ.get('RUN_CLOUDANT_TESTS') is not None, 'Skipping Cloudant test'
+    )
+    def test_save_increment_revision(self):
+        """
+        Test that a local document is saved with an incremented revision number
+        """
+        doc = LocalDocument(self.db, 'julia006')
+        self.db.r_session.put(
+            doc.document_url,
+            data=json.dumps(
+                {'_id': '_local/julia006', '_rev': '0-6', 'name': 'julia', 'age': 6}
+            )
+        )
+        doc.fetch()
+        self.assertEqual(
+            doc,
+            {'_id': '_local/julia006', '_rev': '0-7', 'name': 'julia', 'age': 6}
+        )
+        del doc['_rev']
+        doc.save()
+        self.assertEqual(
+            doc,
+            {'_id': '_local/julia006', '_rev': '0-8', 'name': 'julia', 'age': 6}
+        )
+
+    def test_save_raises_error_on_get(self):
+        """
+        Test local document save raises an HTTPError on initial GET call.
+        """
+        resp = requests.Response()
+        resp.status_code = 400
+        self.client.r_session.get = mock.Mock(return_value=resp)
+        doc = LocalDocument(self.db, 'julia006')
+        with self.assertRaises(requests.HTTPError) as cm:
+            doc.save()
+        err = cm.exception
+        self.assertEqual(err.response.status_code, 400)
+        self.client.r_session.get.assert_called_with(doc.document_url)
+
+    @unittest.skipUnless(
+        os.environ.get('RUN_CLOUDANT_TESTS') is not None, 'Skipping Cloudant test'
+    )
+    def test_save_raises_error_on_put(self):
+        """
+        Test local document save raises an HTTPError on PUT call.
+        """
+        resp = requests.Response()
+        resp.status_code = 400
+        self.client.r_session.put = mock.Mock(return_value=resp)
+        doc = LocalDocument(self.db, 'julia006')
+        with self.assertRaises(requests.HTTPError) as cm:
+            doc.save()
+        err = cm.exception
+        self.assertEqual(err.response.status_code, 400)
+        self.client.r_session.put.assert_called_with(
+            doc.document_url,
+            data='{"_id": "_local/julia006"}',
+            headers={'Content-Type': 'application/json'}
+        )
+
+    @unittest.skipUnless(
+        os.environ.get('RUN_CLOUDANT_TESTS') is not None, 'Skipping Cloudant test'
+    )
+    def test_delete_success(self):
+        """
+        Test that a local document is deleted successfully
+        """
+        doc = LocalDocument(self.db, 'julia006')
+        self.db.r_session.put(
+            doc.document_url,
+            data=json.dumps(
+                {'_id': '_local/julia006', 'name': 'julia', 'age': 6}
+            )
+        )
+        self.assertTrue(doc.exists())
+        doc.delete()
+        self.assertFalse(doc.exists())
+
+    @unittest.skipUnless(
+        os.environ.get('RUN_CLOUDANT_TESTS') is not None, 'Skipping Cloudant test'
+    )
+    def test_delete_raises_error(self):
+        """
+        Test that a request to delete a local document raises an HTTPError when
+        expected in the proper conditions
+        """
+        doc = LocalDocument(self.db, 'julia006')
+        with self.assertRaises(requests.HTTPError) as cm:
+            doc.delete()
+        err = cm.exception
+        self.assertEqual(err.response.status_code, 404)
+
+    @unittest.skipUnless(
+        os.environ.get('RUN_CLOUDANT_TESTS') is not None, 'Skipping Cloudant test'
+    )
+    def test_context_manager(self):
+        """
+        Test that the LocalDocument context manager fetches and saves
+        upon entry and exit as expected
+        """
+        with LocalDocument(self.db, 'julia006') as doc:
+            doc['name'] = 'julia'
+            doc['age'] = 6
+
+        resp = self.db.r_session.get(
+            '/'.join([self.db.database_url, '_local', 'julia006'])
+        )
+        self.assertEqual(
+            resp.json(),
+            {'_id': '_local/julia006', '_rev': '0-1', 'name': 'julia', 'age': 6}
+        )
+
+        with LocalDocument(self.db, 'julia006') as doc:
+            doc['name'] = 'jules'
+            doc['age'] = 6
+
+        resp = self.db.r_session.get(
+            '/'.join([self.db.database_url, '_local', 'julia006'])
+        )
+        self.assertEqual(
+            resp.json(),
+            {'_id': '_local/julia006', '_rev': '0-2', 'name': 'jules', 'age': 6}
+        )
+
+    def test_context_manager_raises_error(self):
+        """
+        Test that the local context manager will raise an error if a problem
+        occurs during initial fetch.
+        """
+        resp = requests.Response()
+        resp.status_code = 400
+        self.client.r_session.get = mock.Mock(return_value=resp)
+        with self.assertRaises(requests.HTTPError) as cm:
+            with LocalDocument(self.db, 'julia006') as doc:
+                doc['name'] = 'does not matter'
+                doc['age'] = 'who cares?'
+        err = cm.exception
+        self.assertEqual(err.response.status_code, 400)
+        self.client.r_session.get.assert_called_with(
+            '/'.join([self.db.database_url, '_local', 'julia006'])
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Added the LocalDocument class to provide support for Cloudant `_local` documents

## How

- Added a LocalDocument class that extends a `dict` and provides `exists`, `create`, `fetch`, `save`, `delete`, and context manager functionality.
- Added docs as well

## Testing

- Added tests that validate new local document functionality.  The majority of the tests target Cloudant only.
- Added tests to valdate the new local document exception class functionality.

## Issues

#284 
