### PR TITLE
Document.save on create/change only

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - [IMPROVED] Updated `Getting started` section with a `get_query_result` example.
 - [FIXED] Removed internal `Document._document_id` property to allow a safe use of
   dict's methods.
+- [IMPROVED] `Document.save` only when creating or local copy changed.
 
 # 2.11.0 (2019-01-21)
 


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Trivial change that commit to remote db only when creating or actually changing local data.

Current behaviour:

```python
doc = Document(self.db, 'http://example.com')
doc.save()
doc.save()
# doc _rev is now 2-
```

New behaviour:

```python
doc = Document(self.db, 'http://example.com')
doc.save()
doc.save()
# doc _rev is still 1-
```

## Approach

Implemented a simple boolean check that flip upon Document's dict update methods calls. Document will still be created even if empty, but save will only happen when an actual change is made, minimizing data transfers.

## Schema & API Changes

- `Document.save` only when creating or local copy changed.

## Security and Privacy

- "No change"

## Testing

- Added new tests:
    - tests.unit.document_tests.test_not_update_unchanged_document

## Monitoring and Logging

- "No change"
