### PR TITLE
Fixed type in docstring for get_query_result

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [IMPROVED] Updated `Getting started` section with a `get_query_result` example. 
+- [FIXED] Fixed type for `selector` in docstring of the `get_query_result` function.
 
 # 2.11.0 (2019-01-21)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 - [IMPROVED] Updated `Getting started` section with a `get_query_result` example. 
-- [FIXED] Fixed type for `selector` in docstring of the `get_query_result` function.
+- [FIXED] Fixed parameter type of `selector` in docstring.
 
 # 2.11.0 (2019-01-21)
 

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2015, 2018 IBM Corp. All rights reserved.
+# Copyright (C) 2015, 2019 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -1112,7 +1112,7 @@ class CouchDatabase(dict):
         For more detail on slicing and iteration, refer to the
         :class:`~cloudant.result.QueryResult` documentation.
 
-        :param str selector: Dictionary object describing criteria used to
+        :param dict selector: Dictionary object describing criteria used to
             select documents.
         :param list fields: A list of fields to be returned by the query.
         :param bool raw_result: Dictates whether the query result is returned

--- a/src/cloudant/query.py
+++ b/src/cloudant/query.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2015, 2018 IBM. All rights reserved.
+# Copyright (C) 2015, 2019 IBM. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/cloudant/query.py
+++ b/src/cloudant/query.py
@@ -75,7 +75,7 @@ class Query(dict):
     :param int limit: Maximum number of results returned.
     :param int r: Read quorum needed for the result.  Each document is read from
         at least 'r' number of replicas before it is returned in the results.
-    :param str selector: Dictionary object describing criteria used to select
+    :param dict selector: Dictionary object describing criteria used to select
         documents.
     :param int skip: Skip the first 'n' results, where 'n' is the value
         specified.
@@ -137,7 +137,7 @@ class Query(dict):
         :param int r: Read quorum needed for the result.  Each document is read
             from at least 'r' number of replicas before it is returned in the
             results.
-        :param str selector: Dictionary object describing criteria used to
+        :param dict selector: Dictionary object describing criteria used to
             select documents.
         :param int skip: Skip the first 'n' results, where 'n' is the value
             specified.
@@ -201,7 +201,7 @@ class Query(dict):
         :param int r: Read quorum needed for the result.  Each document is read
             from at least 'r' number of replicas before it is returned in the
             results.
-        :param str selector: Dictionary object describing criteria used to
+        :param dict selector: Dictionary object describing criteria used to
             select documents.
         :param list sort: A list of fields to sort by.  Optionally the list can
             contain elements that are single member dictionary structures that

--- a/src/cloudant/result.py
+++ b/src/cloudant/result.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2015, 2018 IBM Corp. All rights reserved.
+# Copyright (C) 2015, 2019 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/cloudant/result.py
+++ b/src/cloudant/result.py
@@ -454,7 +454,7 @@ class QueryResult(Result):
     :param int r: Read quorum needed for the result.  Each document is read
         from at least 'r' number of replicas before it is returned in the
         results.
-    :param str selector: Dictionary object describing criteria used to
+    :param dict selector: Dictionary object describing criteria used to
         select documents.
     :param list sort: A list of fields to sort by.  Optionally the list can
         contain elements that are single member dictionary structures that


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Fixed type for `selector` in docstring of the `get_query_result` function.

fixes #424 

## Approach
- Updated `str` to `dict` in `get_query_result` docstring
- Merged @thesimj's work into this branch (483ff9b) that updates the parameter for `selector` in `query.py` and` result.py `docstrings.


## Schema & API Changes

- "No change"
## Security and Privacy

- "No change"
## Testing

N/A

## Monitoring and Logging
- "No change"