### PR TITLE
correct docsting for param `selector` from str to dict

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 - [IMPROVED] Updated `Getting started` section with a `get_query_result` example. 
-- [FIXED] Fixed type for `selector` in docstring of the `get_query_result` function.
+- [FIXED] Fixed parameter type of `selector` in docstring.
 
 # 2.11.0 (2019-01-21)
 

--- a/src/cloudant/query.py
+++ b/src/cloudant/query.py
@@ -75,7 +75,7 @@ class Query(dict):
     :param int limit: Maximum number of results returned.
     :param int r: Read quorum needed for the result.  Each document is read from
         at least 'r' number of replicas before it is returned in the results.
-    :param str selector: Dictionary object describing criteria used to select
+    :param dict selector: Dictionary object describing criteria used to select
         documents.
     :param int skip: Skip the first 'n' results, where 'n' is the value
         specified.
@@ -137,7 +137,7 @@ class Query(dict):
         :param int r: Read quorum needed for the result.  Each document is read
             from at least 'r' number of replicas before it is returned in the
             results.
-        :param str selector: Dictionary object describing criteria used to
+        :param dict selector: Dictionary object describing criteria used to
             select documents.
         :param int skip: Skip the first 'n' results, where 'n' is the value
             specified.
@@ -201,7 +201,7 @@ class Query(dict):
         :param int r: Read quorum needed for the result.  Each document is read
             from at least 'r' number of replicas before it is returned in the
             results.
-        :param str selector: Dictionary object describing criteria used to
+        :param dict selector: Dictionary object describing criteria used to
             select documents.
         :param list sort: A list of fields to sort by.  Optionally the list can
             contain elements that are single member dictionary structures that

--- a/src/cloudant/result.py
+++ b/src/cloudant/result.py
@@ -454,7 +454,7 @@ class QueryResult(Result):
     :param int r: Read quorum needed for the result.  Each document is read
         from at least 'r' number of replicas before it is returned in the
         results.
-    :param str selector: Dictionary object describing criteria used to
+    :param dict selector: Dictionary object describing criteria used to
         select documents.
     :param list sort: A list of fields to sort by.  Optionally the list can
         contain elements that are single member dictionary structures that


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Correct docsting for argument param `selector` from `str` to `dict`

Fixes #424

## Approach
Find `selector` in the library and correct documentations

## Schema & API Changes
- No change

## Security and Privacy
- No change

## Testing
- No new tests because it's only change in documentations

## Monitoring and Logging
- No change