### PR TITLE
Support IAM authentication in replication documents

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 # Unreleased
 
-- [NEW] Moved `create_query_index` and other query related methods to `CouchDatabase` as the `_index`/`_find` API is available in CouchDB 2.x.
 - [NEW] Added functionality to test if a key is in a database as in `key in db`, overriding dict `__contains__` and checking in the remote database.
+- [NEW] Moved `create_query_index` and other query related methods to `CouchDatabase` as the `_index`/`_find` API is available in CouchDB 2.x.
+- [NEW] Support IAM authentication in replication documents.
 - [IMPROVED] Added support for IAM API key in `cloudant_bluemix` method.
 - [IMPROVED] Updated Travis CI and unit tests to run against CouchDB 2.1.1.
 

--- a/src/cloudant/_client_session.py
+++ b/src/cloudant/_client_session.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2015, 2017 IBM Corp. All rights reserved.
+# Copyright (c) 2015, 2018 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -194,6 +194,15 @@ class IAMSession(ClientSession):
         self._api_key = api_key
         self._token_url = os.environ.get(
             'IAM_TOKEN_URL', 'https://iam.bluemix.net/identity/token')
+
+    @property
+    def get_api_key(self):
+        """
+        Get IAM API key.
+
+        :return: IAM API key.
+        """
+        return self._api_key
 
     def login(self):
         """

--- a/src/cloudant/client.py
+++ b/src/cloudant/client.py
@@ -98,6 +98,15 @@ class CouchDB(dict):
         if connect_to_couch and self._DATABASE_CLASS == CouchDatabase:
             self.connect()
 
+    @property
+    def is_iam_authenticated(self):
+        """
+        Show if a client has authenticated using an IAM API key.
+
+        :return: True if client is IAM authenticated. False otherwise.
+        """
+        return self._use_iam
+
     def connect(self):
         """
         Starts up an authentication session for the client using cookie
@@ -107,10 +116,12 @@ class CouchDB(dict):
             self.session_logout()
 
         if self.admin_party:
+            self._use_iam = False
             self.r_session = ClientSession(
                 timeout=self._timeout
             )
         elif self._use_basic_auth:
