### PR TITLE
non-UTF8 chars (like \u2013) in your map/reduce will make the ddoc fetch puke

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,6 @@
 2.5.0 (Unreleased)
 ==================
+- [FIXED] Fixed crash caused by non-UTF8 chars in ddocs
 - [FIXED] Fixed ``TypeError`` when setting revision limits on Python>=3.6.
 - [FIXED] Fixed the ``exists()`` double check on ``client.py`` and ``database.py``.
 - [FIXED] Fixed Cloudant exception code 409 with 412 when creating a database that already exists.

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -283,7 +283,7 @@ class _Code(str):
     codifying map and reduce Javascript content.
     """
     def __new__(cls, code):
-        return str.__new__(cls, code)
+        return str.__new__(cls, code.encode('utf8'))
 
 class InfiniteSession(Session):
     """

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -283,7 +283,9 @@ class _Code(str):
     codifying map and reduce Javascript content.
     """
     def __new__(cls, code):
-        return str.__new__(cls, code.encode('utf8'))
+        if isinstance(code, unicode):
+            return str.__new__(cls, code.encode('utf8'))
+        return str.__new__(cls, code)
 
 class InfiniteSession(Session):
     """


### PR DESCRIPTION

Thanks for your hard work, please ensure all items are complete before opening.

- [x] You have signed the CLA as per the instructions in [CONTRIBUTING.rst](https://github.com/cloudant/python-cloudant/blob/master/CONTRIBUTING.rst#contributor-license-agreement) (IBMer)
- [ ] You have added tests for any code changes
- [x] You have updated the [CHANGES.rst](https://github.com/cloudant/python-cloudant/blob/master/CHANGES.rst) 
- [x] You have completed the PR template below:

## What

What was changed, e.g. Added support for querying views.
- fixed crash on non-UTF8 chars in design docs

## How
 - fixed by encoding to UTF8

## Testing

How to test your changes work, not required for documentation changes.
Setup faulty view with `couchapp`
```bash
mkdir test
cd test
couchapp init
couchapp generate view foo
couchapp push http://admin:password@localhost:5984/foo
```

`test.py`:
```python
from cloudant import couchdb_admin_party
from cloudant.design_document import DesignDocument

with couchdb_admin_party(url="http://localhost:5984") as couch:
    db = couch.get('foo', remote=True)

    ddoc = DesignDocument(db, '_design/test')
    ddoc.fetch()
```
cause error:
```bash
$ python test.py 
Traceback (most recent call last):
  File "test.py", line 8, in <module>
    ddoc.fetch()
  File "/usr/local/lib/python2.7/dist-packages/cloudant/design_document.py", line 491, in fetch
    **view_def
  File "/usr/local/lib/python2.7/dist-packages/cloudant/view.py", line 107, in __init__
    self['reduce'] = codify(reduce_func)
  File "/usr/local/lib/python2.7/dist-packages/cloudant/_common_util.py", line 234, in codify
    return _Code(code_or_str)
  File "/usr/local/lib/python2.7/dist-packages/cloudant/_common_util.py", line 291, in __new__
    return str.__new__(cls, code)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2013' in position 341: ordinal not in range(128)
```

## Issues

Links to the github issue(s) (if present) that this pull request is resolving.
