### PR TITLE
WIP Partitioned Databases

### DIFF
--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -6,6 +6,7 @@ Modules
 
    client
    database
+   database_partition
    document
    design_document
    security_document

--- a/src/cloudant/client.py
+++ b/src/cloudant/client.py
@@ -271,6 +271,8 @@ class CouchDB(dict):
         :param bool throw_on_exists: Boolean flag dictating whether or
             not to throw a CloudantClientException when attempting to
             create a database that already exists.
+        :param bool partitioned: Create as a partitioned database. Defaults to
+            ``False``.
 
         :returns: The newly created database object
         """

--- a/src/cloudant/client.py
+++ b/src/cloudant/client.py
@@ -259,7 +259,7 @@ class CouchDB(dict):
         resp.raise_for_status()
         return response_to_json_dict(resp)
 
-    def create_database(self, dbname, **kwargs):
+    def create_database(self, dbname, partitioned=False, **kwargs):
         """
         Creates a new database on the remote server with the name provided
         and adds the new database object to the client's locally cached
@@ -274,7 +274,7 @@ class CouchDB(dict):
 
         :returns: The newly created database object
         """
-        new_db = self._DATABASE_CLASS(self, dbname)
+        new_db = self._DATABASE_CLASS(self, dbname, partitioned=partitioned)
         try:
             new_db.create(kwargs.get('throw_on_exists', False))
         except CloudantDatabaseException as ex:

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -51,6 +51,8 @@ class CouchDatabase(dict):
     :param str database_name: Database name used to reference the database.
     :param int fetch_limit: Optional fetch limit used to set the max number of
         documents to fetch per query during iteration cycles.  Defaults to 100.
+    :param bool partitioned: Create as a partitioned database. Defaults to
+        ``False``.
     """
     def __init__(self, client, database_name, fetch_limit=100,
                  partitioned=False):
@@ -110,10 +112,11 @@ class CouchDatabase(dict):
 
     def get_partition(self, partition_key):
         """
-        Retrieve database partition object.
+        Retrieve a database partition object for the specified partition key.
 
-        :param partition_key: partition key as string.
-        :return: DatabasePartition object if database is partitioned, else None.
+        :param str partition_key: partition key.
+        :return: DatabasePartition object for specified partition key.
+        :rtype: `~cloudant.database_partition.DatabasePartition`
         """
         return DatabasePartition(self, partition_key)
 
@@ -1189,6 +1192,8 @@ class CloudantDatabase(CouchDatabase):
     :param str database_name: Database name used to reference the database.
     :param int fetch_limit: Optional fetch limit used to set the max number of
         documents to fetch per query during iteration cycles.  Defaults to 100.
+    :param bool partitioned: Create as a partitioned database. Defaults to
+        ``False``.
     """
     def __init__(self, client, database_name, fetch_limit=100,
                  partitioned=False):

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -119,7 +119,7 @@ class CouchDatabase(dict):
         """
         return self._partitioned
 
-    def partition(self, partition_key):
+    def get_partition(self, partition_key):
         """
         Retrieve database partition object.
 

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -110,15 +110,6 @@ class CouchDatabase(dict):
             "user_ctx": session.get('userCtx')
         }
 
-    @property
-    def partitioned(self):
-        """
-        Establish if this database is partitioned.
-
-        :return: True if database is partitioned, else False.
-        """
-        return self._partitioned
-
     def get_partition(self, partition_key):
         """
         Retrieve database partition object.
@@ -126,9 +117,6 @@ class CouchDatabase(dict):
         :param partition_key: partition key as string.
         :return: DatabasePartition object if database is partitioned, else None.
         """
-        if not self._partitioned:
-            return None
-
         return self._DATABASE_PARTITION_CLASS(self, partition_key)
 
     def exists(self):

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -31,6 +31,7 @@ from ._common_util import (
     response_to_json_dict)
 from .document import Document
 from .design_document import DesignDocument
+from .database_partition import CloudantDatabasePartition, CouchDatabasePartition
 from .security_document import SecurityDocument
 from .view import View
 from .index import Index, TextIndex, SpecialIndex
@@ -51,6 +52,8 @@ class CouchDatabase(dict):
     :param int fetch_limit: Optional fetch limit used to set the max number of
         documents to fetch per query during iteration cycles.  Defaults to 100.
     """