+            self._use_iam = False
             self.r_session = BasicSession(
                 self._user,
                 self._auth_token,

--- a/src/cloudant/replicator.py
+++ b/src/cloudant/replicator.py
@@ -51,8 +51,7 @@ class Replicator(object):
         :param str repl_id: Optional replication id.  Generated internally if
             not explicitly set.
         :param dict user_ctx: Optional user to act as.  Composed internally
-            if not explicitly set and not in CouchDB Admin Party
-            mode.
+            if not explicitly set.
         :param bool create_target: Specifies whether or not to
             create the target, if it does not already exist.
         :param bool continuous: If set to True then the replication will be
@@ -101,11 +100,9 @@ class Replicator(object):
 
         # add user context delegation
 
-        if not data.get('user_ctx'):
-            if target_db and target_db.admin_party:
-                pass  # noop - not required for admin party mode
-            elif self.database.creds and self.database.creds.get('user_ctx'):
-                data['user_ctx'] = self.database.creds['user_ctx']
+        if not data.get('user_ctx') and self.database.creds and \
+            self.database.creds.get('user_ctx'):
+            data['user_ctx'] = self.database.creds['user_ctx']
 
         return self.database.create_document(data, throw_on_exists=True)
 

--- a/tests/unit/replicator_mock_tests.py
+++ b/tests/unit/replicator_mock_tests.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+# Copyright (C) 2018 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+_replicator_mock_tests_
+
+replicator module - Mock unit tests for the Replicator class
+"""
+
+import mock
+import unittest
+
+from cloudant.database import CouchDatabase
+from cloudant.replicator import Replicator
+
+from tests.unit.iam_auth_tests import MOCK_API_KEY
+
+
+class ReplicatorDocumentValidationMockTests(unittest.TestCase):
+    """
+    Replicator document validation tests
+    """
+
+    def setUp(self):
+        self.repl_id = 'rep_test'
+
+        self.server_url = 'http://localhost:5984'
+        self.user_ctx = {
+            'name': 'foo',
+            'roles': ['erlanger', 'researcher']
+        }
+
+        self.source_db = 'source_db'
+        self.target_db = 'target_db'
+
+    def setUpClientMocks(self, admin_party=False, iam_api_key=None):
+        m_client = mock.MagicMock()
+        type(m_client).server_url = mock.PropertyMock(
+            return_value=self.server_url)
+
+        type(m_client).admin_party = mock.PropertyMock(
+            return_value=admin_party)
+
+        iam_authenticated = False
+
+        if iam_api_key is not None:
+            iam_authenticated = True
+
+            m_session = mock.MagicMock()
+            type(m_session).get_api_key = mock.PropertyMock(
+                return_value=iam_api_key)
+
+            type(m_client).r_session = mock.PropertyMock(
+                return_value=m_session)
+
+        type(m_client).is_iam_authenticated = mock.PropertyMock(
+            return_value=iam_authenticated)
+
+        return m_client
+
+    def test_using_admin_party_source_and_target(self):
+        m_admin_party_client = self.setUpClientMocks(admin_party=True)
+
+        m_replicator = mock.MagicMock()
+        type(m_replicator).creds = mock.PropertyMock(return_value=None)
+        m_admin_party_client.__getitem__.return_value = m_replicator
+
+        # create source/target databases
+        src = CouchDatabase(m_admin_party_client, self.source_db)
+        tgt = CouchDatabase(m_admin_party_client, self.target_db)
+
+        # trigger replication
+        rep = Replicator(m_admin_party_client)
+        rep.create_replication(src, tgt, repl_id=self.repl_id)
+
+        kcall = m_replicator.create_document.call_args_list
+        self.assertEquals(len(kcall), 1)
+        args, kwargs = kcall[0]
+        self.assertEquals(len(args), 1)
+
+        expected_doc = {
+            '_id': self.repl_id,
+            'source': {'url': '/'.join((self.server_url, self.source_db))},
+            'target': {'url': '/'.join((self.server_url, self.target_db))}
+        }
+
+        self.assertDictEqual(args[0], expected_doc)
+        self.assertTrue(kwargs['throw_on_exists'])
+
+    def test_using_basic_auth_source_and_target(self):
+        test_basic_auth_header = 'abc'
+
+        m_basic_auth_client = self.setUpClientMocks()
+
+        m_replicator = mock.MagicMock()
+        m_basic_auth_client.__getitem__.return_value = m_replicator
+        m_basic_auth_client.basic_auth_str.return_value = test_basic_auth_header
+
+        # create source/target databases
+        src = CouchDatabase(m_basic_auth_client, self.source_db)
+        tgt = CouchDatabase(m_basic_auth_client, self.target_db)
+
+        # trigger replication
+        rep = Replicator(m_basic_auth_client)
+        rep.create_replication(
+            src, tgt, repl_id=self.repl_id, user_ctx=self.user_ctx)
+
+        kcall = m_replicator.create_document.call_args_list
+        self.assertEquals(len(kcall), 1)
+        args, kwargs = kcall[0]
+        self.assertEquals(len(args), 1)
+
+        expected_doc = {
+            '_id': self.repl_id,
+            'user_ctx': self.user_ctx,
+            'source': {
+                'headers': {'Authorization': test_basic_auth_header},
+                'url': '/'.join((self.server_url, self.source_db))
+            },
+            'target': {
+                'headers': {'Authorization': test_basic_auth_header},
+                'url': '/'.join((self.server_url, self.target_db))
+            }
+        }
+
+        self.assertDictEqual(args[0], expected_doc)
+        self.assertTrue(kwargs['throw_on_exists'])
+
+    def test_using_iam_auth_source_and_target(self):
+        m_iam_auth_client = self.setUpClientMocks(iam_api_key=MOCK_API_KEY)
+
+        m_replicator = mock.MagicMock()
+        m_iam_auth_client.__getitem__.return_value = m_replicator
+
+        # create source/target databases
+        src = CouchDatabase(m_iam_auth_client, self.source_db)
+        tgt = CouchDatabase(m_iam_auth_client, self.target_db)
+
+        # trigger replication
+        rep = Replicator(m_iam_auth_client)
+        rep.create_replication(
+            src, tgt, repl_id=self.repl_id, user_ctx=self.user_ctx)
+
+        kcall = m_replicator.create_document.call_args_list
+        self.assertEquals(len(kcall), 1)
+        args, kwargs = kcall[0]
+        self.assertEquals(len(args), 1)
+
+        expected_doc = {
+            '_id': self.repl_id,
+            'user_ctx': self.user_ctx,
+            'source': {
+                'auth': {'iam': {'api_key': MOCK_API_KEY}},
+                'url': '/'.join((self.server_url, self.source_db))
+            },
+            'target': {
+                'auth': {'iam': {'api_key': MOCK_API_KEY}},
+                'url': '/'.join((self.server_url, self.target_db))
+            }
+        }
+
+        self.assertDictEqual(args[0], expected_doc)
+        self.assertTrue(kwargs['throw_on_exists'])

--- a/tests/unit/replicator_tests.py
+++ b/tests/unit/replicator_tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2015, 2016, 2017 IBM Corp. All rights reserved.
+# Copyright (c) 2015, 2018 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -161,7 +161,6 @@ class ReplicatorTests(UnitTestDbBase):
         )
         self.replication_ids.append(repl_id['_id'])
 
-    @skip_if_not_cookie_auth
     @flaky(max_runs=3)
     def test_create_replication(self):
         """
@@ -180,7 +179,7 @@ class ReplicatorTests(UnitTestDbBase):
         # Test that the replication document was created
         expected_keys = ['_id', '_rev', 'source', 'target', 'user_ctx']
         # If Admin Party mode then user_ctx will not be in the key list
-        if self.client.admin_party:
+        if self.client.admin_party or self.client.is_iam_authenticated:
             expected_keys.pop()
         self.assertTrue(all(x in list(repl_doc.keys()) for x in expected_keys))
         self.assertEqual(repl_doc['_id'], repl_id)
@@ -238,7 +237,7 @@ class ReplicatorTests(UnitTestDbBase):
         # Test that the replication document was created
         expected_keys = ['_id', '_rev', 'source', 'target', 'user_ctx']
         # If Admin Party mode then user_ctx will not be in the key list
-        if self.client.admin_party:
+        if self.client.admin_party or self.client.is_iam_authenticated:
             expected_keys.pop()
         self.assertTrue(all(x in list(repl_doc.keys()) for x in expected_keys))
         self.assertEqual(repl_doc['_id'], repl_id)
@@ -305,7 +304,6 @@ class ReplicatorTests(UnitTestDbBase):
         match = [repl_id for repl_id in all_repl_ids if repl_id in repl_ids]
         self.assertEqual(set(repl_ids), set(match))
 
-    @skip_if_not_cookie_auth
     def test_retrieve_replication_state(self):
         """
         Test that the replication state can be retrieved for a replication
@@ -347,7 +345,6 @@ class ReplicatorTests(UnitTestDbBase):
             )
             self.assertIsNone(repl_state)
 
-    @skip_if_not_cookie_auth
     def test_stop_replication(self):
         """
         Test that a replication can be stopped.
@@ -383,7 +380,6 @@ class ReplicatorTests(UnitTestDbBase):
                 'Replication with id {} not found.'.format(repl_id)
             )
 
-    @skip_if_not_cookie_auth
     def test_follow_replication(self):
         """
         Test that follow_replication(...) properly iterates updated


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/python-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/python-cloudant/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What
Support IAM authenticated databases when replicating.

## How
Expose the IAM API key via the client session and inject into the replication document where applicable. 

## Testing
Includes additional mock unit tests.

## Issues
Fixes #354.