### PR TITLE
Updated Travis to run against CouchDB 1.7.1 and Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,20 @@ language: python
 
 python:
   - "2.7"
-  - "3.5"
+  - "3.6"
 
 env:
-  - ADMIN_PARTY=true
-  - ADMIN_PARTY=false
+  - ADMIN_PARTY=true COUCHDB_VERSION=2.1.1
+  - ADMIN_PARTY=false COUCHDB_VERSION=2.1.1
+  - ADMIN_PARTY=true COUCHDB_VERSION=1.7.1
+  - ADMIN_PARTY=false COUCHDB_VERSION=1.7.1
 
 services:
   - docker
 
 before_install:
-  - docker pull apache/couchdb:2.1.1
-  - docker run -d -it -p 5984:5984 apache/couchdb:2.1.1 --with-admin-party-please --with-haproxy
+  - docker pull apache/couchdb:$COUCHDB_VERSION
+  - docker run -d -p 5984:5984 apache/couchdb:$COUCHDB_VERSION
 
 install: "pip install -r requirements.txt && pip install -r test-requirements.txt"
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 - [NEW] Moved `create_query_index` and other query related methods to `CouchDatabase` as the `_index`/`_find` API is available in CouchDB 2.x.
 - [NEW] Support IAM authentication in replication documents.
 - [IMPROVED] Added support for IAM API key in `cloudant_bluemix` method.
-- [IMPROVED] Updated Travis CI and unit tests to run against CouchDB 2.1.1.
+- [IMPROVED] Verified library operation on Python 3.6.3.
 - [IMPROVED] Shortened length of client URLs by removing username and password.
 
 # 2.8.1 (2018-02-16)

--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2015 IBM. All rights reserved.
+# Copyright (C) 2015, 2018 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -968,6 +968,10 @@ class DatabaseTests(UnitTestDbBase):
         finally:
             self.client.connect()
 
+    @unittest.skipIf(not os.environ.get('RUN_CLOUDANT_TESTS') or
+                     (os.environ.get('COUCHDB_VERSION') and
+                     os.environ.get('COUCHDB_VERSION').startswith('1')),
+                     'Skipping test_create_json_index test')
     def test_create_json_index(self):
         """
         Ensure that a JSON index is created as expected.
@@ -991,6 +995,10 @@ class DatabaseTests(UnitTestDbBase):
         self.assertEquals(index['options']['def']['fields'], ['name', 'age'])
         self.assertEquals(index['reduce'], '_count')
 
+    @unittest.skipIf(not os.environ.get('RUN_CLOUDANT_TESTS') or
+                     (os.environ.get('COUCHDB_VERSION') and
+                      os.environ.get('COUCHDB_VERSION').startswith('1')),
+                     'Skipping test_create_json_index test')
     def test_delete_json_index(self):
         """
         Ensure that a JSON index is deleted as expected.

--- a/tests/unit/db_updates_tests.py
+++ b/tests/unit/db_updates_tests.py
@@ -28,6 +28,7 @@ from cloudant._2to3 import unicode_
 from .unit_t_db_base import UnitTestDbBase
 from .. import BYTETYPE
 
+
 class DbUpdatesTestsBase(UnitTestDbBase):
     """
     Common _db_updates tests methods
@@ -41,8 +42,9 @@ class DbUpdatesTestsBase(UnitTestDbBase):
         self.client.connect()
         self.db_names = list()
         self.new_dbs = list()
-        self.create_db_updates()
-        self.create_dbs()
+        if not self.is_couchdb_1x_version():
+            self.create_db_updates()
+            self.create_dbs()
 
     def tearDown(self):
         """
@@ -52,43 +54,55 @@ class DbUpdatesTestsBase(UnitTestDbBase):
         changes = list()
         [db.delete() for db in self.new_dbs]
         # Check the changes in the _db_updates feed to assert that the test databases are deleted
-        while not test_dbs_deleted:
-            feed = Feed(self.client, timeout=1000)
-            for change in feed:
-                if change['db_name'] in self.db_names and change['type'] == 'deleted':
-                    changes.append(change)
-                if len(changes) == 2:
-                    test_dbs_deleted = True
-                    feed.stop()
-        self.delete_db_updates()
+        if not self.is_couchdb_1x_version():
+            while not test_dbs_deleted and not self.is_couchdb_1x_version():
+                feed = Feed(self.client, timeout=1000)
+                for change in feed:
+                    if change['db_name'] in self.db_names and change['type'] == 'deleted':
+                        changes.append(change)
+                    if len(changes) == 2:
+                        test_dbs_deleted = True
+                        feed.stop()
+            self.delete_db_updates()
         self.client.disconnect()
         super(DbUpdatesTestsBase, self).tearDown()
 
     def create_dbs(self):
