### PR TITLE
Use `'/'.join()` to concatenate URL parts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,6 @@
 Unreleased
 ==========
+- [IMPROVED] Updated ``posixpath.join`` references to use ``'/'.join`` when concatenating URL parts.
 
 2.6.0 (2017-08-10)
 ==================

--- a/src/cloudant/client.py
+++ b/src/cloudant/client.py
@@ -18,7 +18,6 @@ instance.
 """
 import base64
 import json
-import posixpath
 
 from ._2to3 import bytes_, unicode_
 from .database import CloudantDatabase, CouchDatabase
@@ -138,7 +137,7 @@ class CouchDB(dict):
         """
         if self.admin_party:
             return None
-        sess_url = posixpath.join(self.server_url, '_session')
+        sess_url = '/'.join((self.server_url, '_session'))
         resp = self.r_session.get(sess_url)
         resp.raise_for_status()
         sess_data = resp.json()
@@ -164,7 +163,7 @@ class CouchDB(dict):
         """
         if self.admin_party:
             return
-        sess_url = posixpath.join(self.server_url, '_session')
+        sess_url = '/'.join((self.server_url, '_session'))
         resp = self.r_session.post(
             sess_url,
             data={
@@ -182,7 +181,7 @@ class CouchDB(dict):
         """
         if self.admin_party:
             return
-        sess_url = posixpath.join(self.server_url, '_session')
+        sess_url = '/'.join((self.server_url, '_session'))
         resp = self.r_session.delete(sess_url)
         resp.raise_for_status()
 
@@ -207,7 +206,7 @@ class CouchDB(dict):
 
         :returns: List of database names for the client
         """
-        url = posixpath.join(self.server_url, '_all_dbs')
+        url = '/'.join((self.server_url, '_all_dbs'))
         resp = self.r_session.get(url)
         resp.raise_for_status()
         return resp.json()
@@ -560,9 +559,7 @@ class Cloudant(CouchDB):
             try:
                 if int(year) > 0 and int(month) in range(1, 13):
                     resp = self.r_session.get(
-                        posixpath.join(
-                            endpoint, str(int(year)), str(int(month)))
-                    )
+                        '/'.join((endpoint, str(int(year)), str(int(month)))))
                 else:
                     err = True
             except (ValueError, TypeError):
@@ -587,7 +584,7 @@ class Cloudant(CouchDB):
 
         :returns: Billing data in JSON format
         """
-        endpoint = posixpath.join(self.server_url, '_api', 'v2', 'bill')
+        endpoint = '/'.join((self.server_url, '_api', 'v2', 'bill'))
         return self._usage_endpoint(endpoint, year, month)
 
     def volume_usage(self, year=None, month=None):
@@ -604,9 +601,8 @@ class Cloudant(CouchDB):
 
         :returns: Volume usage data in JSON format
         """
-        endpoint = posixpath.join(
-            self.server_url, '_api', 'v2', 'usage', 'data_volume'
-        )
+        endpoint = '/'.join((
+            self.server_url, '_api', 'v2', 'usage', 'data_volume'))
         return self._usage_endpoint(endpoint, year, month)
 
     def requests_usage(self, year=None, month=None):
@@ -623,9 +619,8 @@ class Cloudant(CouchDB):
 
         :returns: Requests usage data in JSON format
         """
-        endpoint = posixpath.join(
-            self.server_url, '_api', 'v2', 'usage', 'requests'
-        )
+        endpoint = '/'.join((
+            self.server_url, '_api', 'v2', 'usage', 'requests'))
         return self._usage_endpoint(endpoint, year, month)
 
     def shared_databases(self):
@@ -635,9 +630,8 @@ class Cloudant(CouchDB):
 
         :returns: List of database names
         """
-        endpoint = posixpath.join(
-            self.server_url, '_api', 'v2', 'user', 'shared_databases'
-        )
+        endpoint = '/'.join((
+            self.server_url, '_api', 'v2', 'user', 'shared_databases'))
         resp = self.r_session.get(endpoint)
         resp.raise_for_status()
         data = resp.json()
@@ -649,9 +643,7 @@ class Cloudant(CouchDB):
 
         :returns: API key/pass pair in JSON format
         """
-        endpoint = posixpath.join(
-            self.server_url, '_api', 'v2', 'api_keys'
-        )
+        endpoint = '/'.join((self.server_url, '_api', 'v2', 'api_keys'))
         resp = self.r_session.post(endpoint)
         resp.raise_for_status()
         return resp.json()
@@ -662,9 +654,8 @@ class Cloudant(CouchDB):
 
         :returns: CORS data in JSON format
         """
-        endpoint = posixpath.join(
-            self.server_url, '_api', 'v2', 'user', 'config', 'cors'
-        )
+        endpoint = '/'.join((
+            self.server_url, '_api', 'v2', 'user', 'config', 'cors'))
         resp = self.r_session.get(endpoint)
         resp.raise_for_status()
 
@@ -754,9 +745,8 @@ class Cloudant(CouchDB):
 
         :returns: CORS configuration update status in JSON format
         """
