### PR TITLE
343 fix pylint 1.8.1

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -66,7 +66,7 @@ confidence=
 # Disable "redefined-variable-type" refactor warning messages
 # Disable "too-many-..." and "too-few-..." refactor warning messages
 # Disable "locally-disabled" message
-disable=R0204,R0901,R0902,R0903,R0904,R0913,R0914,R0915,locally-disabled
+disable=R0204,R0901,R0902,R0903,R0904,R0913,R0914,R0915,locally-disabled,keyword-arg-before-vararg
 
 
 [REPORTS]

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2015 IBM. All rights reserved.
+# Copyright (C) 2015, 2018 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -660,7 +660,7 @@ class CouchDatabase(dict):
                     super(CouchDatabase, self).__setitem__(doc['id'], document)
                     yield document
 
-            raise StopIteration
+            return
 
     def bulk_docs(self, docs):
         """

--- a/src/cloudant/document.py
+++ b/src/cloudant/document.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2015 IBM. All rights reserved.
+# Copyright (C) 2015, 2018 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -257,7 +257,7 @@ class Document(dict):
             self.save()
         except requests.HTTPError as ex:
             if tries < max_tries and ex.response.status_code == 409:
-                return self._update_field(
+                self._update_field(
                     action, field, value, max_tries, tries=tries+1)
             raise
 

--- a/src/cloudant/replicator.py
+++ b/src/cloudant/replicator.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2015 IBM. All rights reserved.
+# Copyright (C) 2015, 2018 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -158,7 +158,7 @@ class Replicator(object):
             if repl_doc:
                 yield repl_doc
             if state is not None and state in ['error', 'completed']:
-                raise StopIteration
+                return
 
             # Now listen on changes feed for the state
             for change in self.database.changes():
@@ -167,7 +167,7 @@ class Replicator(object):
                     if repl_doc is not None:
                         yield repl_doc
                     if state is not None and state in ['error', 'completed']:
-                        raise StopIteration
+                        return
 
     def stop_replication(self, repl_id):
         """

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,5 @@
 mock==1.3.0
 nose
 sphinx
-pylint==1.7.4
-astroid==1.5.3
+pylint
 flaky


### PR DESCRIPTION
## What

Fix pylint issues and have code rated 10/10.

## How

- Disabled ‘keyword-arg-before-vararg’ pylint warning
- removed return statement to fix pylint ’inconsistent-return-statements’

## Testing

CI passing, lint version changes only.

## Issues

fixes #343 

**For discussion:** I’ve disabled warnings for ‘keyword-arg-before-vararg’.  If we want to enable this warning, it would require re-working the `error` module and making changes to all exception calls.