### PR TITLE
paginate by startkey

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [IMPROVED] Updated `Result` iteration by paginating with views' `startkey` and
+  queries' `bookmark`.
 - [FIXED] Bug where document context manager performed remote save despite
   uncaught exceptions being raised inside `with` block.
 - [FIXED] Fixed parameter type of `selector` in docstring.

--- a/src/cloudant/client.py
+++ b/src/cloudant/client.py
@@ -629,9 +629,9 @@ class Cloudant(CouchDB):
 
         if err:
             raise CloudantArgumentError(101, year, month)
-        else:
-            resp.raise_for_status()
-            return response_to_json_dict(resp)
+
+        resp.raise_for_status()
+        return response_to_json_dict(resp)
 
     def bill(self, year=None, month=None):
         """

--- a/tests/unit/query_result_tests.py
+++ b/tests/unit/query_result_tests.py
@@ -425,20 +425,10 @@ class QueryResultTests(UnitTestDbBase):
 
     def test_iteration_with_invalid_options(self):
         """
-        Test that iteration raises an exception when "skip" and/or "limit" are
-        used as options for the result.
+        Test that iteration raises an exception when "limit" is
+        used as option for the result.
         """
-        result = self.create_result(q_parms={'skip': 10})
-        with self.assertRaises(ResultException) as cm:
-            invalid_result = [row for row in result]
-        self.assertEqual(cm.exception.status_code, 103)
-
         result = self.create_result(q_parms={'limit': 10})
-        with self.assertRaises(ResultException) as cm:
-            invalid_result = [row for row in result]
-        self.assertEqual(cm.exception.status_code, 103)
-
-        result = self.create_result(q_parms={'limit': 10, 'skip': 10})
         with self.assertRaises(ResultException) as cm:
             invalid_result = [row for row in result]
         self.assertEqual(cm.exception.status_code, 103)

--- a/tests/unit/unit_t_db_base.py
+++ b/tests/unit/unit_t_db_base.py
@@ -314,6 +314,10 @@ class UnitTestDbBase(unittest.TestCase):
             'function (doc) {\n emit([doc.name, doc.age], 1);\n}',
             '_count'
         )
+        self.ddoc.add_view(
+            'view007',
+            'function (doc) {\n emit(1, doc.name);\n}'
+        )
         self.ddoc.save()
         self.view001 = self.ddoc.get_view('view001')
         self.view002 = self.ddoc.get_view('view002')
@@ -321,6 +325,7 @@ class UnitTestDbBase(unittest.TestCase):
         self.view004 = self.ddoc.get_view('view004')
         self.view005 = self.ddoc.get_view('view005')
         self.view006 = self.ddoc.get_view('view006')
+        self.view007 = self.ddoc.get_view('view007')
 
     def create_search_index(self):
         """


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Make `Result`'s iteration faster paginating by `startkey` instead of `skip`.

Fixes #436 

## Approach

As per #436 , paginating by `skip` could be super-slow. This patch fix the problem by using `startkey` so every iteration run in constant time.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- No new tests because current ones are enough

## Monitoring and Logging

- "No change"
