### PR TITLE
Added support for IAM API key in cloudant_bluemix method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- [IMPROVED] Added support for IAM API key in `cloudant_bluemix` method.
 - [IMPROVED] Updated Travis CI and unit tests to run against CouchDB 2.1.1.
 
 # 2.8.1 (2018-02-16)

--- a/src/cloudant/__init__.py
+++ b/src/cloudant/__init__.py
@@ -116,6 +116,7 @@ def cloudant_bluemix(vcap_services, instance_name=None, service_name=None, **kwa
                 "cloudantNoSQLDB": [
                     {
                         "credentials": {
+                            "apikey": "some123api456key"
                             "username": "example",
                             "password": "xxxxxxx",
                             "host": "example.cloudant.com",

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2015, 2017 IBM Corp. All rights reserved.
+# Copyright (C) 2015, 2018 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ from collections import Sequence
 import json
 
 from ._2to3 import LONGTYPE, STRTYPE, NONETYPE, UNITYPE, iteritems_
-from .error import CloudantArgumentError, CloudantException
+from .error import CloudantArgumentError, CloudantException, CloudantClientException
 
 # Library Constants
 
@@ -306,9 +306,14 @@ class CloudFoundryService(object):
                     credentials = service['credentials']
                     self._host = credentials['host']
                     self._name = service.get('name')
-                    self._password = credentials['password']
                     self._port = credentials.get('port', 443)
                     self._username = credentials['username']
+                    if 'apikey' in credentials:
+                        self._iam_api_key = credentials['apikey']
+                    elif 'username' in credentials and 'password' in credentials:
+                        self._password = credentials['password']
+                    else:
+                        raise CloudantClientException(103)
                     break
             else:
                 raise CloudantException('Missing service in VCAP_SERVICES')
@@ -355,3 +360,8 @@ class CloudFoundryService(object):
     def username(self):
         """ Return service username. """
         return self._username
+
+    @property
+    def iam_api_key(self):
+        """ Return service IAM API key. """
+        return self._iam_api_key

--- a/src/cloudant/_messages.py
+++ b/src/cloudant/_messages.py
@@ -72,6 +72,7 @@ CLIENT = {
     100: 'A general Cloudant client exception was raised.',
     101: 'Value must be set to a Database object. Found type: {0}',
     102: 'You must provide a url or an account.',
+    103: 'Invalid service: IAM API key or username/password credentials are required.',
     404: 'Database {0} does not exist. Verify that the client is valid and try again.',
     412: 'Database {0} already exists.'
 }

--- a/tests/unit/unit_t_db_base.py
+++ b/tests/unit/unit_t_db_base.py
@@ -158,6 +158,7 @@ class UnitTestDbBase(unittest.TestCase):
         self.user = os.environ.get('DB_USER', None)
         self.pwd = os.environ.get('DB_PASSWORD', None)
         self.use_cookie_auth = True
+        self.iam_api_key = os.environ.get('IAM_API_KEY', None)
 
         if os.environ.get('RUN_CLOUDANT_TESTS') is None:
             self.url = os.environ['DB_URL']
@@ -198,12 +199,12 @@ class UnitTestDbBase(unittest.TestCase):
                     timeout=timeout,
                     use_basic_auth=True,
                 )
-            elif os.environ.get('IAM_API_KEY'):
+            elif self.iam_api_key:
                 self.use_cookie_auth = False
                 # construct Cloudant client (using IAM authentication)
                 self.client = Cloudant(
                     None,  # username is not required
-                    os.environ.get('IAM_API_KEY'),
+                    self.iam_api_key,
                     url=self.url,
                     x_cloudant_user=self.account,
                     connect=auto_connect,


### PR DESCRIPTION
 Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/python-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/python-cloudant/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What

Updated VCAP to support IAM API key and username/password credentials.

## How

- Updated CloudFoundryService to create a client session using IAM API key in VCAP
- Added iam_api_key property
- Handle cases when IAM or legacy credentials do not exist
- Added test cases to verify new IAM/creds case logic

## Testing

- Updated sample VCAP dictionaries in `CloudFoundryServiceTests`.
- Verify VCAP with IAM and legacy creds
- Assert new logic by creating VCAP client with either IAM or legacy creds
- If IAM key is missing and either/both username and password are missing, throw exception

## Issues