### PR TITLE
Get document by revision

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # Unreleased
+- [NEW] Added functionality to retrieve a previous version of a document.
 
 # 2.9.0 (2018-06-13)
 

--- a/src/cloudant/_messages.py
+++ b/src/cloudant/_messages.py
@@ -102,7 +102,8 @@ DOCUMENT = {
     101: 'A document id is required to fetch document contents. '
          'Add an _id key and value to the document and re-try.',
     102: 'The field {0} is not a list.',
-    103: 'Attempting to delete a doc with no _rev. Try running .fetch and re-try.'
+    103: 'Attempting to delete a doc with no _rev. Try running .fetch and re-try.',
+    104: 'Document revision {0} is either invalid or its contents are not available'
 }
 
 FEED = {

--- a/src/cloudant/document.py
+++ b/src/cloudant/document.py
@@ -104,6 +104,9 @@ class Document(dict):
         """
         Retrieves whether the document exists in the remote database or not.
 
+        Any parameters will be treated as request arguments to the
+        document endpoint.
+
         :returns: True if the document exists in the remote database,
             otherwise False
         """
@@ -159,6 +162,9 @@ class Document(dict):
         and populates the locally cached Document object with that content.
         A call to fetch will overwrite any dictionary content currently in
         the locally cached Document object.
+
+        Any parameters will be treated as request arguments to the
+        document endpoint.
         """
         if self.document_url is None:
             raise CloudantDocumentException(101)

--- a/src/cloudant/document.py
+++ b/src/cloudant/document.py
@@ -100,7 +100,7 @@ class Document(dict):
             url_quote(self._document_id, safe='')
         ))
 
-    def exists(self):
+    def exists(self, **kwargs):
         """
         Retrieves whether the document exists in the remote database or not.
 
@@ -110,7 +110,7 @@ class Document(dict):
         if self._document_id is None:
             return False
         else:
-            resp = self.r_session.head(self.document_url)
+            resp = self.r_session.head(self.document_url, params=kwargs)
             if resp.status_code not in [200, 404]:
                 resp.raise_for_status()
 
@@ -153,7 +153,7 @@ class Document(dict):
         super(Document, self).__setitem__('_rev', data['rev'])
         return
 
-    def fetch(self):
+    def fetch(self, **kwargs):
         """
         Retrieves the content of the current document from the remote database
         and populates the locally cached Document object with that content.
@@ -162,7 +162,7 @@ class Document(dict):
         """
         if self.document_url is None:
             raise CloudantDocumentException(101)
-        resp = self.r_session.get(self.document_url)
+        resp = self.r_session.get(self.document_url, params=kwargs)
         resp.raise_for_status()
         self.clear()
         self.update(resp.json())
@@ -493,3 +493,20 @@ class Document(dict):
         resp.raise_for_status()
         self.fetch()
         return resp.json()
+
+        def get_revision(self, rev):
+            """
+            Retrieves a given revision of the current document.
+
+            :param rev: Revision ID.
+
+            :returns: Document data
+            """
+            doc = self.__class__(self._database, self._document_id)
+
+            if doc.exists(rev=rev):
+                doc.fetch(rev=rev)
+
+                return dict(doc)
+
+            raise CloudantDocumentException(104, rev)

--- a/src/cloudant/document.py
+++ b/src/cloudant/document.py
@@ -162,11 +162,10 @@ class Document(dict):
         """
         Retrieves the content of the current document from the remote database
         and populates the locally cached Document object with that content.
-        A call to fetch will overwrite any dictionary content currently in
-        the locally cached Document object.
+        A call to fetch_revision will overwrite any dictionary content
+        currently in the locally cached Document object.
 
         :param str rev: Get a specific revision of the document.
-            Default is ``None``, which gets the most recent revision.
         """
         if self.document_url is None:
             raise CloudantDocumentException(101)

--- a/tests/unit/document_tests.py
+++ b/tests/unit/document_tests.py
@@ -184,7 +184,7 @@ class DocumentTests(UnitTestDbBase):
             doc.exists()
         err = cm.exception
         self.assertEqual(err.response.status_code, 400)
-        self.client.r_session.head.assert_called_with(doc.document_url)
+        self.client.r_session.head.assert_called_with(doc.document_url, params={})
 
     def test_retrieve_document_json(self):
         """
@@ -488,7 +488,7 @@ class DocumentTests(UnitTestDbBase):
             self.fail('Above statement should raise an Exception')
         except CloudantDocumentException as err:
             self.assertEqual(
-                str(err), 
+                str(err),
                 'Attempting to delete a doc with no _rev. '
                 'Try running .fetch and re-try.'
             )
@@ -692,7 +692,7 @@ class DocumentTests(UnitTestDbBase):
             )
             orig_size = doc['_attachments']['attachment.txt']['length']
             self.assertEqual(orig_size, len(attachment.getvalue()))
-            # Confirm that the local document dictionary matches 
+            # Confirm that the local document dictionary matches
             # the document on the database.
             expected = Document(self.db, 'julia006')
             expected.fetch()
@@ -732,7 +732,7 @@ class DocumentTests(UnitTestDbBase):
                 doc.get_attachment('attachment.txt', attachment_type='text'),
                 attachment.getvalue()
             )
-            # Confirm that the local document dictionary matches 
+            # Confirm that the local document dictionary matches
             # the document on the database.
             expected = Document(self.db, 'julia006')
             expected.fetch()
@@ -759,7 +759,7 @@ class DocumentTests(UnitTestDbBase):
                     '_attachments'
                 ])
             )
-            # Confirm that the local document dictionary matches 
+            # Confirm that the local document dictionary matches
             # the document on the database.
             expected = Document(self.db, 'julia006')
             expected.fetch()
@@ -778,7 +778,7 @@ class DocumentTests(UnitTestDbBase):
                     'age'
                 ])
             )
-            # Confirm that the local document dictionary matches 
+            # Confirm that the local document dictionary matches
             # the document on the database.
             expected = Document(self.db, 'julia006')
             expected.fetch()


### PR DESCRIPTION
…ocument if it is available in the database

<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [v] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [v] Added tests for code changes _or_ test/build only changes
- [v] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [v] Completed the PR template below:

## Description
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->
This adds a simple way to retrieve a previous revision of a document.
## Approach

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->
Changed ```cloudant.document.Document.fetch``` to take keyword arguments and pass them through to the raw session object.

Changed ```cloudant.document.Document.exists``` to take keyword arguments and pass them through to the raw session object when making the HEAD request.

Added a new method ```cloudant.document.Document.get_revision``` which creates a new Document instance, checks if the data for the revision exists, and returns a ```dict``` holding the document data for that revision.

## Schema & API Changes

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->
```cloudant.document.Document.exists``` and ```cloudant.document.Document.fetch``` now can also take keyword arguments.

## Security and Privacy

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->
No change
## Testing

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->
Modified ```tests.unit.document_tests.test_document_exists_raises_httperror``` to account for the changed API

## Monitoring and Logging
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
No change