### PR TITLE
[WIP] 337 fix creating replication with source and target strings

### DIFF
--- a/src/cloudant/replicator.py
+++ b/src/cloudant/replicator.py
@@ -69,6 +69,10 @@ class Replicator(object):
         :returns: Replication document as a Document instance
         """
 
+        # WIP: Handle 'repl_id' when 'source' and 'target' parameters exist
+        if not repl_id and source_db and isinstance(source_db, str):
+            repl_id = source_db
+
         data = dict(
             _id=repl_id if repl_id else str(uuid.uuid4()),
             **kwargs
@@ -93,7 +97,8 @@ class Replicator(object):
                 )
 
         if not data.get('user_ctx'):
-            if not target_db.admin_party:
+            if (target_db and not target_db.admin_party or
+                    self.database.creds and self.database.creds.get('user_ctx')):
                 data['user_ctx'] = self.database.creds['user_ctx']
 
         return self.database.create_document(data, throw_on_exists=True)

--- a/tests/unit/replicator_tests.py
+++ b/tests/unit/replicator_tests.py
@@ -155,7 +155,11 @@ class ReplicatorTests(UnitTestDbBase):
 
     def test_replication_with_generated_id(self):
         clone = Replicator(self.client)
-        clone.create_replication(self.db, self.target_db)
+        repl_id = clone.create_replication(
+            self.db,
+            self.target_db
+        )
+        repl_id.delete()
 
     @skip_if_not_cookie_auth
     @flaky(max_runs=3)


### PR DESCRIPTION
## What

- Fix the `null` error that occurs when creating a replicator with source and target strings.  
- Properly handle `repl_id` when only `source` and `target` parameters exist
- Decide on how `source` and `target` dictionaries should be passed in (see below)

## How

- Added [null check](https://github.com/cloudant/python-cloudant/compare/337-create-replication-with-src-trg-strings?expand=1#diff-941fe21666606963577a17ff664cdfe5R100) on `target_db` before calling `.admin_party`.  Also set 'user_ctx' if the database object's 'creds' exists.
- WIP: improve the logic to set `repl_id`.  When `source` and `target` parameters exist, the passed in `repl_id` value is set in `source_db`.  I've added logic to set `repl_id` = `source_db` if `source` and `target` exist and `source_db` is a string.

## Testing

- Added unit tests to verify that source and target string parameters work as expected
- If source or target url do not contain credentials, replication_state should equal `error` since the user is unauthorized

## Issues

fixes #337

~~TODO: Remove replicator doc that currently exists after tests finish.~~

TODO: How should `source` and `target` dictionaries be passed in?
If this below is the expected way, then this will also require fixing as it's not properly handled:
```
replication_doc = Replicator(client).create_replication(
    {'source': 'src_db', 'target': 'tgt_db'}
)
```