### PR TITLE
Fix pylint failure on Py3

### DIFF
--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -283,7 +283,7 @@ class _Code(str):
     codifying map and reduce Javascript content.
     """
     def __new__(cls, code):
-        if isinstance(code, unicode):
+        if type(code).__name__ == 'unicode':
             return str.__new__(cls, code.encode('utf8'))
         return str.__new__(cls, code)
 

--- a/src/cloudant/adapters.py
+++ b/src/cloudant/adapters.py
@@ -18,7 +18,7 @@ Module that contains default transport adapters for use with requests.
 """
 from requests.adapters import HTTPAdapter
 
-from urllib3.util import Retry
+from requests.packages import urllib3
 
 class Replay429Adapter(HTTPAdapter):
     """
@@ -33,7 +33,7 @@ class Replay429Adapter(HTTPAdapter):
     :param float initialBackoff: time in seconds for the first backoff.
     """
     def __init__(self, retries=3, initialBackoff=0.25):
-        super(Replay429Adapter, self).__init__(max_retries=Retry(
+        super(Replay429Adapter, self).__init__(max_retries=urllib3.util.Retry(
             # Configure the number of retries for status codes
             total=retries,
             # No retries for connect|read errors


### PR DESCRIPTION
## What
Encode unicode strings as UTF-8 in Py2.

## Testing
No additional tests added.

## Issues
Fixes #301.