-        self.db_names = [self.dbname() for x in range(2)]
-        self.new_dbs += [self.client.create_database(dbname) for dbname in self.db_names]
-        # Verify that all created databases are listed in _db_updates
-        all_dbs_exist = False
-        while not all_dbs_exist:
-            changes = list()
-            feed = Feed(self.client, timeout=1000)
-            for change in feed:
-                changes.append(change)
-                if len(changes) == 3:
-                    all_dbs_exist = True
-                    feed.stop()
+        if not self.is_couchdb_1x_version():
+            self.db_names = [self.dbname() for x in range(2)]
+            self.new_dbs += [self.client.create_database(dbname) for dbname in self.db_names]
+            # Verify that all created databases are listed in _db_updates
+            all_dbs_exist = False
+            while not all_dbs_exist:
+                changes = list()
+                feed = Feed(self.client, timeout=1000)
+                for change in feed:
+                    changes.append(change)
+                    if len(changes) == 3:
+                            all_dbs_exist = True
+                            feed.stop()
+        else:
+            self.new_dbs += [(self.client.create_database(self.dbname())) for x in range(3)]
 
     def assert_changes_in_db_updates_feed(self, changes):
         """
         Assert that databases created in setup for db_updates_tests exist when looping through _db_updates feed
         Note: During the creation of _global_changes database, a doc called '_dbs' is created and seen in _db_updates
         """
-        self.dbs = ['_dbs', self.new_dbs[0].database_name, self.new_dbs[1].database_name]
-        types = ['created', 'updated']
-        for doc in changes:
-            self.assertIsNotNone(doc['seq'])
-            self.assertTrue(doc['db_name'] in self.dbs)
-            self.assertTrue(doc['type'] in types)
+        if not self.is_couchdb_1x_version():
+            self.dbs = ['_dbs', self.new_dbs[0].database_name, self.new_dbs[1].database_name]
+            types = ['created', 'updated']
+            for doc in changes:
+                self.assertIsNotNone(doc['seq'])
+                self.assertTrue(doc['db_name'] in self.dbs)
+                self.assertTrue(doc['type'] in types)
+        else:
+            self.assertDictEqual(
+                changes[0], {'db_name': self.new_dbs[0].database_name, 'type': 'created'})
+            self.assertDictEqual(
+                changes[1], {'db_name': self.new_dbs[1].database_name, 'type': 'created'})
+            self.assertDictEqual(
+                changes[2], {'db_name': self.new_dbs[2].database_name, 'type': 'created'})
 
 @unittest.skipIf(os.environ.get('RUN_CLOUDANT_TESTS'),
     'Skipping CouchDB _db_updates feed tests')
@@ -116,9 +130,12 @@ class CouchDbUpdatesTests(DbUpdatesTestsBase):
         feed = Feed(self.client, feed='continuous', timeout=100)
         changes = list()
         for change in feed:
-            changes.append(change)
-            if len(changes) == 3:
-                feed.stop()
+            if not change and self.is_couchdb_1x_version():
+                self.create_dbs()
+            else:
+                changes.append(change)
+                if len(changes) == 3:
+                    feed.stop()
         self.assert_changes_in_db_updates_feed(changes)
         self.assertEqual(len(changes), 3)
 
@@ -130,9 +147,12 @@ class CouchDbUpdatesTests(DbUpdatesTestsBase):
         raw_content = list()
         for raw_line in feed:
             self.assertIsInstance(raw_line, BYTETYPE)
-            raw_content.append(raw_line)
-            if len(raw_content) == 3:
-                feed.stop()
+            if not raw_line and self.is_couchdb_1x_version():
+                self.create_dbs()
+            else:
+                raw_content.append(raw_line)
+                if len(raw_content) == 3:
+                    feed.stop()
         changes = [json.loads(unicode_(x)) for x in raw_content]
         self.assert_changes_in_db_updates_feed(changes)
 
@@ -142,11 +162,20 @@ class CouchDbUpdatesTests(DbUpdatesTestsBase):
         """
         feed = Feed(self.client, timeout=1000)
         changes = list()
-        for change in feed:
-            self.assertIsNotNone(change)
-            changes.append(change)
-        self.assert_changes_in_db_updates_feed(changes)
-        self.assertEqual(len(changes), 3)
+        if self.is_couchdb_1x_version():
+            for change in feed:
+                self.assertIsNone(change)
+                changes.append(change)
+            self.assertEqual(len(changes), 1)
+            self.assertIsNone(changes[0])
+        else:
+            for change in feed:
+                self.assertIsNotNone(change)
+                changes.append(change)
+                if len(changes) == 3:
+                    feed.stop()
+            self.assert_changes_in_db_updates_feed(changes)
+            self.assertEqual(len(changes), 3)
 
     def test_get_longpoll_feed_explicit(self):
         """
