### PR TITLE
Document.atomic context manager

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 - [IMPROVED] Updated `Getting started` section with a `get_query_result` example. 
 - [FIXED] Fixed parameter type of `selector` in docstring.
+- [NEW] `Document.atomic` context manager.
 
 # 2.11.0 (2019-01-21)
 

--- a/src/cloudant/document.py
+++ b/src/cloudant/document.py
@@ -18,6 +18,7 @@ API module/class for interacting with a document in a database.
 import json
 import requests
 from requests.exceptions import HTTPError
+from contextlib import contextmanager
 
 from ._2to3 import url_quote, url_quote_plus
 from ._common_util import response_to_json_dict
@@ -347,6 +348,14 @@ class Document(dict):
         logic.  Executes a Document.save() upon exit.
         """
         self.save()
+
+    @contextmanager
+    def atomic(self):
+        """
+        Context manager that only save if there is no exceptions in inner block.
+        """
+        yield self.__enter__()
+        self.__exit__()
 
     def __setitem__(self, key, value):
         """


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
This PR implements a `Document.atomic` context manager that don't save a document if there is any uncatched exception in inner code block. Tentatively fixes #427.

## Approach

As this change could be breaking (in fact it change a default behaviour) I've decided to implement a brand new context manager using python's contextlib.
When it's needed, one could use `atomic` as a context manager:
```python
with Document(self.db, 'julia006').atomic() as doc:
```
Context Manager implementation follow current one, in fact it uses the [same dunders](https://github.com/aogier/python-cloudant/commit/00c339f635ff5c777c4685d48d1887ebae10de4d#diff-396eae97315a21001968a65d1ed17e61R352).

## Schema & API Changes

- Added a new `Document.atomic` context manager

## Security and Privacy

- "No change"

## Testing

- Added new tests:
    - unit.document_tests.test_document_context_manager_atomic_creation_failure
    - unit.document_tests.test_document_context_manager_atomic_update_failure

## Monitoring and Logging

- "No change"
