### PR TITLE
Query index in couchdb and support dict syntax: _id in database

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [NEW] Moved `create_query_index` and other query related methods to `CouchDatabase` as the `_index`/`_find` API is available in CouchDB 2.x.
+- [NEW] Added functionality to test if a key is in a database as in `key in db`, overriding dict `__contains__` and checking in the remote database.
 - [IMPROVED] Added support for IAM API key in `cloudant_bluemix` method.
 - [IMPROVED] Updated Travis CI and unit tests to run against CouchDB 2.1.1.
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -270,6 +270,19 @@ classes are sub-classes of ``dict``, this is accomplished through standard
     # Display the document
     print(my_document)
 
+Checking if a document exists
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can check if a document exists in a database the same way you would check
+if a ``dict`` has a key-value pair by key.
+
+.. code-block:: python
+
+    doc_exists = 'julia30' in my_database
+
+    if doc_exists:
+        print('document with _id julia30 exists')
+
 Retrieve all documents
 ^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/python-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/python-cloudant/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What

I added 2 things, I needed both of them at the same time so I ended up doing a single PR instead of 2, sorry for that.

* Move  `create_query_index` from `CloudantDatabase` to `CouchDatabase` as the JSON indexes for Mango queries are now part of CouchDB.
* Add a feature to allow checking if a document exists in a DB without having to resort to try-catch blocks, using standard `dict` syntax:

```Python
_id = 'julia30'
doc_exists = _id in my_database

if doc_exists:
    print('doc with _id julia30 exists in DB')
```

## How

*  `create_query_index`: move the method from one class to the other. Move the tests from Cloudant specific to CouchDB.
* Add a `dict` override for `__contains__` that checks in the remote DB if the document exists.

## Testing

Create a `CouchDatabase` object and call the `create_query_index` the same way you would for a Cloudant database.

## Issues

I didn't create an issue before solving it.
