### PR TITLE
Add a copy operation to the Document class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 Unreleased
 ==========
 - [IMPROVED] Updated ``posixpath.join`` references to use ``'/'.join`` when concatenating URL parts.
+- [NEW] Add support for copying Document objects.
 
 2.6.0 (2017-08-10)
 ==================

--- a/pylintrc
+++ b/pylintrc
@@ -109,7 +109,7 @@ required-attributes=
 bad-functions=map,filter,input
 
 # Good variable names which should always be accepted, separated by a comma
-good-names=i,j,k,ex,Run,_,db
+good-names=i,j,k,ex,Run,_,db,v
 
 # Bad variable names which should always be refused, separated by a comma
 bad-names=foo,bar,baz,toto,tutu,tata

--- a/src/cloudant/document.py
+++ b/src/cloudant/document.py
@@ -65,6 +65,21 @@ class Document(dict):
             self['_id'] = self._document_id
         self.encoder = self._client.encoder
 
+    def copy(self):
+        """
+        Create a copy of the Document, including any locally cached content.
+        """
+        return self.__copy__()
+
+    def __copy__(self):
+        """
+        Copy the document, for use in copy.copy() calls. See `copy()`.
+        """
+        cpy = Document(self._database, document_id=self._document_id)
+        for k, v in self.items():
+            cpy[k] = v
+        return cpy
+
     @property
     def r_session(self):
         """

--- a/src/cloudant/document.py
+++ b/src/cloudant/document.py
@@ -15,6 +15,7 @@
 """
 API module/class for interacting with a document in a database.
 """
+import copy
 import json
 import requests
 from requests.exceptions import HTTPError
@@ -65,19 +66,22 @@ class Document(dict):
             self['_id'] = self._document_id
         self.encoder = self._client.encoder
 
-    def copy(self):
-        """
-        Create a copy of the Document, including any locally cached content.
-        """
-        return self.__copy__()
-
     def __copy__(self):
         """
-        Copy the document, for use in copy.copy() calls. See `copy()`.
+        Shallow copy the document, for use in copy.copy() calls.
         """
         cpy = Document(self._database, document_id=self._document_id)
         for k, v in self.items():
             cpy[k] = v
+        return cpy
+
+    def __deepcopy__(self, memo):
+        """
+        Deep copy the document, for use in copy.deepcopy() calls.
+        """
+        cpy = Document(self._database, document_id=self._document_id)
+        for k, v in self.items():
+            cpy[k] = copy.deepcopy(v, memo)
         return cpy
 
     @property

--- a/tests/unit/document_tests.py
+++ b/tests/unit/document_tests.py
@@ -128,7 +128,7 @@ class DocumentTests(UnitTestDbBase):
         doc = Document(self.db, "clonable")
         for k, v in contents.items():
             doc[k] = v
-        for cpy in [doc.copy(), copy.copy(doc)]:
+        for cpy in [copy.deepcopy(doc), copy.copy(doc)]:
             self.assertEqual(doc._client, cpy._client)
             self.assertEqual(doc._database, cpy._database)
             self.assertEqual(doc._database_host, cpy._database_host)
@@ -141,17 +141,37 @@ class DocumentTests(UnitTestDbBase):
 
     def test_document_copy_independent(self):
         """
-        Test that changes to an original or copy don't affect the other.
+        Test that changes to an original or copy don't affect the other
+        at first level.
         """
-        contents = {'number': 3}
+        contents = {'number': 3, 'dict': {}}
         doc = Document(self.db, "clonable")
         for k, v in contents.items():
             doc[k] = v
         cpy = copy.copy(doc)
         doc['number'] = 5
         cpy['number'] = 7
+        cpy['dict']['h'] = 'w'
         self.assertEqual(doc['number'], 5)
         self.assertEqual(cpy['number'], 7)
+        self.assertEqual(cpy['dict']['h'], 'w')
+
+    def test_document_deepcopy_independent(self):
+        """
+        Test that changes to an original or copy don't affect the other
+        at all levels.
+        """
+        contents = {'number': 3, 'dict': {'h': 'm'}}
+        doc = Document(self.db, "clonable")
+        for k, v in contents.items():
+            doc[k] = v
+        cpy = copy.deepcopy(doc)
+        doc['number'] = 5
+        cpy['number'] = 7
+        doc['dict']['h'] = 'w'
+        self.assertEqual(doc['number'], 5)
+        self.assertEqual(cpy['number'], 7)
+        self.assertEqual(cpy['dict']['h'], 'm')
 
 
     def test_document_url(self):


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/python-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.rst](https://github.com/cloudant/python-cloudant/blob/master/CHANGES.rst) 
- [x] You have completed the PR template below:

## What

Added support for (shallow) copying Document objects.

## How

Added a public `copy` method and private `__copy__` method. This means that a document can be copied via a call to the object itself and also via the `copy` module, that is `copy.copy(doc)`. The latter allows for calling code to be more generic.

## Testing

I added a test that both `copy` and `copy.copy` produce accurate copies and that they are distinct objects.

## Issues

N/A, minor change.
