### PR TITLE
Updated Travis CI and unit tests to run against CouchDB 2.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+
 language: python
 
 python:
@@ -9,9 +11,18 @@ env:
   - ADMIN_PARTY=false
 
 services:
-  - couchdb
+  - docker
+
+before_install:
+  - docker pull apache/couchdb:2.1.1
+  - docker run -d -it -p 5984:5984 apache/couchdb:2.1.1 --with-admin-party-please --with-haproxy
 
 install: "pip install -r requirements.txt && pip install -r test-requirements.txt"
+
+before_script:
+    - curl -X PUT http://localhost:5984/_users
+    - curl -X PUT http://localhost:5984/_replicator
+
 # command to run tests
 script:
     - pylint ./src/cloudant

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [IMPROVED] Updated Travis CI and unit tests to run against CouchDB 2.1.1.
+
 # 2.8.1 (2018-02-16)
 
 - [FIXED] Installation failures of 2.8.0 caused by missing VERSION file in distribution.

--- a/tests/unit/changes_tests.py
+++ b/tests/unit/changes_tests.py
@@ -100,12 +100,7 @@ class ChangesTests(UnitTestDbBase):
             self.assertIsInstance(raw_line, BYTETYPE)
             raw_content.append(raw_line)
         changes = json.loads(''.join([unicode_(x) for x in raw_content]))
-        if self.cloudant_test:
-            self.assertSetEqual(
-                set(changes.keys()), set(['results', 'last_seq', 'pending']))
-        else:
-            self.assertSetEqual(
-                set(changes.keys()), set(['results', 'last_seq']))
+        self.assertSetEqual(set(changes.keys()), set(['results', 'last_seq', 'pending']))
         results = list()
         for result in changes['results']:
             self.assertSetEqual(set(result.keys()), set(['seq', 'changes', 'id']))
@@ -223,12 +218,11 @@ class ChangesTests(UnitTestDbBase):
 
     def test_get_feed_descending(self):
         """
-        Test getting content back for a descending feed.  When testing with
-        Cloudant the sequence identifier is in the form of 
-        <number prefix>-<random char seq>.  Often times the number prefix sorts
-        as expected when using descending but sometimes the number prefix is
-        repeated.  In these cases the check is to see if the following random
-        character sequence suffix is longer than its predecessor.
+        Test getting content back for a descending feed.  When testing, the sequence
+        identifier is in the form of <number prefix>-<random char seq>.  Often times
+        the number prefix sorts as expected when using descending but sometimes the
+        number prefix is repeated.  In these cases the check is to see if the following
+        random character sequence suffix is longer than its predecessor.
         """
         self.populate_db_with_documents(50)
         feed = Feed(self.db, descending=True)
@@ -236,16 +230,13 @@ class ChangesTests(UnitTestDbBase):
         last_seq = None
         for change in feed:
             if last_seq:
-                if self.cloudant_test:
-                    current = int(change['seq'][0: change['seq'].find('-')])
-                    last = int(last_seq[0:last_seq.find('-')])
-                    try:
-                        self.assertTrue(current < last)
-                    except AssertionError:
-                        self.assertEqual(current, last)
-                        self.assertTrue(len(change['seq']) > len(last_seq))
-                else:
-                    self.assertTrue(change['seq'] < last_seq)
+                current = int(change['seq'][0: change['seq'].find('-')])
+                last = int(last_seq[0:last_seq.find('-')])
+                try:
+                    self.assertTrue(current < last)
+                except AssertionError:
+                    self.assertEqual(current, last)
+                    self.assertTrue(len(change['seq']) > len(last_seq))
             seq_list.append(change['seq'])
             last_seq = change['seq']
         self.assertEqual(len(seq_list), 50)
@@ -303,8 +294,6 @@ class ChangesTests(UnitTestDbBase):
         changes = list()
         for change in feed:
             self.assertSetEqual(set(change.keys()), set(['seq', 'changes', 'id']))
-            if not self.cloudant_test:
-                self.assertEqual(len(change['changes']), 2)
             changes.append(change)
         expected = set(['julia000', 'julia001', 'julia002'])
         self.assertSetEqual(set([x['id'] for x in changes]), expected)

--- a/tests/unit/view_tests.py
+++ b/tests/unit/view_tests.py
@@ -309,19 +309,13 @@ class ViewTests(UnitTestDbBase):
             'view001',
             'This is not valid Javascript'
         )
-        ddoc.save()
-        # Verify that the ddoc and view were saved remotely 
-        # along with the invalid Javascript
-        del ddoc
-        ddoc = DesignDocument(self.db, 'ddoc001')
-        ddoc.fetch()
-        view = ddoc.get_view('view001')
-        self.assertEqual(view.map, 'This is not valid Javascript')
-        try:
-            for row in view.result:
-                self.fail('Above statement should raise an Exception')
-        except requests.HTTPError as err:
-            self.assertEqual(err.response.status_code, 500)
+        with self.assertRaises(requests.HTTPError) as cm:
+            ddoc.save()
+        err = cm.exception
+        self.assertTrue(str(err).startswith(
+            '400 Client Error: Bad Request compilation_error Compilation of the map function '
+            'in the \'view001\' view failed: Expression does not eval to a function.'
+        ))
 
     def test_custom_result_context_manager(self):
         """


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/python-cloudant/blob/master/DCO1.1.txt)
- [ ] You have added tests for any code changes -- PR is for updating existing tests
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/python-cloudant/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What

Updated Travis CI to use the CouchDB Docker image and updated the existing tests to pass against the latest CouchDB version.

## How

- Build CouchDB docker image in Travis
- Updated CouchDB setup to retrieve node name from `_membership` when admin user is created (ADMIN_PARTY=false)
- Added functionality for setting up and tearing down` _global_changes` database as it's required by the `_db_updates` unit tests
- Updated existing `DbUpdatesTestsBase.create_dbs` function to verify that all created test databases are listed in the `_db_updates` feed
- Additional fixes and updates to db_updates, view, and changes unit tests
## Testing

Fixed existing tests to pass against CouchDB 2.1.1.
No new tests.

## Issues
