### PR TITLE
Removed source and target optional parameters from replicator API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,6 @@
 2.8.0 (Unreleased)
 ==================
+- [REMOVED] Removed broken source and target parameters that constantly threw ``AttributeError`` when creating a replication document.
 
 2.7.0 (2017-10-31)
 ==================

--- a/src/cloudant/replicator.py
+++ b/src/cloudant/replicator.py
@@ -50,14 +50,6 @@ class Replicator(object):
             ``CouchDatabase`` or ``CloudantDatabase`` instance.
         :param str repl_id: Optional replication id.  Generated internally if
             not explicitly set.
-        :param source: Optional ``str`` or ``dict`` representing the source
-            database, along with authentication info, if any.  Composed
-            internally if not explicitly set and not in CouchDB Admin Party
-            mode.
-        :param target: Optional ``str`` or ``dict`` representing the
-            target database, possibly including authentication info.  Composed
-            internally if not explicitly set and not in CouchDB Admin Party
-            mode.
         :param dict user_ctx: Optional user to act as.  Composed internally
             if not explicitly set and not in CouchDB Admin Party
             mode.
@@ -74,26 +66,25 @@ class Replicator(object):
             **kwargs
         )
 
-        if not data.get('source'):
-            if source_db is None:
-                raise CloudantReplicatorException(101)
-            data['source'] = {'url': source_db.database_url}
-            if not source_db.admin_party:
-                data['source'].update(
-                    {'headers': {'Authorization': source_db.creds['basic_auth']}}
-                )
+        if source_db is None:
+            raise CloudantReplicatorException(101)
+        data['source'] = {'url': source_db.database_url}
+        if not source_db.admin_party:
+            data['source'].update(
+                {'headers': {'Authorization': source_db.creds['basic_auth']}}
+            )
 
-        if not data.get('target'):
-            if target_db is None:
-                raise CloudantReplicatorException(102)
-            data['target'] = {'url': target_db.database_url}
-            if not target_db.admin_party:
-                data['target'].update(
-                    {'headers': {'Authorization': target_db.creds['basic_auth']}}
-                )
+        if target_db is None:
+            raise CloudantReplicatorException(102)
+        data['target'] = {'url': target_db.database_url}
+        if not target_db.admin_party:
+            data['target'].update(
+                {'headers': {'Authorization': target_db.creds['basic_auth']}}
+            )
 
         if not data.get('user_ctx'):
-            if not target_db.admin_party:
+            if (target_db and not target_db.admin_party or
+                    self.database.creds):
                 data['user_ctx'] = self.database.creds['user_ctx']
 
         return self.database.create_document(data, throw_on_exists=True)

--- a/tests/integration/replicator_test.py
+++ b/tests/integration/replicator_test.py
@@ -190,57 +190,6 @@ class ReplicatorTest(unittest.TestCase):
             self.assertTrue(len(updates) > 0)
             self.assertEqual(updates[-1]['_replication_state'], 'completed')
 
-    @unittest.skip("Doesn't reliably get into error state on couch side.")
-    def test_follow_replication_with_errors(self):
-        """
-        _test_follow_replication_with_errors_
-
-        Test to make sure that we exit the follow loop when we submit
-        a bad replication.
-
-        """
-        dbsource = unicode_("test_follow_replication_source_error_{}".format(
-            unicode_(uuid.uuid4())))
-        dbtarget = unicode_("test_follow_replication_target_error_{}".format(
-            unicode_(uuid.uuid4())))
-
-        self.dbs = [dbsource, dbtarget]
-
-        with cloudant(self.user, self.passwd, account=self.user) as c:
-            dbs = c.create_database(dbsource)
-            dbt = c.create_database(dbtarget)
-
-            doc1 = dbs.create_document(
-                {"_id": "doc1", "testing": "document 1"}
-            )
-            doc2 = dbs.create_document(
-                {"_id": "doc2", "testing": "document 1"}
-            )
-            doc3 = dbs.create_document(
-                {"_id": "doc3", "testing": "document 1"}
-            )
-
-            replicator = Replicator(c)
-            repl_id = unicode_("test_follow_replication_{}".format(
-                unicode_(uuid.uuid4())))
-            self.replication_ids.append(repl_id)
-
-            ret = replicator.create_replication(
-                source_db=dbs,
-                target_db=dbt,
-                # Deliberately override these good params with bad params
-                source=dbsource + "foo",
-                target=dbtarget + "foo",
-                repl_id=repl_id,
-                continuous=False,
-            )
-            updates = [
-                update for update in replicator.follow_replication(repl_id)
-            ]
-            self.assertTrue(len(updates) > 0)
-            self.assertEqual(updates[-1]['_replication_state'], 'error')
-
-
     def test_replication_state(self):
         """
         _test_replication_state_

--- a/tests/unit/replicator_tests.py
+++ b/tests/unit/replicator_tests.py
@@ -155,7 +155,11 @@ class ReplicatorTests(UnitTestDbBase):
 
     def test_replication_with_generated_id(self):
         clone = Replicator(self.client)
-        clone.create_replication(self.db, self.target_db)
+        repl_id = clone.create_replication(
+            self.db,
+            self.target_db
+        )
+        self.replication_ids.append(repl_id['_id'])
 
     @skip_if_not_cookie_auth
     @flaky(max_runs=3)


### PR DESCRIPTION
## What

Removed source/target optional parameters from `create_replication`.

## How

- Remove constructor parameters and docstring

## Testing

No new tests.
Removed reference of `source/target` parameters in `integration/replicator_test.py`.
Deleted replication document in `test_replication_with_generated_id` after test completed.

## Issues

fixes #341 