-        endpoint = posixpath.join(
-            self.server_url, '_api', 'v2', 'user', 'config', 'cors'
-        )
+        endpoint = '/'.join((
+            self.server_url, '_api', 'v2', 'user', 'config', 'cors'))
         resp = self.r_session.put(
             endpoint,
             data=json.dumps(config, cls=self.encoder),

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -17,7 +17,6 @@ API module that maps to a Cloudant or CouchDB database instance.
 """
 import json
 import contextlib
-import posixpath
 
 from requests.exceptions import HTTPError
 
@@ -84,10 +83,8 @@ class CouchDatabase(dict):
 
         :returns: Database URL
         """
-        return posixpath.join(
-            self._database_host,
-            url_quote_plus(self.database_name)
-        )
+        return '/'.join((
+            self._database_host, url_quote_plus(self.database_name)))
 
     @property
     def creds(self):
@@ -189,7 +186,7 @@ class CouchDatabase(dict):
 
         :returns: All design documents found in this database in JSON format
         """
-        url = posixpath.join(self.database_url, '_all_docs')
+        url = '/'.join((self.database_url, '_all_docs'))
         query = "startkey=\"_design\"&endkey=\"_design0\"&include_docs=true"
         resp = self.r_session.get(url, params=query)
         resp.raise_for_status()
@@ -203,7 +200,7 @@ class CouchDatabase(dict):
 
         :returns: List of names for all design documents in this database
         """
-        url = posixpath.join(self.database_url, '_all_docs')
+        url = '/'.join((self.database_url, '_all_docs'))
         query = "startkey=\"_design\"&endkey=\"_design0\""
         resp = self.r_session.get(url, params=query)
         resp.raise_for_status()
@@ -675,7 +672,7 @@ class CouchDatabase(dict):
 
         :returns: Bulk document creation/update status in JSON format
         """
-        url = posixpath.join(self.database_url, '_bulk_docs')
+        url = '/'.join((self.database_url, '_bulk_docs'))
         data = {'docs': docs}
         headers = {'Content-Type': 'application/json'}
         resp = self.r_session.post(
@@ -698,7 +695,7 @@ class CouchDatabase(dict):
 
         :returns: List of missing document revision values
         """
-        url = posixpath.join(self.database_url, '_missing_revs')
+        url = '/'.join((self.database_url, '_missing_revs'))
         data = {doc_id: list(revisions)}
 
         resp = self.r_session.post(
@@ -727,7 +724,7 @@ class CouchDatabase(dict):
 
         :returns: The revision differences in JSON format
         """
-        url = posixpath.join(self.database_url, '_revs_diff')
+        url = '/'.join((self.database_url, '_revs_diff'))
         data = {doc_id: list(revisions)}
 
         resp = self.r_session.post(
@@ -746,7 +743,7 @@ class CouchDatabase(dict):
 
         :returns: Revision limit value for the current remote database
         """
-        url = posixpath.join(self.database_url, '_revs_limit')
+        url = '/'.join((self.database_url, '_revs_limit'))
         resp = self.r_session.get(url)
         resp.raise_for_status()
 
@@ -767,7 +764,7 @@ class CouchDatabase(dict):
 
         :returns: Revision limit set operation status in JSON format
         """
-        url = posixpath.join(self.database_url, '_revs_limit')
+        url = '/'.join((self.database_url, '_revs_limit'))
 
         resp = self.r_session.put(url, data=json.dumps(limit, cls=self.client.encoder))
         resp.raise_for_status()
@@ -781,7 +778,7 @@ class CouchDatabase(dict):
 
         :returns: View cleanup status in JSON format
         """
-        url = posixpath.join(self.database_url, '_view_cleanup')
+        url = '/'.join((self.database_url, '_view_cleanup'))
         resp = self.r_session.post(
             url,
             headers={'Content-Type': 'application/json'}
@@ -958,8 +955,8 @@ class CloudantDatabase(CouchDatabase):
 
         :returns: Security document URL
         """
-        parts = ['_api', 'v2', 'db', self.database_name, '_security']
-        url = posixpath.join(self._database_host, *parts)
+        url = '/'.join((self._database_host, '_api', 'v2', 'db',
+                        self.database_name, '_security'))
         return url
 
     def share_database(self, username, roles=None):
@@ -1040,7 +1037,7 @@ class CloudantDatabase(CouchDatabase):
 
         :returns: Shard information retrieval status in JSON format
         """
-        url = posixpath.join(self.database_url, '_shards')
+        url = '/'.join((self.database_url, '_shards'))
         resp = self.r_session.get(url)
         resp.raise_for_status()
 
@@ -1059,7 +1056,7 @@ class CloudantDatabase(CouchDatabase):
         :returns: The query indexes in the database
         """
 
-        url = posixpath.join(self.database_url, '_index')
+        url = '/'.join((self.database_url, '_index'))
         resp = self.r_session.get(url)
         resp.raise_for_status()
 

--- a/src/cloudant/document.py
+++ b/src/cloudant/document.py
@@ -16,7 +16,6 @@
 API module/class for interacting with a document in a database.
 """
 import json
-import posixpath
 import requests
 from requests.exceptions import HTTPError
 
@@ -87,19 +86,19 @@ class Document(dict):
 
         # handle design document url
         if self._document_id.startswith('_design/'):
-            return posixpath.join(
+            return '/'.join((
                 self._database_host,
                 url_quote_plus(self._database_name),
                 '_design',
                 url_quote(self._document_id[8:], safe='')
-            )
+            ))
 
         # handle document url
-        return posixpath.join(
+        return '/'.join((
             self._database_host,
             url_quote_plus(self._database_name),
             url_quote(self._document_id, safe='')
-        )
+        ))
 
     def exists(self):
         """
@@ -389,7 +388,7 @@ class Document(dict):
         """
         # need latest rev
         self.fetch()
-        attachment_url = posixpath.join(self.document_url, attachment)
+        attachment_url = '/'.join((self.document_url, attachment))
         if headers is None:
             headers = {'If-Match': self['_rev']}
         else:
@@ -432,7 +431,7 @@ class Document(dict):
         """
         # need latest rev
         self.fetch()
-        attachment_url = posixpath.join(self.document_url, attachment)
+        attachment_url = '/'.join((self.document_url, attachment))
         if headers is None:
             headers = {'If-Match': self['_rev']}
         else:
@@ -473,7 +472,7 @@ class Document(dict):
         """
         # need latest rev
         self.fetch()
-        attachment_url = posixpath.join(self.document_url, attachment)
+        attachment_url = '/'.join((self.document_url, attachment))
         if headers is None:
             headers = {
                 'If-Match': self['_rev'],

--- a/src/cloudant/index.py
+++ b/src/cloudant/index.py
@@ -16,7 +16,6 @@
 API module for managing/viewing query indexes.
 """
 
-import posixpath
 import json
 
 from ._2to3 import STRTYPE, iteritems_
@@ -60,7 +59,7 @@ class Index(object):
 
         :returns: Index URL
         """
-        return posixpath.join(self._database.database_url, '_index')
+        return '/'.join((self._database.database_url, '_index'))
 
     @property
     def design_document_id(self):
@@ -166,7 +165,7 @@ class Index(object):
         ddoc_id = self._ddoc_id
         if ddoc_id.startswith('_design/'):
             ddoc_id = ddoc_id[8:]
-        url = posixpath.join(self.index_url, ddoc_id, self._type, self._name)
+        url = '/'.join((self.index_url, ddoc_id, self._type, self._name))
         resp = self._r_session.delete(url)
         resp.raise_for_status()
         return

--- a/src/cloudant/query.py
+++ b/src/cloudant/query.py
@@ -16,7 +16,6 @@
 API module for composing and executing Cloudant queries.
 """
 
-import posixpath
 import json
 import contextlib
 
@@ -105,7 +104,7 @@ class Query(dict):
 
         :returns: Query URL
         """
-        return posixpath.join(self._database.database_url, '_find')
+        return '/'.join((self._database.database_url, '_find'))
 
     def __call__(self, **kwargs):
         """

--- a/src/cloudant/view.py
+++ b/src/cloudant/view.py
@@ -16,7 +16,6 @@
 API module for interacting with a view in a design document.
 """
 import contextlib
-import posixpath
 
 from ._2to3 import STRTYPE
 from ._common_util import codify, get_docs
@@ -168,11 +167,11 @@ class View(dict):
 
         :returns: View URL
         """
-        return posixpath.join(
+        return '/'.join((
             self.design_doc.document_url,
             '_view',
             self.view_name
-        )
+        ))
 
     def __call__(self, **kwargs):
         """

--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -25,7 +25,6 @@ module docstring.
 import unittest
 import mock
 import requests
-import posixpath
 import os
 import uuid
 
@@ -149,8 +148,8 @@ class DatabaseTests(UnitTestDbBase):
         """
         self.assertEqual(
             self.db.database_url,
-            posixpath.join(self.client.server_url, self.test_dbname)
-            )
+            '/'.join((self.client.server_url, self.test_dbname))
+        )
 
     def test_retrieve_creds(self):
         """
@@ -233,8 +232,7 @@ class DatabaseTests(UnitTestDbBase):
         same.  Therefore comparing keys is a valid test of this functionality.
         """
         resp = self.db.r_session.get(
-            posixpath.join(self.client.server_url, self.test_dbname)
-            )
+            '/'.join((self.client.server_url, self.test_dbname)))
         expected = resp.json()
         actual = self.db.metadata()
         self.assertListEqual(list(actual.keys()), list(expected.keys()))
@@ -656,7 +654,7 @@ class DatabaseTests(UnitTestDbBase):
             # A valid document must have a document_url
             self.assertEqual(
                 doc.document_url,
-                posixpath.join(self.db.database_url, doc['_id'])
+                '/'.join((self.db.database_url, doc['_id']))
             )
             if isinstance(doc, DesignDocument):
                 self.assertEqual(doc['_id'], '_design/ddoc001')

--- a/tests/unit/document_tests.py
+++ b/tests/unit/document_tests.py
@@ -24,7 +24,6 @@ module docstring.
 
 import unittest
 import mock
-import posixpath
 import json
 import requests
 import os
@@ -115,7 +114,7 @@ class DocumentTests(UnitTestDbBase):
         """
         doc = Document(self.db, 'julia006')
         self.assertEqual(
-            doc.document_url, posixpath.join(self.db.database_url, 'julia006')
+            doc.document_url, '/'.join((self.db.database_url, 'julia006'))
         )
 
     def test_document_url_encodes_correctly(self):
@@ -124,10 +123,8 @@ class DocumentTests(UnitTestDbBase):
         """
         doc = Document(self.db, 'http://example.com')
         self.assertEqual(
-            doc.document_url, posixpath.join(
-                self.db.database_url,
-                'http%3A%2F%2Fexample.com'
-            )
+            doc.document_url,
+            '/'.join((self.db.database_url, 'http%3A%2F%2Fexample.com'))
         )
 
     def test_design_document_url(self):
@@ -137,10 +134,8 @@ class DocumentTests(UnitTestDbBase):
         """
         doc = Document(self.db, '_design/ddoc001')
         self.assertEqual(
-            doc.document_url, posixpath.join(
-                self.db.database_url,
-                '_design/ddoc001'
-            )
+            doc.document_url,
+            '/'.join((self.db.database_url, '_design/ddoc001'))
         )
 
     def test_design_document_url_encodes_correctly(self):
@@ -149,10 +144,8 @@ class DocumentTests(UnitTestDbBase):
         """
         doc = Document(self.db, '_design/http://example.com')
         self.assertEqual(
-            doc.document_url, posixpath.join(
-                self.db.database_url,
-                '_design/http%3A%2F%2Fexample.com'
-            )
+            doc.document_url,
+            '/'.join((self.db.database_url, '_design/http%3A%2F%2Fexample.com'))
         )
 
     def test_constructor_without_docid(self):

--- a/tests/unit/index_tests.py
+++ b/tests/unit/index_tests.py
@@ -25,7 +25,6 @@ from __future__ import absolute_import
 import unittest
 import mock
 import os
-import posixpath
 import requests
 
 from cloudant.index import Index, TextIndex, SpecialIndex
@@ -122,7 +121,7 @@ class IndexTests(UnitTestDbBase):
         index = Index(self.db)
         self.assertEqual(
             index.index_url,
-            posixpath.join(self.db.database_url, '_index')
+            '/'.join((self.db.database_url, '_index'))
         )
 
     def test_index_to_dictionary(self):

--- a/tests/unit/query_tests.py
+++ b/tests/unit/query_tests.py
@@ -22,7 +22,6 @@ module docstring.
 
 import unittest
 import os
-import posixpath
 
 from cloudant.query import Query
 from cloudant.result import QueryResult
@@ -78,7 +77,7 @@ class QueryTests(UnitTestDbBase):
         query = Query(self.db)
         self.assertEqual(
             query.url,
-            posixpath.join(self.db.database_url, '_find')
+            '/'.join((self.db.database_url, '_find'))
         )
 
     def test_callable_with_invalid_argument(self):

--- a/tests/unit/view_tests.py
+++ b/tests/unit/view_tests.py
@@ -24,7 +24,6 @@ module docstring.
 
 import unittest
 import mock
-import posixpath
 import requests
 import os
 
@@ -182,7 +181,7 @@ class ViewTests(UnitTestDbBase):
         view = View(ddoc, 'view001')
         self.assertEqual(
             view.url,
-            posixpath.join(ddoc.document_url, '_view/view001')
+            '/'.join((ddoc.document_url, '_view/view001'))
         )
 
     def test_get_view_callable_raw_json(self):


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/python-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.rst](https://github.com/cloudant/python-cloudant/blob/master/CHANGES.rst) 
- [x] You have completed the PR template below:

## What
Use `'/'.join()` to concatenate URL parts.

## How
Updated `posixpath.join` references to use `'/'.join` when concatenating URL parts.

## Issues
Fixes #127.