### PR TITLE
Add ``Result.all()`` convenience method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,6 @@
 Unreleased
 ==========
+- [NEW] Added ``Result.all()`` convenience method.
 - [IMPROVED] Updated ``posixpath.join`` references to use ``'/'.join`` when concatenating URL parts.
 
 2.6.0 (2017-08-10)

--- a/src/cloudant/result.py
+++ b/src/cloudant/result.py
@@ -359,6 +359,18 @@ class Result(object):
         """
         return data.get('rows', [])
 
+    def all(self):
+        """
+        Retrieve all results.
+
+        Specifying a ``limit`` parameter in the ``Result`` constructor will
+        limit the number of documents returned. Be aware that the ``page_size``
+        parameter is not honoured.
+
+        :return: results data as list in JSON format.
+        """
+        return self[:]
+
 class QueryResult(Result):
     """
     Provides a index key accessible, sliceable and iterable interface to query

--- a/tests/unit/result_tests.py
+++ b/tests/unit/result_tests.py
@@ -248,6 +248,16 @@ class ResultTests(UnitTestDbBase):
                     {'key': 'julia002', 'id': 'julia002', 'value': 1}]
         self.assertEqual(result[:], expected)
 
+    def test_get_all_items(self):
+        """
+        Test that all results can be retrieved.
+        """
+        result = Result(self.view001, limit=3)
+        expected = [{'key': 'julia000', 'id': 'julia000', 'value': 1},
+                    {'key': 'julia001', 'id': 'julia001', 'value': 1},
+                    {'key': 'julia002', 'id': 'julia002', 'value': 1}]
+        self.assertEqual(result.all(), expected)
+
     def test_get_item_invalid_index_slice(self):
         """
         Test that when invalid start and stop values are provided in a slice


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/python-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.rst](https://github.com/cloudant/python-cloudant/blob/master/CHANGES.rst) 
- [x] You have completed the PR template below:

## What
Add ``Result.all()`` convenience method.

## How
Performs same functionality as `result[:]`.

## Testing
Includes additional unit test.

## Issues
Fixes #233.