### PR TITLE
Removed document._document_id logic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
   uncaught exceptions being raised inside `with` block.
 - [FIXED] Fixed parameter type of `selector` in docstring.
 - [IMPROVED] Updated `Getting started` section with a `get_query_result` example.
+- [FIXED] Removed internal `Document._document_id` property to allow a safe use of
+  dict's methods.
 
 # 2.11.0 (2019-01-21)
 

--- a/tests/unit/document_tests.py
+++ b/tests/unit/document_tests.py
@@ -680,10 +680,8 @@ class DocumentTests(UnitTestDbBase):
         """
         doc = Document(self.db)
         self.assertIsNone(doc.get('_id'))
-        self.assertEqual(doc._document_id, None)
         doc['_id'] = 'julia006'
         self.assertEqual(doc['_id'], 'julia006')
-        self.assertEqual(doc._document_id, 'julia006')
 
     def test_removing_id(self):
         """
@@ -693,7 +691,6 @@ class DocumentTests(UnitTestDbBase):
         doc['_id'] = 'julia006'
         del doc['_id']
         self.assertIsNone(doc.get('_id'))
-        self.assertEqual(doc._document_id, None)
 
     def test_get_text_attachment(self):
         """


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Removing _document_id logic so dict's updating methods work by default.
Fixes #430 

## Approach

Removed _document_id logic from Document class, now everything works based in `_id` property instead.


## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- No new tests because current ones are enough

## Monitoring and Logging

- "No change"
