### PR TITLE
Stopped raising exception on conflict retry success

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [NEW] Add new view parameters, `stable` and `update`, as keyword arguments to `get_view_result`.
+- [FIXED] Case where an exception was raised after successful retry when using `doc.update_field`.
 
 # 2.9.0 (2018-06-13)
 

--- a/src/cloudant/document.py
+++ b/src/cloudant/document.py
@@ -259,7 +259,8 @@ class Document(dict):
             if tries < max_tries and ex.response.status_code == 409:
                 self._update_field(
                     action, field, value, max_tries, tries=tries+1)
-            raise
+            else:
+                raise
 
     def update_field(self, action, field, value, max_tries=10):
         """


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Stopped incorrect raising of exception after successful retry in `doc.update_field`.

Fixes #393 

## Approach

Moved the exception `raise` into an `else` block to prevent it being raised after successful execution of the recursive call into `_update_field`.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Added new tests for conflict retry cases:
- `test_update_field_maxretries` - checks that the exception is raised when `max_tries` is exhausted
- `test_update_field_success_on_retry` - checks that an exception is not raised when a retry succeeds

## Monitoring and Logging

- "No change"
