### PR TITLE
Fix pylint warning messages

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -66,7 +66,8 @@ confidence=
 # Disable "redefined-variable-type" refactor warning messages
 # Disable "too-many-..." and "too-few-..." refactor warning messages
 # Disable "locally-disabled" message
-disable=R0204,R0901,R0902,R0903,R0904,R0913,R0914,R0915,locally-disabled,keyword-arg-before-vararg
+# Disable Python 3 "useless-object-inheritance" message
+disable=R0204,R0901,R0902,R0903,R0904,R0913,R0914,R0915,locally-disabled,keyword-arg-before-vararg,useless-object-inheritance
 
 
 [REPORTS]

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -147,7 +147,7 @@ def feed_arg_types(feed_type):
     """
     if feed_type == 'Cloudant':
         return _DB_UPDATES_ARG_TYPES
-    elif feed_type == 'CouchDB':
+    if feed_type == 'CouchDB':
         return _COUCH_DB_UPDATES_ARG_TYPES
     return _CHANGES_ARG_TYPES
 
@@ -200,7 +200,7 @@ def _py_to_couch_translate(key, val):
     try:
         if key in ['keys', 'endkey_docid', 'startkey_docid', 'stale', 'update']:
             return {key: val}
-        elif val is None:
+        if val is None:
             return {key: None}
         arg_converter = TYPE_CONVERTERS.get(type(val))
         return {key: arg_converter(val)}

--- a/src/cloudant/client.py
+++ b/src/cloudant/client.py
@@ -387,9 +387,9 @@ class CouchDB(dict):
         db = self._DATABASE_CLASS(self, key)
         if db.exists():
             super(CouchDB, self).__setitem__(key, db)
-            return db
         else:
             raise KeyError(key)
+        return db
 
     def __delitem__(self, key, remote=False):
         """

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -337,7 +337,7 @@ class CouchDatabase(dict):
         view = View(DesignDocument(self, ddoc_id), view_name)
         if raw_result:
             return view(**kwargs)
-        elif kwargs:
+        if kwargs:
             return Result(view, **kwargs)
 
         return view.result
@@ -613,9 +613,9 @@ class CouchDatabase(dict):
         if doc.exists():
             doc.fetch()
             super(CouchDatabase, self).__setitem__(key, doc)
-            return doc
         else:
             raise KeyError(key)
+        return doc
 
     def __contains__(self, key):
         """

--- a/src/cloudant/document.py
+++ b/src/cloudant/document.py
@@ -112,10 +112,10 @@ class Document(dict):
         """
         if self._document_id is None:
             return False
-        else:
-            resp = self.r_session.head(self.document_url)
-            if resp.status_code not in [200, 404]:
-                resp.raise_for_status()
+
+        resp = self.r_session.head(self.document_url)
+        if resp.status_code not in [200, 404]:
+            resp.raise_for_status()
 
         return resp.status_code == 200
 
@@ -154,7 +154,6 @@ class Document(dict):
         self._document_id = data['id']
         super(Document, self).__setitem__('_id', data['id'])
         super(Document, self).__setitem__('_rev', data['rev'])
-        return
 
     def fetch(self):
         """
@@ -320,7 +319,6 @@ class Document(dict):
         del_resp.raise_for_status()
         self.clear()
         self.__setitem__('_id', self._document_id)
-        return
 
     def __enter__(self):
         """
@@ -413,13 +411,13 @@ class Document(dict):
                 attachment_type = 'binary'
 
         if write_to is not None:
-            if attachment_type == 'text' or attachment_type == 'json':
+            if attachment_type in ('text', 'json'):
                 write_to.write(resp.text)
             else:
                 write_to.write(resp.content)
         if attachment_type == 'text':
             return resp.text
-        elif attachment_type == 'json':
+        if attachment_type == 'json':
             return resp.json()
 
         return resp.content

--- a/src/cloudant/feed.py
+++ b/src/cloudant/feed.py
@@ -164,8 +164,7 @@ class Feed(object):
         skip = False
         if self._raw_data:
             return skip, line
-        else:
-            line = unicode_(line)
+        line = unicode_(line)
         if not line:
             if (self._options.get('heartbeat', False) and
                     self._options.get('feed') in ('continuous', 'longpoll') and

--- a/src/cloudant/index.py
+++ b/src/cloudant/index.py
@@ -145,7 +145,6 @@ class Index(object):
         resp.raise_for_status()
         self._ddoc_id = resp.json()['id']
         self._name = resp.json()['name']
-        return
 
     def _def_check(self):
         """
@@ -168,7 +167,6 @@ class Index(object):
         url = '/'.join((self.index_url, ddoc_id, self._type, self._name))
         resp = self._r_session.delete(url)
         resp.raise_for_status()
-        return
 
 class TextIndex(Index):
     """

--- a/src/cloudant/result.py
+++ b/src/cloudant/result.py
@@ -268,13 +268,13 @@ class Result(object):
         start = idx_slice.start
         stop = idx_slice.stop
         data = None
-        if (start is not None and stop is not None and
-                start >= 0 and stop >= 0 and start < stop):
+        # start and stop cannot be None and both must be greater than 0
+        if all(i is not None and i >= 0 for i in [start, stop]) and start < stop:
             if limit is not None:
                 if start >= limit:
                     # Result is out of range
                     return dict()
-                elif stop > limit:
+                if stop > limit:
                     # Ensure that slice does not extend past original limit
                     return self._ref(skip=skip+start, limit=limit-start, **opts)
             data = self._ref(skip=skip+start, limit=stop-start, **opts)
@@ -498,8 +498,8 @@ class QueryResult(Result):
                  type_or_none(int, arg.start) and
                  type_or_none(int, arg.stop))):
             return super(QueryResult, self).__getitem__(arg)
-        else:
-            raise ResultException(101, arg)
+
+        raise ResultException(101, arg)
 
     def _parse_data(self, data):
         """

--- a/src/cloudant/scheduler.py
+++ b/src/cloudant/scheduler.py
@@ -41,9 +41,9 @@ class Scheduler(object):
         :param skip: How many result to skip starting at the beginning, if ordered by document ID.
         """
         params = dict()
-        if limit != None:
+        if limit is not None:
             params["limit"] = limit
-        if skip != None:
+        if skip is not None:
             params["skip"] = skip
         resp = self._r_session.get('/'.join([self._scheduler, 'docs']), params=params)
         resp.raise_for_status()
@@ -72,9 +72,9 @@ class Scheduler(object):
         :param skip: How many result to skip starting at the beginning, if ordered by document ID.
         """
         params = dict()
-        if limit != None:
+        if limit is not None:
             params["limit"] = limit
-        if skip != None:
+        if skip is not None:
             params["skip"] = skip
         resp = self._r_session.get('/'.join([self._scheduler, 'jobs']), params=params)
         resp.raise_for_status()


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes 
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Fix pylint warning messages

**Note**: I tried to set a specific version of `pylint` in test-requirements.txt but unfortunately there's different versions for this package in Python 2 and 3.  Python 3 has 2.1.1 as the latest, Python 2 has 1.9.3 as the latest.
## Approach

Pylint warning messages in client, database, document, index, result, and scheduler required attention.
One warning message was added to the disable list in `pylintrc`.
`useless-object-inheritance` is a warning message for Python 3.  This one is problematic in Python 2 which requires the `object` inheritance.  It's unfortunate that this warning was added because it's not backward compatible

## Schema & API Changes
- "No change"

## Security and Privacy
- "No change"


## Testing
N/A pylint changes

## Monitoring and Logging
- "No change"