+    _DATABASE_PARTITION_CLASS = CouchDatabasePartition
+
     def __init__(self, client, database_name, fetch_limit=100,
                  partitioned=False):
         super(CouchDatabase, self).__init__()
@@ -106,6 +109,27 @@ class CouchDatabase(dict):
             "basic_auth": self.client.basic_auth_str(),
             "user_ctx": session.get('userCtx')
         }
+
+    @property
+    def partitioned(self):
+        """
+        Establish if this database is partitioned.
+
+        :return: True if database is partitioned, else False.
+        """
+        return self._partitioned
+
+    def partition(self, partition_key):
+        """
+        Retrieve database partition object.
+
+        :param partition_key: partition key as string.
+        :return: DatabasePartition object if database is partitioned, else None.
+        """
+        if not self._partitioned:
+            return None
+
+        return self._DATABASE_PARTITION_CLASS(self, partition_key)
 
     def exists(self):
         """
@@ -1180,6 +1204,8 @@ class CloudantDatabase(CouchDatabase):
     :param int fetch_limit: Optional fetch limit used to set the max number of
         documents to fetch per query during iteration cycles.  Defaults to 100.
     """
+    _DATABASE_PARTITION_CLASS = CloudantDatabasePartition
+
     def __init__(self, client, database_name, fetch_limit=100,
                  partitioned=False):
         super(CloudantDatabase, self).__init__(

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -31,7 +31,7 @@ from ._common_util import (
     response_to_json_dict)
 from .document import Document
 from .design_document import DesignDocument
-from .database_partition import CloudantDatabasePartition, CouchDatabasePartition
+from .database_partition import DatabasePartition
 from .security_document import SecurityDocument
 from .view import View
 from .index import Index, TextIndex, SpecialIndex
@@ -52,8 +52,6 @@ class CouchDatabase(dict):
     :param int fetch_limit: Optional fetch limit used to set the max number of
         documents to fetch per query during iteration cycles.  Defaults to 100.
     """
-    _DATABASE_PARTITION_CLASS = CouchDatabasePartition
-
     def __init__(self, client, database_name, fetch_limit=100,
                  partitioned=False):
         super(CouchDatabase, self).__init__()
@@ -117,7 +115,7 @@ class CouchDatabase(dict):
         :param partition_key: partition key as string.
         :return: DatabasePartition object if database is partitioned, else None.
         """
-        return self._DATABASE_PARTITION_CLASS(self, partition_key)
+        return DatabasePartition(self, partition_key)
 
     def exists(self):
         """
@@ -1192,8 +1190,6 @@ class CloudantDatabase(CouchDatabase):
     :param int fetch_limit: Optional fetch limit used to set the max number of
         documents to fetch per query during iteration cycles.  Defaults to 100.
     """
-    _DATABASE_PARTITION_CLASS = CloudantDatabasePartition
-
     def __init__(self, client, database_name, fetch_limit=100,
                  partitioned=False):
         super(CloudantDatabase, self).__init__(

--- a/src/cloudant/database_partition.py
+++ b/src/cloudant/database_partition.py
@@ -13,32 +13,170 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Database partition.
+Partitioned databases introduce the ability for a user to create logical groups
+of documents called partitions by providing a partition key with each document.
+
+.. warning:: Your Cloudant cluster must have the ``partitions`` feature enabled.
+             A full list of enabled features can be retrieved by calling the
+             client :meth:`~cloudant.client.CouchDB.metadata` method.
+
+Creating a partitioned database
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+    db = client.create_database('mydb', partitioned=True)
+
+Handling documents
+^^^^^^^^^^^^^^^^^^
+
+The document ID contains both the partition key and document key in the form
+``<partitionkey>:<documentkey>`` where:
+
+- Partition Key *(string)*. Must be non-empty. Must not contain colons (as this
+  is the partition key delimiter) or begin with an underscore.
+- Document Key *(string)*. Must be non-empty. Must not begin with an underscore.
+
+Be aware that ``_design`` documents and ``_local`` documents must not contain a
+partition key as they are global definitions.
+
+**Create a document**
+
+.. code-block:: python
+
+    partition_key = 'Year2'
+    document_key = 'julia30'
+
+    db.create_document({
+        '_id': ':'.join((partition_key, document_key)),
+        'name': 'Jules',
+        'age': 6
+    })
+
+**Get a document**
+
+.. code-block:: python
+
+    doc = db[':'.join((partition_key, document_key))]
+
+    # OR...
+
+    partition = db.get_partition(partition_key)
+    doc = partition[document_key]
+
+Creating design documents
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To define partitioned indexes you must set the ``partitioned=True`` optional
+when constructing the new ``DesignDocument`` class.
+
+.. code-block:: python
+
+    ddoc = DesignDocument(db, document_id='view', partitioned=True)
+    ddoc.add_view('myview','function(doc) { emit(doc.foo, doc.bar); }')
+    ddoc.save()
+
+Similarly, to define a partitioned Cloudant Query index you must set the
+``partitioned=True`` optional.
+
+.. code-block:: python
+
+    index = db.create_query_index(
+        design_document_id='query',
+        index_name='foo-index',
+        fields=['foo'],
+        partitioned=True
+    )
+
+    index.create()
+
+Querying Data
+^^^^^^^^^^^^^
+
+A partition key can be specified when querying data so that results can be
+constrained to a specific database partition.
+
+.. warning:: To run partitioned queries the database itself must be partitioned.
+
+**Query**
+
+.. code-block:: python
+
+    partition = db.get_partition(partition_key)
+    for result in partition.query(selector={'name': {'$eq': 'Jules'}}, use_index='_design/query')):
+        ...
+
+See :meth:`~cloudant.database.CouchDatabase.get_query_result` for a full
+list of supported parameters.
+
+**Search**
+
+.. code-block:: python
+
+    partition = db.get_partition(partition_key)
+    results = partition.search('_design/search', 'mysearch', q='name:Jules')
+
+    for result in results['rows']:
+       ...
+
+See :meth:`~cloudant.database.CloudantDatabase.get_search_result` for a full
+list of supported parameters.
+
+**Views (MapReduce)**
+
+.. code-block:: python
+
+    partition = db.get_partition(partition_key)
+    for result in partition.view('_design/view', 'myview')
+       ...
+
+See :meth:`~cloudant.database.CouchDatabase.get_view_result` for a full
+list of supported parameters.
 """
 
 
 class DatabasePartition(object):
     """
-    CouchDB database partition.
+    Database partition.
 
-    :param partition_key: Partition key as string.
+    :param str partition_key: Partition key.
     """
     def __init__(self, db, partition_key):
         self._db = db
         self._partition_key = partition_key
 
     def __contains__(self, item):
+        """
+        Check if a document exists in this database partition.
+
+        See :meth:`cloudant.database.CouchDatabase.__contains__`.
+
+        :param str item: Document ID.
+        :returns: ``True`` if the document exists in the database partition,
+            otherwise ``False``.
+        :rtype: bool
+        """
         return self._db.__contains__(self._get_doc_id(item))
 
-    def __getitem__(self, item):
-        return self._db.__getitem__(self._get_doc_id(item))
+    def __getitem__(self, key):
+        """
+        Get a document instance for the specified key from this database
+        partition.
+
+        See :meth:`cloudant.database.CouchDatabase.__getitem__`.
+
+        :param str key: Document ID used to retrieve the document from the
+            database.
+        :returns: A Document or DesignDocument object depending on the specified
+            document ID (key).
+        :rtype: :class:`~cloudant.document.Document`,
+            :class:`~cloudant.design_document.DesignDocument`
+        """
+        return self._db.__getitem__(self._get_doc_id(key))
 
     def _get_doc_id(self, doc_key):
         """
         Get document ID.
-
-        :param doc_key: Document key as string.
-        :return: Document ID as string.
         """
         return '{partition_key}:{doc_key}'.format(
             partition_key=self._partition_key,
@@ -50,7 +188,8 @@ class DatabasePartition(object):
         """
         Get partition key.
 
-        :return: Partition key as string.
+        :return: Partition key.
+        :rtype: str
         """
         return self._partition_key
 
@@ -58,7 +197,8 @@ class DatabasePartition(object):
         """
         Run a query over this database partition.
 
-        See :func:`~database.CouchDatabase.get_query_result`.
+        See :meth:`~cloudant.database.CouchDatabase.get_query_result` for a full
+        list of supported parameters.
 
         :return: The result.
         """
@@ -70,7 +210,8 @@ class DatabasePartition(object):
         """
         Run a search over this database partition.
 
-        See :func:`~database.CloudantDatabase.get_search_result`.
+        See :meth:`~cloudant.database.CloudantDatabase.get_search_result` for a
+        full list of supported parameters.
 
         :return: The result.
         """
@@ -82,7 +223,8 @@ class DatabasePartition(object):
         """
         Run a view over this database partition.
 
-        See :func:`~database.CouchDatabase.get_view_result`.
+        See :meth:`~cloudant.database.CouchDatabase.get_view_result` for a full
+        list of supported parameters.
 
         :return: The result.
         """

--- a/src/cloudant/database_partition.py
+++ b/src/cloudant/database_partition.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+# Copyright (C) 2018 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Database partition.
+"""
+
+
+class CouchDatabasePartition(object):
+    """
+    CouchDB database partition.
+
+    :param partition_key: Partition key as string.
+    """
+    def __init__(self, db, partition_key):
+        self._db = db
+        self._partition_key = partition_key
+
+    def __contains__(self, item):
+        return self._db.__contains__(self._get_doc_id(item))
+
+    def __getitem__(self, item):
+        return self._db.__getitem__(self._get_doc_id(item))
+
+    def _get_doc_id(self, doc_key):
+        """
+        Get document ID.
+
+        :param doc_key: Document key as string.
+        :return: Document ID as string.
+        """
+        return '{partition_key}:{doc_key}'.format(
+            partition_key=self._partition_key,
+            doc_key=doc_key
+        )
+
+    @property
+    def partition_key(self):
+        """
+        Get partition key.
+
+        :return: Partition key as string.
+        """
+        return self._partition_key
+
+    def query(self, *args, **kwargs):
+        """
+        Run a query over this database partition.
+
+        See :func:`~database.CouchDatabase.get_query_result`.
+
+        :return: The result.
+        """
+        return self._db.get_query_result(*args,
+                                         partition_key=self._partition_key,
+                                         **kwargs)
+
+    def view(self, *args, **kwargs):
+        """
+        Run a view over this database partition.
+
+        See :func:`~database.CouchDatabase.get_view_result`.
+
+        :return: The result.
+        """
+        return self._db.get_view_result(*args,
+                                        partition_key=self._partition_key,
+                                        **kwargs)
+
+
+class CloudantDatabasePartition(CouchDatabasePartition):
+    """
+    Cloudant database partition.
+    """
+    def search(self, *args, **kwargs):
+        """
+        Run a search over this database partition.
+
+        See :func:`~database.CloudantDatabase.get_search_result`.
+
+        :return: The result.
+        """
+        return self._db.get_search_result(*args,
+                                          partition_key=self._partition_key,
+                                          **kwargs)

--- a/src/cloudant/database_partition.py
+++ b/src/cloudant/database_partition.py
@@ -17,7 +17,7 @@ Database partition.
 """
 
 
-class CouchDatabasePartition(object):
+class DatabasePartition(object):
     """
     CouchDB database partition.
 
@@ -66,23 +66,6 @@ class CouchDatabasePartition(object):
                                          partition_key=self._partition_key,
                                          **kwargs)
 
