### PR TITLE
Support '/_search_disk_size' search endpoint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
 # 2.8.0 (Unreleased)
-
+- [NEW] Added support for `/_search_disk_size` endpoint which retrieves disk size information for a specific search index.
 - [FIXED] Updated default IBM Cloud Identity and Access Management token URL.
 - [REMOVED] Removed broken source and target parameters that constantly threw `AttributeError` when creating a replication document.
 

--- a/src/cloudant/design_document.py
+++ b/src/cloudant/design_document.py
@@ -699,3 +699,15 @@ class DesignDocument(Document):
             '/'.join([self.document_url, '_search_info', search_index]))
         ddoc_search_info.raise_for_status()
         return ddoc_search_info.json()
+
+    def search_disk_size(self, search_index):
+        """
+        Retrieves disk size information about a specified search index within
+        the design document, returns dictionary
+
+        GET databasename/_design/{ddoc}/_search_disk_size/{search_index}
+        """
+        ddoc_search_disk_size = self.r_session.get(
+            '/'.join([self.document_url, '_search_disk_size', search_index]))
+        ddoc_search_disk_size.raise_for_status()
+        return ddoc_search_disk_size.json()


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/python-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/python-cloudant/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What
Support `/_search_disk_size` search endpoint.

## How
Added new method `DesignDocument.search_disk_size`.

 - Calls `GET databasename/_design/{ddoc}/_search_disk_size/{search_index}`.
 - Returns results as dictionary.
 - Raises `requests.exceptions.HTTPError` on bad status code.

## Testing
Includes additional unit test.

## Issues
Fixes #357.
