### PR TITLE
Stop document context manager from saving if an error is raised.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,9 @@
 # Unreleased
 
-- [IMPROVED] Updated `Getting started` section with a `get_query_result` example. 
+- [FIXED] Bug where document context manager performed remote save despite
+  uncaught exceptions being raised inside `with` block.
 - [FIXED] Fixed parameter type of `selector` in docstring.
+- [IMPROVED] Updated `Getting started` section with a `get_query_result` example.
 
 # 2.11.0 (2019-01-21)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,6 +21,8 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
 
+sys.path.insert(0, os.path.abspath('../src'))
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -441,41 +441,45 @@ multiple updates to a single document. Note that we don't save to the server
 after each update. We only save once to the server upon exiting the ``Document``
 context manager.
 
- .. code-block:: python
+.. warning:: Uncaught exceptions inside the ``with`` block will prevent your
+             document changes being saved to the remote server. However, changes
+             will still be applied to your local document object.
 
-    from cloudant import cloudant
-    from cloudant.document import Document
+.. code-block:: python
 
-    with cloudant(USERNAME, PASSWORD, account=ACCOUNT_NAME) as client:
+   from cloudant import cloudant
+   from cloudant.document import Document
 
-        my_database = client.create_database('my_database')
+   with cloudant(USERNAME, PASSWORD, account=ACCOUNT_NAME) as client:
 
-        # Upon entry into the document context, fetches the document from the
-        # remote database, if it exists. Upon exit from the context, saves the
-        # document to the remote database with changes made within the context
-        # or creates a new document.
-        with Document(database, 'julia006') as document:
-            # If document exists, it's fetched from the remote database
-            # Changes are made locally
-            document['name'] = 'Julia'
-            document['age'] = 6
-            # The document is saved to the remote database
+       my_database = client.create_database('my_database')
 
-        # Display a Document
-        print(my_database['julia30'])
-    
-        # Delete the database
-        client.delete_database('my_database')
+       # Upon entry into the document context, fetches the document from the
+       # remote database, if it exists. Upon exit from the context, saves the
+       # document to the remote database with changes made within the context
+       # or creates a new document.
+       with Document(database, 'julia006') as document:
+           # If document exists, it's fetched from the remote database
+           # Changes are made locally
+           document['name'] = 'Julia'
+           document['age'] = 6
+           # The document is saved to the remote database
 
-        print('Databases: {0}'.format(client.all_dbs()))
+       # Display a Document
+       print(my_database['julia30'])
+
+       # Delete the database
+       client.delete_database('my_database')
+
+       print('Databases: {0}'.format(client.all_dbs()))
 
 Always use the ``_deleted`` document property to delete a document from within
 a ``Document`` context manager. For example:
 
- .. code-block:: python
+.. code-block:: python
 
-    with Document(my_database, 'julia30') as doc:
-        doc['_deleted'] = True
+   with Document(my_database, 'julia30') as doc:
+       doc['_deleted'] = True
 
 *You can also delete non underscore prefixed document keys to reduce the size of the request.*
 

--- a/src/cloudant/document.py
+++ b/src/cloudant/document.py
@@ -341,12 +341,13 @@ class Document(dict):
 
         return self
 
-    def __exit__(self, *args):
+    def __exit__(self, exc_type, exc_value, traceback):
         """
-        Support context like editing of document fields.  Handles context exit
-        logic.  Executes a Document.save() upon exit.
+        Support context like editing of document fields. Handles context exit
+        logic. Executes a `Document.save()` upon exit if no exception occurred.
         """
-        self.save()
+        if exc_type is None:
+            self.save()
 
     def __setitem__(self, key, value):
         """


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->
Fix bug where document CM performed save in event of uncaught exception.

## Schema & API Changes

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->
No change.

## Security and Privacy

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->
No change.

## Testing

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->
Includes 2 additional unit tests.

## Monitoring and Logging
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
No change.