-    def view(self, *args, **kwargs):
-        """
-        Run a view over this database partition.
-
-        See :func:`~database.CouchDatabase.get_view_result`.
-
-        :return: The result.
-        """
-        return self._db.get_view_result(*args,
-                                        partition_key=self._partition_key,
-                                        **kwargs)
-
-
-class CloudantDatabasePartition(CouchDatabasePartition):
-    """
-    Cloudant database partition.
-    """
     def search(self, *args, **kwargs):
         """
         Run a search over this database partition.
@@ -94,3 +77,15 @@ class CloudantDatabasePartition(CouchDatabasePartition):
         return self._db.get_search_result(*args,
                                           partition_key=self._partition_key,
                                           **kwargs)
+
+    def view(self, *args, **kwargs):
+        """
+        Run a view over this database partition.
+
+        See :func:`~database.CouchDatabase.get_view_result`.
+
+        :return: The result.
+        """
+        return self._db.get_view_result(*args,
+                                        partition_key=self._partition_key,
+                                        **kwargs)

--- a/src/cloudant/design_document.py
+++ b/src/cloudant/design_document.py
@@ -720,8 +720,9 @@ class DesignDocument(Document):
         """
         Retrieve the partition URL.
 
-        :param partition_key: Partition key as string.
-        :return: Partition URL as string.
+        :param str partition_key: Partition key.
+        :return: Partition URL.
+        :rtype: str
         """
         if self._document_id is None:
             return None

--- a/src/cloudant/index.py
+++ b/src/cloudant/index.py
@@ -45,13 +45,14 @@ class Index(object):
         :func:`~cloudant.database.CloudantDatabase.create_query_index`.
     """
 
