### PR TITLE
291 doc throw on exists

### DIFF
--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -201,9 +201,8 @@ def _py_to_couch_translate(key, val):
             return {key: val}
         elif val is None:
             return {key: None}
-        else:
-            arg_converter = TYPE_CONVERTERS.get(type(val))
-            return {key: arg_converter(val)}
+        arg_converter = TYPE_CONVERTERS.get(type(val))
+        return {key: arg_converter(val)}
     except Exception as ex:
         raise CloudantArgumentError(136, key, ex)
 
@@ -299,7 +298,7 @@ class InfiniteSession(Session):
         self._server_url = server_url
         self._timeout = kwargs.get('timeout', None)
 
-    def request(self, method, url, **kwargs):
+    def request(self, method, url, **kwargs):  # pylint: disable=W0221
         """
         Overrides ``requests.Session.request`` to perform a POST to the
         _session endpoint to renew Session cookie authentication settings and
@@ -338,7 +337,7 @@ class ClientSession(Session):
         self._server_url = server_url
         self._timeout = kwargs.get('timeout', None)
 
-    def request(self, method, url, **kwargs):
+    def request(self, method, url, **kwargs):  # pylint: disable=W0221
         """
         Overrides ``requests.Session.request`` to set the timeout.
         """

--- a/src/cloudant/client.py
+++ b/src/cloudant/client.py
@@ -371,8 +371,8 @@ class CouchDB(dict):
         if db.exists():
             super(CouchDB, self).__setitem__(key, db)
             return db
-        else:
-            return default
+
+        return default
 
     def __setitem__(self, key, value, remote=False):
         """

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -157,10 +157,15 @@ class CouchDatabase(dict):
             doc = DesignDocument(self, docid)
         else:
             doc = Document(self, docid)
-        if throw_on_exists and doc.exists():
-            raise CloudantDatabaseException(409, docid)
         doc.update(data)
-        doc.create()
+        try:
+            doc.create()
+        except HTTPError as error:
+            if error.response.status_code == 409:
+                if throw_on_exists:
+                    raise CloudantDatabaseException(409, docid)
+            else:
+                raise
         super(CouchDatabase, self).__setitem__(doc['_id'], doc)
         return doc
 

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -331,8 +331,8 @@ class CouchDatabase(dict):
             return view(**kwargs)
         elif kwargs:
             return Result(view, **kwargs)
-        else:
-            return view.result
+
+        return view.result
 
     def create(self, throw_on_exists=False):
         """
@@ -1237,8 +1237,8 @@ class CloudantDatabase(CouchDatabase):
             return query(**kwargs)
         if kwargs:
             return QueryResult(query, **kwargs)
-        else:
-            return query.result
+
+        return query.result
 
     def get_search_result(self, ddoc_id, index_name, **query_params):
         """

--- a/src/cloudant/result.py
+++ b/src/cloudant/result.py
@@ -201,7 +201,7 @@ class Result(object):
         data = None
         if isinstance(arg, int):
             data = self._handle_result_by_index(arg)
-        elif isinstance(arg, STRTYPE) or isinstance(arg, list):
+        elif isinstance(arg, (STRTYPE, list)):
             data = self._handle_result_by_key(arg)
         elif isinstance(arg, ResultByKey):
             data = self._handle_result_by_key(arg())
@@ -345,7 +345,7 @@ class Result(object):
             )
             result = self._parse_data(response)
             skip += int(self._page_size)
-            if len(result) > 0:
+            if result:
                 for row in result:
                     yield row
                 del result

--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -267,6 +267,17 @@ class DatabaseTests(UnitTestDbBase):
                 'Document with id julia06 already exists.'
                 )
 
+    def test_create_document_that_already_exists(self):
+        """
+        Test creating a document that already exists
+        """
+        data = {'_id': 'julia'}
+        doc = self.db.create_document(data)
+        self.assertEqual(self.db['julia'], doc)
+        self.assertTrue(doc['_rev'].startswith('1-'))
+        # attempt to recreate document
+        self.db.create_document(data, throw_on_exists=False)
+
     def test_create_document_without_id(self):
         """
         Test creating a document without supplying a document id


### PR DESCRIPTION
## What
Catch error if `throw_on_exists` flag is set to `False` for document create.

## How
Add new `throw_on_exists` boolean param to the `Document.create` method. Note that default behaviour is unchanged.

## Testing
Includes additional unit test `test_create_document_that_already_exists`.

## Issues
- #291
