### PR TITLE
Allow query parameters to be passed to custom changes filters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 - [NEW] Add custom JSON encoder/decoder option to `Document` constructor.
 - [NEW] Add new view parameters, `stable` and `update`, as keyword arguments to `get_view_result`.
+- [NEW] Allow arbitrary query parameters to be passed to custom changes filters.
 - [FIXED] Case where an exception was raised after successful retry when using `doc.update_field`.
 - [FIXED] Removed unnecessary request when retrieving a Result collection that is less than the 'page_size' value
 

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -47,6 +47,9 @@ SPECIAL_INDEX_TYPE = 'special'
 
 # Argument Types
 
+ANY_ARG = object()
+ANY_TYPE = object()
+
 RESULT_ARG_TYPES = {
     'descending': (bool,),
     'endkey': (int, LONGTYPE, STRTYPE, Sequence,),
@@ -101,6 +104,7 @@ _CHANGES_ARG_TYPES = {
     'filter': (STRTYPE,),
     'include_docs': (bool,),
     'style': (STRTYPE,),
+    ANY_ARG: ANY_TYPE  # pass arbitrary query parameters to a custom filter
 }
 _CHANGES_ARG_TYPES.update(_DB_UPDATES_ARG_TYPES)
 

--- a/src/cloudant/feed.py
+++ b/src/cloudant/feed.py
@@ -100,7 +100,7 @@ class Feed(object):
                 if isinstance(val, STRTYPE):
                     translation[key] = val
                 elif not isinstance(val, NONETYPE):
-                    arg_converter = TYPE_CONVERTERS.get(type(val))
+                    arg_converter = TYPE_CONVERTERS.get(type(val), json.dumps)
                     translation[key] = arg_converter(val)
             except Exception as ex:
                 raise CloudantArgumentError(115, key, ex)

--- a/src/cloudant/feed.py
+++ b/src/cloudant/feed.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2015, 2016 IBM. All rights reserved.
+# Copyright (c) 2015, 2018 IBM. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import json
 
 from ._2to3 import iteritems_, next_, unicode_, STRTYPE, NONETYPE
 from .error import CloudantArgumentError, CloudantFeedException
-from ._common_util import feed_arg_types, TYPE_CONVERTERS
+from ._common_util import ANY_ARG, ANY_TYPE, feed_arg_types, TYPE_CONVERTERS
 
 class Feed(object):
     """
@@ -111,11 +111,18 @@ class Feed(object):
         Ensures that the key and the value are valid arguments to be used with
         the feed.
         """
-        if key not in arg_types:
-            raise CloudantArgumentError(116, key)
-        if (not isinstance(val, arg_types[key]) or
-                (isinstance(val, bool) and int in arg_types[key])):
-            raise CloudantArgumentError(117, key, arg_types[key])
+        if key in arg_types:
+            arg_type = arg_types[key]
+        else:
+            if ANY_ARG not in arg_types:
+                raise CloudantArgumentError(116, key)
+            arg_type = arg_types[ANY_ARG]
+
+        if arg_type == ANY_TYPE:
+            return
+        if (not isinstance(val, arg_type) or
+                (isinstance(val, bool) and int in arg_type)):
+            raise CloudantArgumentError(117, key, arg_type)
         if isinstance(val, int) and val < 0 and not isinstance(val, bool):
             raise CloudantArgumentError(118, key, val)
         if key == 'feed':

--- a/tests/unit/changes_tests.py
+++ b/tests/unit/changes_tests.py
@@ -465,14 +465,20 @@ class ChangesTests(UnitTestDbBase):
         self.assertSetEqual(set([x['id'] for x in changes]), expected)
         self.assertTrue(str(feed.last_seq).startswith('100'))
 
-    def test_invalid_argument(self):
+    def test_get_feed_with_custom_filter_query_params(self):
         """
-        Test that an invalid argument is caught and an exception is raised
+        Test using feed with custom filter query parameters.
         """
-        feed = Feed(self.db, foo='bar')
-        with self.assertRaises(CloudantArgumentError) as cm:
-            invalid_feed = [x for x in feed]
-        self.assertEqual(str(cm.exception), 'Invalid argument foo')
+        feed = Feed(
+            self.db,
+            filter='mailbox/new_mail',
+            foo='bar',  # query parameters to a custom filter
+            include_docs=False
+        )
+        params = feed._translate(feed._options)
+        self.assertEquals(params['filter'], 'mailbox/new_mail')
+        self.assertEquals(params['foo'], 'bar')
+        self.assertEquals(params['include_docs'], 'false')
 
     def test_invalid_argument_type(self):
         """


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->
Allow arbitrary query parameters to be passed to custom changes filters.

Fixes #402.

## Approach
<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->
Add new `ANY_ARG` and `ANY_TYPE` to list of valid changes arguments:

```py
_CHANGES_ARG_TYPES = {
    'conflicts': (bool,),
    'doc_ids': (list,),
    'filter': (STRTYPE,),
    'include_docs': (bool,),
    'style': (STRTYPE,),
    ANY_ARG: ANY_TYPE  # pass arbitrary query parameters to a custom filter
}
```

## Schema & API Changes
<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->
No change.

## Security and Privacy
<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->
No change.

## Testing
<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->
Includes additional unit test.

## Monitoring and Logging
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
No change.
