### PR TITLE
414 decode content

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- [FIXED] A performance regression deserializing JSON in version 2.10.1.
+
 # 2.10.1 (2018-11-16)
 
 - [FIXED] Unexpected keyword argument errors when using the library with the

--- a/src/cloudant/_client_session.py
+++ b/src/cloudant/_client_session.py
@@ -95,12 +95,14 @@ class ClientSession(Session):
         """
         No-op method - not implemented here.
         """
+        # pylint: disable=unnecessary-pass
         pass
 
     def logout(self):
         """
         No-op method - not implemented here.
         """
+        # pylint: disable=unnecessary-pass
         pass
 
 

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -288,6 +288,8 @@ def response_to_json_dict(response, **kwargs):
 
     :returns: dict of JSON response
     """
+    if response.encoding is None:
+        response.encoding = 'utf-8'
     return json.loads(response.text, **kwargs)
 
 # Classes


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Added `encoding='utf-8'` to responses to avoid slow `chardet` path.

Fixes #414 

## Approach

Check if the repsonse encoding is unset and if so set it to `utf-8`.
(Unrelated) Removed unnecessary`pass` statements causing lint failures.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- No new tests because this path is covered by existing tests. We don't have any performance tests where we could automatically validate that this fix works or check for regressions.

## Monitoring and Logging

- "No change"
