### PR TITLE
297 changes feed since option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 2.6.0 (Unreleased)
 ==================
 - [FIXED] Fixed client construction in ``cloudant_bluemix`` context manager.
+- [FIXED] Fixed validation for feed options to accept zero as a valid value.
 
 2.5.0 (2017-07-06)
 ==================

--- a/src/cloudant/feed.py
+++ b/src/cloudant/feed.py
@@ -116,7 +116,7 @@ class Feed(object):
         if (not isinstance(val, arg_types[key]) or
                 (isinstance(val, bool) and int in arg_types[key])):
             raise CloudantArgumentError(117, key, arg_types[key])
-        if isinstance(val, int) and val <= 0 and not isinstance(val, bool):
+        if isinstance(val, int) and val < 0 and not isinstance(val, bool):
             raise CloudantArgumentError(118, key, val)
         if key == 'feed':
             valid_vals = ('continuous', 'normal', 'longpoll')

--- a/tests/unit/changes_tests.py
+++ b/tests/unit/changes_tests.py
@@ -353,6 +353,20 @@ class ChangesTests(UnitTestDbBase):
         expected = set(['julia003', 'julia004', 'julia005'])
         self.assertSetEqual(set([x['id'] for x in changes]), expected)
 
+    def test_get_feed_using_since_zero(self):
+        """
+        Test getting content back for a feed using since set to zero
+        """
+        self.populate_db_with_documents(3)
+        feed = Feed(self.db, since=0)
+        changes = list()
+        for change in feed:
+            self.assertSetEqual(set(change.keys()), {'seq', 'changes', 'id'})
+            changes.append(change)
+        expected = set(['julia{0:03d}'.format(i) for i in range(3)])
+        self.assertSetEqual(set([x['id'] for x in changes]), expected)
+        self.assertTrue(str(feed.last_seq).startswith('3'))
+
     def test_get_feed_using_timeout(self):
         """
         Test getting content back for a feed using timeout


### PR DESCRIPTION
## What

Fix changes feed validation to allow for the valid value `0` for `since` option.

## How

- Fixed exception check so that value `0` for changes feed option `since` is valid

## Testing

Added test case in `changes_tests.py`

## Issues

fixes #297 