### PR TITLE
Add special handling for auto_renew with _users DB

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 2.8.2 (2018-04-05)
+
+- [FIXED] Added special handling for requesting the `_users` database, as it can send `404` errors when a session expires.
+
 # 2.8.1 (2018-02-16)
 
 - [FIXED] Installation failures of 2.8.0 caused by missing VERSION file in distribution.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,5 @@
 # Unreleased
 
-# 2.8.2 (2018-04-05)
-
 - [FIXED] Added special handling for requesting the `_users` database, as it can send `404` errors when a session expires.
 
 # 2.8.1 (2018-02-16)

--- a/src/cloudant/_client_session.py
+++ b/src/cloudant/_client_session.py
@@ -104,8 +104,9 @@ class ClientSession(Session):
 
     def is_users_db_url(self, url):
         """
-        Check if a requested url is for the users database, to be used with auto_renew=True
-        as this database could return a 404 error while the problem could actually be an expired session.
+        Check if a requested url is for the users database, to be used
+        with auto_renew=True as this database could return a 404 error
+        while the problem could actually be an expired session.
         Reference: http://docs.couchdb.org/en/2.1.1/intro/security.html#users-public-information
 
         :param str url: Requested URL to check.

--- a/src/cloudant/_client_session.py
+++ b/src/cloudant/_client_session.py
@@ -113,7 +113,7 @@ class ClientSession(Session):
         server_url_parts = self._session_url.split('/')[:-1]  # Without the session path
         server_url = '/'.join(server_url_parts)
         users_db_url = url_join(server_url, '_users')
-        return url in users_db_url
+        return users_db_url in url
 
 
 class BasicSession(ClientSession):

--- a/src/cloudant/_client_session.py
+++ b/src/cloudant/_client_session.py
@@ -102,6 +102,19 @@ class ClientSession(Session):
         """
         pass
 
+    def is_users_db_url(self, url):
+        """
+        Check if a requested url is for the users database, to be used with auto_renew=True
+        as this database could return a 404 error while the problem could actually be an expired session.
+        Reference: http://docs.couchdb.org/en/2.1.1/intro/security.html#users-public-information
+
+        :param str url: Requested URL to check.
+        """
+        server_url_parts = self._session_url.split('/')[:-1]  # Without the session path
+        server_url = '/'.join(server_url_parts)
+        users_db_url = url_join(server_url, '_users')
+        return url in users_db_url
+
 
 class BasicSession(ClientSession):
     """
@@ -174,7 +187,12 @@ class CookieSession(ClientSession):
             resp.status_code == 401
         ))
 
-        if is_expired:
+        can_be_user_db_expired = (
+            resp.status_code == 404 and
+            self.is_users_db_url(url)
+        )
+
+        if is_expired or can_be_user_db_expired:
             self.login()
             resp = super(CookieSession, self).request(method, url, **kwargs)
 


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/python-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/python-cloudant/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What

As the [ `_users` database could return a 404 error while the problem is actually about session expiration](http://docs.couchdb.org/en/2.1.1/intro/security.html#users-public-information), it requires special handling when using `auto_renew=True`. 

The current implementation only checks for `403` and `401`. And errors `404` should be taken into account only when dealing with the `_users` database.

## How

* Add `is_users_db_url` method to `ClientSession` class to check if a requested URL is for the `_users` DB.
* Modify the method `request` of the subclass `CookieSession` to check if the error is a `404` and if the request is for the `_users` DB.

## Testing

Currently, when I run the tests from the `master` branch, there are several tests that are not passing. That's before any of my modifications.

With respect to this PR, as this is a very specific behavior of the `_users` database in CouchDB, I'm not sure if you want me to add all the specific code with all the boilerplate for that.

## Issues

I found the issue while developing my application, investigated and solved it right away. I didn't create an issue for it.
