### PR TITLE
Fix _all_docs call where keys is an empty list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 - [FIXED] Fixed ``TypeError`` when setting revision limits on Python>=3.6.
 - [FIXED] Fixed the ``exists()`` double check on ``client.py`` and ``database.py``.
 - [FIXED] Fixed Cloudant exception code 409 with 412 when creating a database that already exists.
+- [FIXED] Catch error if ``throw_on_exists`` flag is ``False`` for document create.
+- [FIXED] Fixed /_all_docs call where ``keys`` is an empty list.
 
 2.4.0 (2017-02-14)
 ==================

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -237,11 +237,11 @@ def get_docs(r_session, url, encoder=None, headers=None, **params):
     """
     keys_list = params.pop('keys', None)
     keys = None
-    if keys_list:
+    if keys_list is not None:
         keys = json.dumps({'keys': keys_list}, cls=encoder)
     f_params = python_to_couch(params)
     resp = None
-    if keys:
+    if keys is not None:
         # If we're using POST we are sending JSON so add the header
         if headers is None:
             headers = {}

--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -432,6 +432,15 @@ class DatabaseTests(UnitTestDbBase):
         keys_returned = [row['key'] for row in rows]
         self.assertTrue(all(x in keys_returned for x in keys_list))
 
+    def test_all_docs_post_empty_key_list(self):
+        """
+        Test the all_docs POST request functionality using empty keys param
+        """
+        self.populate_db_with_documents()
+        # Request all_docs using an empty key list
+        rows = self.db.all_docs(keys=[]).get('rows')
+        self.assertEqual(len(rows), 0)
+
     def test_all_docs_post_multiple_params(self):
         """
         Test the all_docs POST request functionality using keys and other params


### PR DESCRIPTION
## What
Fix `/_all_docs` call where `keys=[]`.

## How
The `get_docs` common function was incorrectly dropping the `keys` parameter if the value of `keys` was an empty list.

## Testing
Includes additional unit tests.

## Issues
- #289 
