### PR TITLE
Fixed document context manager when document id does not exist

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - [IMPROVED] Added support for IAM API key in `cloudant_bluemix` method.
 - [IMPROVED] Verified library operation on Python 3.6.3.
 - [IMPROVED] Shortened length of client URLs by removing username and password.
+- [FIXED] Case where `Document` context manager would throw instead of creating a new document if no `_id` was provided.
 
 # 2.8.1 (2018-02-16)
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -430,11 +430,16 @@ context manager.
 
         my_database = client.create_database('my_database')
 
-        # Performs a fetch upon entry and a save upon exit of this block
-        with Document(my_database, 'julia30') as doc:
-            doc['name'] = 'Julia'
-            doc['age'] = 30
-            doc['pets'] = ['cat', 'dog', 'frog']
+        # Upon entry into the document context, fetches the document from the
+        # remote database, if it exists. Upon exit from the context, saves the
+        # document to the remote database with changes made within the context
+        # or creates a new document.
+        with Document(database, 'julia006') as document:
+            # If document exists, it's fetched from the remote database
+            # Changes are made locally
+            document['name'] = 'Julia'
+            document['age'] = 6
+            # The document is saved to the remote database
 
         # Display a Document
         print(my_database['julia30'])

--- a/src/cloudant/document.py
+++ b/src/cloudant/document.py
@@ -332,6 +332,9 @@ class Document(dict):
         except HTTPError as error:
             if error.response.status_code != 404:
                 raise
+        except CloudantDocumentException as error:
+            if error.status_code != 101:
+                raise
 
         return self
 

--- a/tests/unit/document_tests.py
+++ b/tests/unit/document_tests.py
@@ -540,6 +540,29 @@ class DocumentTests(UnitTestDbBase):
         self.assertTrue(doc['_rev'].startswith('2-'))
         self.assertEqual(self.db['julia006'], doc)
 
+    def test_document_context_manager_no_doc_id(self):
+        """
+        Test that the __enter__ and __exit__ methods perform as expected
+        with no document id when initiated through a document context manager
+        """
+        with Document(self.db) as doc:
+            doc['_id'] = 'julia006'
+            doc['name'] = 'julia'
+            doc['age'] = 6
+        self.assertTrue(doc['_rev'].startswith('1-'))
+        self.assertEqual(self.db['julia006'], doc)
+
+    def test_document_context_manager_doc_create(self):
+        """
+        Test that the document context manager will create a doc if it does
+        not yet exist.
+        """
+        with Document(self.db, 'julia006') as doc:
+            doc['name'] = 'julia'
+            doc['age'] = 6
+        self.assertTrue(doc['_rev'].startswith('1-'))
+        self.assertEqual(self.db['julia006'], doc)
+
     def test_setting_id(self):
         """
         Ensure that proper processing occurs when setting the _id


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/python-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/python-cloudant/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What

We mention that the `Document` context manager will [not raise an exception when the document id is not found](https://github.com/cloudant/python-cloudant/blob/master/src/cloudant/document.py#L327-L329).  Unfortunately this isn't the case and a `CloudantDocumentException` is thrown.

This PR fixes `fetch()` to handle context manager cases when the document id doesn't exist and the user wants to create a new doc.

## How

- Return from `fetch` function early if the document id doesn't exist and if `fetch` was called within the entry context manager logic
- Updated getting started example

## Testing

Added `test_document_context_manager_no_doc_id` test.

## Issues

fixes #361 