### PR TITLE
Fix pylint import error in adapters.py

### DIFF
--- a/src/cloudant/adapters.py
+++ b/src/cloudant/adapters.py
@@ -18,7 +18,7 @@ Module that contains default transport adapters for use with requests.
 """
 from requests.adapters import HTTPAdapter
 
-from requests.packages.urllib3.util import Retry
+from urllib3.util import Retry
 
 class Replay429Adapter(HTTPAdapter):
     """


### PR DESCRIPTION
## What
Fix pylint import error in `adapters.py`.

## How
Import `Retry` directly from `urllib3.util`.