-    def __init__(self, database, design_document_id=None, name=None, **kwargs):
+    def __init__(self, database, design_document_id=None, name=None, partitioned=False, **kwargs):
         self._database = database
         self._r_session = self._database.r_session
         self._ddoc_id = design_document_id
         self._name = name
         self._type = JSON_INDEX_TYPE
         self._def = kwargs
+        self._partitioned = partitioned
 
     @property
     def index_url(self):
@@ -100,6 +101,16 @@ class Index(object):
         """
         return self._def
 
+    @property
+    def partitioned(self):
+        """
+        Establish if this index is partitioned.
+
+        :return: True if index is partitioned, else False.
+        """
+
+        return self._partitioned
+
     def as_a_dict(self):
         """
         Displays the index as a dictionary.  This includes the design document
@@ -113,6 +124,9 @@ class Index(object):
             'type': self._type,
             'def': self._def
         }
+
+        if self._partitioned:
+            index_dict['partitioned'] = True
 
         return index_dict
 
@@ -136,6 +150,9 @@ class Index(object):
                 raise CloudantArgumentError(123, self._name)
         self._def_check()
         payload['index'] = self._def
+
+        if self._partitioned:
+            payload['partitioned'] = True
 
         headers = {'Content-Type': 'application/json'}
         resp = self._r_session.post(

--- a/src/cloudant/query.py
+++ b/src/cloudant/query.py
@@ -19,7 +19,7 @@ API module for composing and executing Cloudant queries.
 import json
 import contextlib
 
-from ._2to3 import iteritems_
+from ._2to3 import iteritems_, url_quote_plus
 from .result import QueryResult
 from .error import CloudantArgumentError
 from ._common_util import QUERY_ARG_TYPES
@@ -92,6 +92,7 @@ class Query(dict):
     def __init__(self, database, **kwargs):
         super(Query, self).__init__()
         self._database = database
+        self._partition_key = kwargs.pop('partition_key', None)
         self._r_session = self._database.r_session
         self._encoder = self._database.client.encoder
         if kwargs:
@@ -105,6 +106,10 @@ class Query(dict):
 
         :returns: Query URL
         """
+        if self._partition_key:
+            return '/'.join((self._database.database_url, '_partition',
+                             url_quote_plus(self._partition_key), '_find'))
+
         return '/'.join((self._database.database_url, '_find'))
 
     def __call__(self, **kwargs):

--- a/src/cloudant/view.py
+++ b/src/cloudant/view.py
@@ -94,6 +94,7 @@ class View(dict):
             view_name,
             map_func=None,
             reduce_func=None,
+            partition_key=None,
             **kwargs
     ):
         super(View, self).__init__()
@@ -104,6 +105,7 @@ class View(dict):
             self['map'] = codify(map_func)
         if reduce_func is not None:
             self['reduce'] = codify(reduce_func)
+        self._partition_key = partition_key
         self.update(kwargs)
         self.result = Result(self)
 
@@ -167,6 +169,10 @@ class View(dict):
 
         :returns: View URL
         """
+        if self._partition_key:
+            return '/'.join((self.design_doc.partition_url(self._partition_key),
+                             '_view', self.view_name))
+
         return '/'.join((
             self.design_doc.document_url,
             '_view',

--- a/tests/unit/database_partition.py
+++ b/tests/unit/database_partition.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python
+# Copyright (C) 2018 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+_database_partition_tests_
+"""
+
+import unittest
+import mock
+
+from cloudant.client import Cloudant
+
+
+class DatabasePartitionTests(unittest.TestCase):
+
+    def __init__(self, *arg, **kwargs):
+        super(DatabasePartitionTests, self).__init__(*arg, **kwargs)
+
+        self.client = Cloudant('foo', 'bar', account='foo', use_basic_auth=True)
+        self.client.connect()
+
+        self.mock_200 = mock.MagicMock()
+        type(self.mock_200).status_code = mock.PropertyMock(return_value=200)
+        self.mock_200.json.return_value = {'ok': True}
+
+        self.mock_404 = mock.MagicMock()
+        type(self.mock_404).status_code = mock.PropertyMock(return_value=404)
+        self.mock_404.json.return_value = {'error': 'missing'}
+
+        self.mock_empty_results = mock.MagicMock()
+        type(self.mock_200).status_code = mock.PropertyMock(return_value=200)
+        self.mock_200.json.return_value = {'docs': []}
+
+    @mock.patch('cloudant._client_session.ClientSession.request')
+    def test_create_partitioned_database(self, m_req):
+        m_req.side_effect = [self.mock_404, self.mock_200]
+
+        db = self.client.create_database('partitioned_db_1', partitioned=True)
+        self.assertTrue(db.partitioned)
+
+        self.assertEquals(m_req.call_count, 2)
+
+        m_req.assert_has_calls([
+            mock.call('HEAD', 'https://foo.cloudant.com/partitioned_db_1',
+                      allow_redirects=False, auth=('foo', 'bar')),
+            mock.call('PUT', 'https://foo.cloudant.com/partitioned_db_1',
+                      auth=('foo', 'bar'), data=None,
+                      params={'partitioned': True})
+        ])
+
+    @mock.patch('cloudant._client_session.ClientSession.request')
+    def test_database_partition_query(self, m_req):
+        m_req.side_effects = [
+            self.mock_404,
+            self.mock_200,
+            self.mock_empty_results
+        ]
+
+        db = self.client.create_database('partitioned_db_2', partitioned=True)
+        self.assertTrue(db.partitioned)
+
+        result = db.partition('partition_key_a')\
+                   .query(selector={'name': {'$eq': 'foo'}})
+
+        docs = [doc for doc in result]  # trigger query fetch
+        self.assertEquals(len(docs), 0)
+
+        self.assertEquals(m_req.call_count, 3)
+
+        calls = [
+            mock.call('HEAD', 'https://foo.cloudant.com/partitioned_db_2',
+                      allow_redirects=False, auth=('foo', 'bar')),
+            mock.call('PUT', 'https://foo.cloudant.com/partitioned_db_2',
+                      auth=('foo', 'bar'), data=None,
+                      params={'partitioned': True}),
+            mock.call('POST',
+                      'https://foo.cloudant.com/partitioned_db_2/_partition/partition_key_a/_find',
+                      auth=('foo', 'bar'),
+                      data='{"skip": 0, "limit": 100, "selector": {"name": {"$eq": "foo"}}}',
+                      headers={'Content-Type': 'application/json'}, json=None)
+        ]
+
+        self.assertTrue(all([call in m_req.call_args_list for call in calls]))
+
+    @mock.patch('cloudant._client_session.ClientSession.request')
+    def test_database_partition_search(self, m_req):
+        m_req.side_effects = [
+            self.mock_404,
+            self.mock_200,
+            self.mock_empty_results
+        ]
+
+        db = self.client.create_database('partitioned_db_3', partitioned=True)
+        self.assertTrue(db.partitioned)
+
+        result = db.partition('partition_key_b')\
+                   .search('ddoc001', 'searchindex001', query='name:julia*')
+
+        docs = [doc for doc in result]  # trigger query fetch
+        self.assertEquals(len(docs), 0)
+
+        self.assertEquals(m_req.call_count, 3)
+
+        calls = [
+            mock.call('HEAD', 'https://foo.cloudant.com/partitioned_db_3',
+                      allow_redirects=False, auth=('foo', 'bar')),
+            mock.call('PUT', 'https://foo.cloudant.com/partitioned_db_3',
+                      auth=('foo', 'bar'), data=None,
+                      params={'partitioned': True}),
+            mock.call('POST',
+                      'https://foo.cloudant.com/partitioned_db_3/_partition/partition_key_b/_design/ddoc001/_search/searchindex001',
+                      auth=('foo', 'bar'), data='{"query": "name:julia*"}',
+                      headers={'Content-Type': 'application/json'}, json=None)
+        ]
+
+        self.assertTrue(all([call in m_req.call_args_list for call in calls]))
+
+    @mock.patch('cloudant._client_session.ClientSession.request')
+    def test_database_partition_view(self, m_req):
+        m_req.side_effects = [
+            self.mock_404,
+            self.mock_200,
+            self.mock_empty_results
+        ]
+
+        db = self.client.create_database('partitioned_db_4', partitioned=True)
+        self.assertTrue(db.partitioned)
+
+        result = db.partition('partition_key_c')\
+                   .view('ddoc', 'my_view')
+
+        docs = [doc for doc in result]  # trigger query fetch
+        self.assertEquals(len(docs), 0)
+
+        self.assertEquals(m_req.call_count, 3)
+
+        calls = [
+            mock.call('HEAD', 'https://foo.cloudant.com/partitioned_db_4',
+                      allow_redirects=False, auth=('foo', 'bar')),
+            mock.call('PUT', 'https://foo.cloudant.com/partitioned_db_4',
+                      auth=('foo', 'bar'), data=None,
+                      params={'partitioned': True}),
+            mock.call('GET',
+                      'https://foo.cloudant.com/partitioned_db_4/_partition/partition_key_c/_design/ddoc/_view/my_view',
+                      allow_redirects=True, auth=('foo', 'bar'), headers=None,
+                      params={'skip': 0, 'limit': 100})
+        ]
+
+        self.assertTrue(all([call in m_req.call_args_list for call in calls]))

--- a/tests/unit/database_partition.py
+++ b/tests/unit/database_partition.py
@@ -56,7 +56,7 @@ class DatabasePartitionTests(unittest.TestCase):
                       allow_redirects=False, auth=('foo', 'bar')),
             mock.call('PUT', 'https://foo.cloudant.com/partitioned_db_1',
                       auth=('foo', 'bar'), data=None,
-                      params={'partitioned': True})
+                      params={'partitioned': 'true'})
         ])
 
     @mock.patch('cloudant._client_session.ClientSession.request')
@@ -83,7 +83,7 @@ class DatabasePartitionTests(unittest.TestCase):
                       allow_redirects=False, auth=('foo', 'bar')),
             mock.call('PUT', 'https://foo.cloudant.com/partitioned_db_2',
                       auth=('foo', 'bar'), data=None,
-                      params={'partitioned': True}),
+                      params={'partitioned': 'true'}),
             mock.call('POST',
                       'https://foo.cloudant.com/partitioned_db_2/_partition/partition_key_a/_find',
                       auth=('foo', 'bar'),
@@ -117,7 +117,7 @@ class DatabasePartitionTests(unittest.TestCase):
                       allow_redirects=False, auth=('foo', 'bar')),
             mock.call('PUT', 'https://foo.cloudant.com/partitioned_db_3',
                       auth=('foo', 'bar'), data=None,
-                      params={'partitioned': True}),
+                      params={'partitioned': 'true'}),
             mock.call('POST',
                       'https://foo.cloudant.com/partitioned_db_3/_partition/partition_key_b/_design/ddoc001/_search/searchindex001',
                       auth=('foo', 'bar'), data='{"query": "name:julia*"}',
@@ -150,7 +150,7 @@ class DatabasePartitionTests(unittest.TestCase):
                       allow_redirects=False, auth=('foo', 'bar')),
             mock.call('PUT', 'https://foo.cloudant.com/partitioned_db_4',
                       auth=('foo', 'bar'), data=None,
-                      params={'partitioned': True}),
+                      params={'partitioned': 'true'}),
             mock.call('GET',
                       'https://foo.cloudant.com/partitioned_db_4/_partition/partition_key_c/_design/ddoc/_view/my_view',
                       allow_redirects=True, auth=('foo', 'bar'), headers=None,

--- a/tests/unit/database_partition.py
+++ b/tests/unit/database_partition.py
@@ -70,7 +70,7 @@ class DatabasePartitionTests(unittest.TestCase):
         db = self.client.create_database('partitioned_db_2', partitioned=True)
         self.assertTrue(db.partitioned)
 
-        result = db.partition('partition_key_a')\
+        result = db.get_partition('partition_key_a')\
                    .query(selector={'name': {'$eq': 'foo'}})
 
         docs = [doc for doc in result]  # trigger query fetch
@@ -104,7 +104,7 @@ class DatabasePartitionTests(unittest.TestCase):
         db = self.client.create_database('partitioned_db_3', partitioned=True)
         self.assertTrue(db.partitioned)
 
-        result = db.partition('partition_key_b')\
+        result = db.get_partition('partition_key_b')\
                    .search('ddoc001', 'searchindex001', query='name:julia*')
 
         docs = [doc for doc in result]  # trigger query fetch
@@ -137,7 +137,7 @@ class DatabasePartitionTests(unittest.TestCase):
         db = self.client.create_database('partitioned_db_4', partitioned=True)
         self.assertTrue(db.partitioned)
 
-        result = db.partition('partition_key_c')\
+        result = db.get_partition('partition_key_c')\
                    .view('ddoc', 'my_view')
 
         docs = [doc for doc in result]  # trigger query fetch

--- a/tests/unit/database_partition.py
+++ b/tests/unit/database_partition.py
@@ -47,7 +47,6 @@ class DatabasePartitionTests(unittest.TestCase):
         m_req.side_effect = [self.mock_404, self.mock_200]
 
         db = self.client.create_database('partitioned_db_1', partitioned=True)
-        self.assertTrue(db.partitioned)
 
         self.assertEquals(m_req.call_count, 2)
 
@@ -68,7 +67,6 @@ class DatabasePartitionTests(unittest.TestCase):
         ]
 
         db = self.client.create_database('partitioned_db_2', partitioned=True)
-        self.assertTrue(db.partitioned)
 
         result = db.get_partition('partition_key_a')\
                    .query(selector={'name': {'$eq': 'foo'}})
@@ -102,7 +100,6 @@ class DatabasePartitionTests(unittest.TestCase):
         ]
 
         db = self.client.create_database('partitioned_db_3', partitioned=True)
-        self.assertTrue(db.partitioned)
 
         result = db.get_partition('partition_key_b')\
                    .search('ddoc001', 'searchindex001', query='name:julia*')
@@ -135,7 +132,6 @@ class DatabasePartitionTests(unittest.TestCase):
         ]
 
         db = self.client.create_database('partitioned_db_4', partitioned=True)
-        self.assertTrue(db.partitioned)
 
         result = db.get_partition('partition_key_c')\
                    .view('ddoc', 'my_view')


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [ ] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
This PR introduces a new feature, user-defined partitioned databases.

A new kind of database can be created with the `?partitioned=true` option. All documents within the database must have document ids of the following format;

`partition_name:doc_id`

both `partition_name` and `doc_id` must follow the couchdb id format (can't begin with _, etc).

All documents with the same partition_name are guaranteed to be mapped to the same shard range. When querying an index, the new `/db/_partition/$partition/_view` endpoint can query the view more efficiently, by only consulting the single shard range holding the partition. This is much more efficient and scales the same way that primary key lookup (`GET /dbname/docid`) does (approximately linearly).
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

## Approach
TODO
<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes
TODO
<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy
TODO
<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing
TODO
<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
TODO
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->

## Examples

- Create partitioned database:
```py
db = self.client.create_database('partitioned_db_1', partitioned=True)
```

- Run partitioned query:
```py
result = db.partition('partition_key_a').query(selector={'name': {'$eq': 'foo'}})
```

- Run partitioned search:
```py
result = db.partition('partition_key_a').search('ddoc001', 'searchindex001', query='name:julia*')
```

- Run partitioned view:
```py
result = db.partition('partition_key_a').view('ddoc', 'my_view')
```