### PR TITLE
halves memory usage Result iterator side

### DIFF
--- a/src/cloudant/result.py
+++ b/src/cloudant/result.py
@@ -379,6 +379,7 @@ class Result(object):
 
         while True:
             result = self._parse_data(response)
+            del response
             if result:
                 doc_count = len(result)
                 last = result.pop()


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Working on #437 I've noticed this one that is trivial but effectively halves memory utilization during iteration. As we release ram before `yield` we let users exploit their memory for doing whatever they would (I've seen people/comments in the wild speaking about documents > hundred MB in size).

We could elaborate further implementing a FIFO on the iterator three lines below, eg. with a deque that pops while iterating but this one alone already effectively halves ram.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- No new tests because current ones are enough

## Monitoring and Logging

- "No change"
