### PR TITLE
304 fix bad startkey in all doc iter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@
 - [FIXED] Fixed Cloudant exception code 409 with 412 when creating a database that already exists.
 - [FIXED] Catch error if ``throw_on_exists`` flag is ``False`` for document create.
 - [FIXED] Fixed /_all_docs call where ``keys`` is an empty list.
+- [FIXED] Issue where docs with IDs that sorted lower than 0 were not returned when iterating through _all_docs.
 
 2.4.0 (2017-02-14)
 ==================

--- a/src/cloudant/_2to3.py
+++ b/src/cloudant/_2to3.py
@@ -32,6 +32,9 @@ UNITYPE = unicode if PY2 else str
 # pylint: disable=undefined-variable
 LONGTYPE = long if PY2 else int
 
+# pylint: disable=undefined-variable
+UNICHR = unichr if PY2 else chr
+
 if PY2:
     # pylint: disable=wrong-import-position,no-name-in-module,import-error,unused-import
     from urllib import quote as url_quote, quote_plus as url_quote_plus


### PR DESCRIPTION
## What
Fix bad `startkey` parameter in `/_all_docs` iterator.

## How
Initially use `u'\u0000'` as a `startkey` parameter. With each batch, update the `startkey` to `docs[-1]['id'] + u'\u0000'`. 

This means that fetching an additional document per batch to act as the next `startkey` is now unnecessary.

## Testing
Includes additional `/_all_docs` test.

## Issues
Fixes #304.