@@ -155,11 +184,20 @@ class CouchDbUpdatesTests(DbUpdatesTestsBase):
         """
         feed = Feed(self.client, timeout=1000, feed='longpoll')
         changes = list()
-        for change in feed:
-            self.assertIsNotNone(change)
-            changes.append(change)
-        self.assert_changes_in_db_updates_feed(changes)
-        self.assertEqual(len(changes), 3)
+        if self.is_couchdb_1x_version():
+            for change in feed:
+                self.assertIsNone(change)
+                changes.append(change)
+            self.assertEqual(len(changes), 1)
+            self.assertIsNone(changes[0])
+        else:
+            for change in feed:
+                self.assertIsNotNone(change)
+                changes.append(change)
+                if len(changes) == 3:
+                    feed.stop()
+            self.assert_changes_in_db_updates_feed(changes)
+            self.assertEqual(len(changes), 3)
 
     def test_get_continuous_with_timeout(self):
         """
@@ -168,13 +206,16 @@ class CouchDbUpdatesTests(DbUpdatesTestsBase):
         """
         feed = Feed(self.client, feed='continuous', heartbeat=False, timeout=1000)
         changes = list()
-        for change in feed:
-            self.assertIsNotNone(change)
-            changes.append(change)
-            if len(changes) == 3:
-                feed.stop()
-        self.assert_changes_in_db_updates_feed(changes)
-        self.assertEqual(len(changes), 3)
+        if self.is_couchdb_1x_version():
+            self.assertListEqual([x for x in feed], [])
+        else:
+            for change in feed:
+                self.assertIsNotNone(change)
+                changes.append(change)
+                if len(changes) == 3:
+                    feed.stop()
+            self.assert_changes_in_db_updates_feed(changes)
+            self.assertEqual(len(changes), 3)
 
     def test_invalid_argument(self):
         """

--- a/tests/unit/document_tests.py
+++ b/tests/unit/document_tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2015 IBM. All rights reserved.
+# Copyright (C) 2015, 2018 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -306,9 +306,9 @@ class DocumentTests(UnitTestDbBase):
         err = cm.exception
         # Should be a 400 error code, but CouchDB 1.6 issues a 500
         if err.response.status_code == 500:
-            #Check this is CouchDB 1.6
-            self.assertTrue(self.client.r_session.head(self.url).headers['Server'].find('CouchDB/1.6.') >= 0,
-                            '500 returned but was not CouchDB 1.6.x')
+            # Check this is CouchDB 1.x
+            self.assertTrue(self.client.r_session.head(self.url).headers['Server'].find('CouchDB/1.') >= 0,
+                            '500 returned but was not CouchDB 1.x')
             self.assertEqual(
                 str(err.response.reason),
                 'Internal Server Error doc_validation Bad special document member: _invalid_key'

--- a/tests/unit/view_tests.py
+++ b/tests/unit/view_tests.py
@@ -293,30 +293,6 @@ class ViewTests(UnitTestDbBase):
         except requests.HTTPError as err:
             self.assertEqual(err.response.status_code, 404)
 
-    @unittest.skipUnless(
-    os.environ.get('RUN_CLOUDANT_TESTS') is None,
-            'Only execute as part of CouchDB tests')
-    def test_view_callable_with_invalid_javascript(self):
-        """
-        Test error condition when Javascript errors exist.  This test is only
-        valid for CouchDB because the map function Javascript is validated on
-        the Cloudant server when attempting to save a design document so invalid
-        Javascript is not possible there.
-        """
-        self.populate_db_with_documents()
-        ddoc = DesignDocument(self.db, 'ddoc001')
-        ddoc.add_view(
-            'view001',
-            'This is not valid Javascript'
-        )
-        with self.assertRaises(requests.HTTPError) as cm:
-            ddoc.save()
-        err = cm.exception
-        self.assertTrue(str(err).startswith(
-            '400 Client Error: Bad Request compilation_error Compilation of the map function '
-            'in the \'view001\' view failed: Expression does not eval to a function.'
-        ))
-
     def test_custom_result_context_manager(self):
         """
         Test that the context manager for custom results returns


### PR DESCRIPTION
- Updated COUCHDB_VERSION variable to just contain version number
- Get couchdb node name from _membership only if CouchDB version is 2.1.1
- Updated tests to support CouchDB 1.7.x
- Added helper method to check what version
- Removed javascript validation test that doesn’t apply to CouchDB 1.7.1

Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/python-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/python-cloudant/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What

Added CouchDB 1.7.1 to travis test matrix and updated Python 3.5 env to 3.6.

## How

- Updated logic to check if COUCHDB_VERSION starts with 1 for skipping tests when running against CouchDB 1.6.x and 1.7.x.
- Only get the CouchDB node name from _membership if CouchDB version is 2.1.1
- Added helper method to check if CouchDB version is 1.x

## Testing

No new tests.
Removed `test_view_callable_with_invalid_javascript` in `view_tests.py` as it's not valid in CouchDB 1.7.1.