### PR TITLE
Updated deprecated docs.cloudant.com links

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@ Unreleased
 ==========
 - [NEW] Added ``Result.all()`` convenience method.
 - [IMPROVED] Updated ``posixpath.join`` references to use ``'/'.join`` when concatenating URL parts.
+- [IMPROVED] Updated documentation by replacing deprecated Cloudant links with the latest Bluemix links.
 
 2.6.0 (2017-08-10)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -55,8 +55,8 @@ Related Documentation
 =====================
 
 * `Cloudant Python client library docs (readthedocs.io) <http://python-cloudant.readthedocs.io>`_
-* `Cloudant documentation <http://docs.cloudant.com/>`_
-* `Cloudant for developers <https://cloudant.com/for-developers/>`_
+* `Cloudant documentation <https://console.bluemix.net/docs/services/Cloudant/cloudant.html#overview>`_
+* `Cloudant Learning Center <https://developer.ibm.com/clouddataservices/cloudant-learning-center/>`_
 
 ===========
 Development

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -811,7 +811,7 @@ class CouchDatabase(dict):
                 # Process data (in text format).
 
         For more detail on list functions, refer to the
-        `Cloudant list documentation <https://docs.cloudant.com/
+        `Cloudant list documentation <https://console.bluemix.net/docs/services/Cloudant/api/
         design_documents.html#list-functions>`_.
 
         :param str ddoc_id: Design document id used to get result.
@@ -849,7 +849,7 @@ class CouchDatabase(dict):
                 # Process data (in text format).
 
         For more detail on show functions, refer to the
-        `Cloudant show documentation <https://docs.cloudant.com/
+        `Cloudant show documentation <https://console.bluemix.net/docs/services/Cloudant/api/
         design_documents.html#show-functions>`_.
 
         :param str ddoc_id: Design document id used to get the result.
@@ -897,7 +897,7 @@ class CouchDatabase(dict):
                                             data={'month': 'July'})
 
         For more details, see the `update handlers documentation
-        <https://docs.cloudant.com/design_documents.html#update-handlers>`_.
+        <https://console.bluemix.net/docs/services/Cloudant/api/design_documents.html#update-handlers>`_.
 
         :param str ddoc_id: Design document id used to get result.
         :param str handler_name: Name used in part to identify the
@@ -970,7 +970,8 @@ class CloudantDatabase(CouchDatabase):
 
         :param str username: Cloudant user to share the database with.
         :param list roles: A list of
-            `roles <https://docs.cloudant.com/authorization.html#roles>`_
+            `roles
+            <https://console.bluemix.net/docs/services/Cloudant/api/authorization.html#roles>`_
             to grant to the named user.
 
         :returns: Share database status in JSON format

--- a/src/cloudant/design_document.py
+++ b/src/cloudant/design_document.py
@@ -68,7 +68,7 @@ class DesignDocument(Document):
             ddoc.save()
 
         For more details, see the `Update Validators documentation
-        <https://docs.cloudant.com/design_documents.html#update-validators>`_.
+        <https://console.bluemix.net/docs/services/Cloudant/api/design_documents.html#update-validators>`_.
 
         :returns: Dictionary containing update validator functions
         """
@@ -104,7 +104,7 @@ class DesignDocument(Document):
         :func:`~cloudant.database.CouchDatabase.changes`
 
         For more details, see the `Filter functions documentation
-        <https://docs.cloudant.com/design_documents.html#filter-functions>`_.
+        <https://console.bluemix.net/docs/services/Cloudant/api/design_documents.html#filter-functions>`_.
 
         :returns: Dictionary containing filter function names and functions
             as key/value
@@ -179,10 +179,10 @@ class DesignDocument(Document):
         Once the Cloudant Geo index is saved to the remote database, you can
         query the index with a GET request.  To issue a request against the
         ``_geo`` endpoint, see the steps outlined in the `endpoint access
-        documentation <getting_started.html#endpoint-access>`_.
+        <getting_started.html#endpoint-access>`_ section.
 
         For more details, see the `Cloudant Geospatial
-        documentation <https://docs.cloudant.com/geo.html>`_.
+        documentation <https://console.bluemix.net/docs/services/Cloudant/api/cloudant-geo.html>`_.
 
         :return: Dictionary containing Cloudant Geo names and index objects
             as key/value
@@ -241,7 +241,7 @@ class DesignDocument(Document):
         rewritten as ``/$DATABASE/_design/doc/_rewrite/new?k=v``.
 
         For more details on URL rewriting, see the `rewrite rules
-        documentation <https://docs.cloudant.com/design_documents.html
+        documentation <https://console.bluemix.net/docs/services/Cloudant/api/design_documents.html
         #rewrite-rules>`_.
 
         :returns: List of dictionaries containing rewrite rules as key/value


### PR DESCRIPTION
## What

Updated `docs.cloudant.com` links to the latest Bluemix `console.bluemix.net/docs/` documentation.

## How

- Replaced all deprecated links in library with the appropriate Bluemix doc links
- Replaced `Cloudant for developers` with `Cloudant Learning Center` link
- Changed wording in endpoint access link from 'documentation' to 'section'

## Testing

No new tests.
Tested and verified all new links on local Sphinx build.

## Issues

fixes #333 