### PR TITLE
403 remove unnecessary request in Result iteration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 - [NEW] Add custom JSON encoder/decoder option to `Document` constructor.
 - [NEW] Add new view parameters, `stable` and `update`, as keyword arguments to `get_view_result`.
 - [FIXED] Case where an exception was raised after successful retry when using `doc.update_field`.
+- [FIXED] Removed unnecessary request when retrieving a Result collection that is less than the 'page_size' value
 
 # 2.9.0 (2018-06-13)
 

--- a/src/cloudant/result.py
+++ b/src/cloudant/result.py
@@ -341,7 +341,8 @@ class Result(object):
             raise ResultException(103, invalid_options, self.options)
 
         try:
-            if int(self._page_size) <= 0:
+            self._page_size = int(self._page_size)
+            if self._page_size <= 0:
                 raise ResultException(104, self._page_size)
         except ValueError:
             raise ResultException(104, self._page_size)
@@ -349,15 +350,17 @@ class Result(object):
         skip = 0
         while True:
             response = self._ref(
-                limit=int(self._page_size),
+                limit=self._page_size,
                 skip=skip,
                 **self.options
             )
             result = self._parse_data(response)
-            skip += int(self._page_size)
+            skip += self._page_size
             if result:
                 for row in result:
                     yield row
+                if len(result) < self._page_size:
+                    break
                 del result
             else:
                 break


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Two request are executed when only one request is required for getting a result collection that is less than the `page_size` value.

Fixes #403


## Approach

Break out of `while` loop in `Result.__iter__` when the length of `result` is less than the page size.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- No new tests.
- Verified that only one request is executed in local CouchDB logging


## Monitoring and Logging
- "No change"

