### PR TITLE
376 skip tests when running with IAM auth

### DIFF
--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -38,7 +38,7 @@ from cloudant.index import Index, TextIndex, SpecialIndex
 from cloudant.feed import Feed, InfiniteFeed
 from tests.unit._test_util import LONG_NUMBER
 
-from .unit_t_db_base import skip_if_not_cookie_auth, UnitTestDbBase
+from .unit_t_db_base import skip_if_not_cookie_auth, UnitTestDbBase, skip_if_iam
 from .. import unicode_
 
 class CloudantDatabaseExceptionTests(unittest.TestCase):
@@ -863,7 +863,7 @@ class DatabaseTests(UnitTestDbBase):
             resp,
             'Hello from doc001!'
         )
-
+    @skip_if_iam
     def test_create_doc_with_update_handler(self):
         """
         Test update_handler_result executes an update handler function
@@ -884,6 +884,7 @@ class DatabaseTests(UnitTestDbBase):
             'Created new doc: {"message":"hello","_id":"testDoc"}'
         )
 
+    @skip_if_iam
     def test_update_doc_with_update_handler(self):
         """
         Test update_handler_result executes an update handler function

--- a/tests/unit/design_document_tests.py
+++ b/tests/unit/design_document_tests.py
@@ -32,7 +32,7 @@ from cloudant.design_document import DesignDocument
 from cloudant.view import View, QueryIndexView
 from cloudant.error import CloudantArgumentError, CloudantDesignDocumentException
 
-from .unit_t_db_base import UnitTestDbBase
+from .unit_t_db_base import UnitTestDbBase, skip_if_iam
 
 class CloudantDesignDocumentExceptionTests(unittest.TestCase):
     """
@@ -1252,6 +1252,7 @@ class DesignDocumentTests(UnitTestDbBase):
                 '{"store": true}); }\n}'}
         )
 
+    @skip_if_iam
     def test_rewrite_rule(self):
         """
         Test that design document URL is rewritten to the expected test document.

--- a/tests/unit/unit_t_db_base.py
+++ b/tests/unit/unit_t_db_base.py
@@ -78,6 +78,13 @@ def skip_if_not_cookie_auth(f):
     return wrapper
 
 
+def skip_if_iam(f):
+    def wrapper(*args):
+        if os.environ.get('IAM_API_KEY'):
+            raise unittest.SkipTest('Test only supports non-IAM authentication')
+        return f(*args)
+    return wrapper
+
 class UnitTestDbBase(unittest.TestCase):
     """
     The base class for all unit tests targeting a database


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/python-cloudant/blob/master/DCO1.1.txt)
- [ ] You have added tests for any code changes
- [ ] You have updated the [CHANGES.md](https://github.com/cloudant/python-cloudant/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What

Added `skip_if_iam` decorator to skip tests when running with IAM auth.

## Testing

No new tests.
Skips tests when IAM is enabled:
```
tests.unit.database_tests.DatabaseTests.test_create_doc_with_update_handler
tests.unit.database_tests.DatabaseTests.test_update_doc_with_update_handler
tests.unit.design_document_tests.DesignDocumentTests.test_rewrite_rule
```

## Issues

fixes #376