### PR TITLE
Partitioned databases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- [NEW] Added partitioned database support.
 - [IMPROVED] Updated `Result` iteration by paginating with views' `startkey` and
   queries' `bookmark`.
 - [FIXED] Bug where document context manager performed remote save despite

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,8 +33,9 @@ def setupPythonAndTest(pythonVersion, testSuite) {
       withEnv(getEnvForSuite("${testSuite}")) {
         try {
           sh """
-            virtualenv tmp -p /usr/local/lib/python${pythonVersion}/bin/${pythonVersion.startsWith('3') ? "python3" : "python"}
+            virtualenv tmp -p ${pythonVersion.startsWith('3') ? "python3" : "python"}
             . ./tmp/bin/activate
+            python --version
             pip install -r requirements.txt
             pip install -r test-requirements.txt
             ${'simplejson'.equals(testSuite) ? 'pip install simplejson' : ''}
@@ -60,8 +61,8 @@ stage('Checkout'){
 }
 
 stage('Test'){
-  def py2 = '2.7.12'
-  def py3 = '3.5.2'
+  def py2 = '2'
+  def py3 = '3'
   def axes = [:]
   [py2, py3].each { version ->
     ['basic','cookie','iam'].each { auth ->

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2015, 2018 IBM Corp. All rights reserved.
+# Copyright (C) 2015, 2019 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -140,7 +140,8 @@ SEARCH_INDEX_ARGS = {
     'highlight_post_tag': STRTYPE,
     'highlight_number': (int, LONGTYPE, NONETYPE),
     'highlight_size': (int, LONGTYPE, NONETYPE),
-    'include_fields': list
+    'include_fields': list,
+    'partition': STRTYPE
 }
 
 # Functions

--- a/src/cloudant/client.py
+++ b/src/cloudant/client.py
@@ -267,7 +267,7 @@ class CouchDB(dict):
         resp.raise_for_status()
         return response_to_json_dict(resp)
 
-    def create_database(self, dbname, **kwargs):
+    def create_database(self, dbname, partitioned=False, **kwargs):
         """
         Creates a new database on the remote server with the name provided
         and adds the new database object to the client's locally cached
@@ -279,10 +279,12 @@ class CouchDB(dict):
         :param bool throw_on_exists: Boolean flag dictating whether or
             not to throw a CloudantClientException when attempting to
             create a database that already exists.
+        :param bool partitioned: Create as a partitioned database. Defaults to
+            ``False``.
 
         :returns: The newly created database object
         """
-        new_db = self._DATABASE_CLASS(self, dbname)
+        new_db = self._DATABASE_CLASS(self, dbname, partitioned=partitioned)
         try:
             new_db.create(kwargs.get('throw_on_exists', False))
         except CloudantDatabaseException as ex:

--- a/src/cloudant/design_document.py
+++ b/src/cloudant/design_document.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2015, 2018 IBM. All rights reserved.
+# Copyright (C) 2015, 2019 IBM. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 """
 API module/class for interacting with a design document in a database.
 """
-from ._2to3 import iteritems_, STRTYPE
+from ._2to3 import iteritems_, url_quote_plus, STRTYPE
 from ._common_util import QUERY_LANGUAGE, codify, response_to_json_dict
 from .document import Document
 from .view import View, QueryIndexView
@@ -39,11 +39,18 @@ class DesignDocument(Document):
         either a ``CouchDatabase`` or ``CloudantDatabase`` instance.
     :param str document_id: Optional document id.  If provided and does not
         start with ``_design/``, it will be prepended with ``_design/``.
+    :param bool partitioned: Optional. Create as a partitioned design document.
+        Defaults to ``False`` for both partitioned and non-partitioned
+        databases.
     """
-    def __init__(self, database, document_id=None):
+    def __init__(self, database, document_id=None, partitioned=False):
         if document_id and not document_id.startswith('_design/'):
             document_id = '_design/{0}'.format(document_id)
         super(DesignDocument, self).__init__(database, document_id)
+
+        if partitioned:
+            self.setdefault('options', {'partitioned': True})
+
         self._nested_object_names = frozenset(['views', 'indexes', 'lists', 'shows'])
         for prop in self._nested_object_names:
             self.setdefault(prop, dict())
@@ -268,6 +275,20 @@ class DesignDocument(Document):
             as key/value
         """
         return self.get('indexes')
+
+    def document_partition_url(self, partition_key):
+        """
+        Retrieve the design document partition URL.
+
+        :param str partition_key: Partition key.
+        :return: Design document partition URL.
+        :rtype: str
+        """
+        return '/'.join((
+            self._database.database_partition_url(partition_key),
+            '_design',
+            url_quote_plus(self['_id'][8:], safe='')
+        ))
 
     def add_view(self, view_name, map_func, reduce_func=None, **kwargs):
         """

--- a/src/cloudant/index.py
+++ b/src/cloudant/index.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2015, 2018 IBM. All rights reserved.
+# Copyright (C) 2015, 2019 IBM. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,18 +40,21 @@ class Index(object):
         Index.
     :param str design_document_id: Optional identifier of the design document.
     :param str name: Optional name of the index.
+    :param bool partitioned: Optional. Create as a partitioned index. Defaults
+        to ``False`` for both partitioned and non-partitioned databases.
     :param kwargs: Options used to construct the index definition for the
         purposes of index creation.  For more details on valid options See
         :func:`~cloudant.database.CloudantDatabase.create_query_index`.
     """
 
-    def __init__(self, database, design_document_id=None, name=None, **kwargs):
+    def __init__(self, database, design_document_id=None, name=None, partitioned=False, **kwargs):
         self._database = database
         self._r_session = self._database.r_session
         self._ddoc_id = design_document_id
         self._name = name
         self._type = JSON_INDEX_TYPE
         self._def = kwargs
+        self._partitioned = partitioned
 
     @property
     def index_url(self):
@@ -100,6 +103,17 @@ class Index(object):
         """
         return self._def
 
+    @property
+    def partitioned(self):
+        """
+        Check if this index is partitioned.
+
+        :return: ``True`` if index is partitioned, else ``False``.
+        :rtype: bool
+        """
+
+        return self._partitioned
+
     def as_a_dict(self):
         """
         Displays the index as a dictionary.  This includes the design document
@@ -113,6 +127,9 @@ class Index(object):
             'type': self._type,
             'def': self._def
         }
+
+        if self._partitioned:
+            index_dict['partitioned'] = True
 
         return index_dict
 
@@ -136,6 +153,9 @@ class Index(object):
                 raise CloudantArgumentError(123, self._name)
         self._def_check()
         payload['index'] = self._def
+
+        if self._partitioned:
+            payload['partitioned'] = True
 
         headers = {'Content-Type': 'application/json'}
         resp = self._r_session.post(

--- a/src/cloudant/view.py
+++ b/src/cloudant/view.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2015, 2018 IBM. All rights reserved.
+# Copyright (C) 2015, 2019 IBM. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -87,6 +87,8 @@ class View(dict):
     :param str view_name: Name used in part to identify the view.
     :param str map_func: Optional Javascript map function.
     :param str reduce_func: Optional Javascript reduce function.
+    :param str partition_key: Optional. Specify a view partition key. Defaults
+        to ``None`` resulting in global queries.
     """
     def __init__(
             self,
@@ -94,6 +96,7 @@ class View(dict):
             view_name,
             map_func=None,
             reduce_func=None,
+            partition_key=None,
             **kwargs
     ):
         super(View, self).__init__()
@@ -104,6 +107,7 @@ class View(dict):
             self['map'] = codify(map_func)
         if reduce_func is not None:
             self['reduce'] = codify(reduce_func)
+        self._partition_key = partition_key
         self.update(kwargs)
         self.result = Result(self)
 
@@ -167,8 +171,14 @@ class View(dict):
 
         :returns: View URL
         """
+        if self._partition_key:
+            base_url = self.design_doc.document_partition_url(
+                self._partition_key)
+        else:
+            base_url = self.design_doc.document_url
+
         return '/'.join((
-            self.design_doc.document_url,
+            base_url,
             '_view',
             self.view_name
         ))

--- a/tests/unit/database_partition_tests.py
+++ b/tests/unit/database_partition_tests.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+# Copyright (C) 2019 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+_database_partition_tests_
+"""
+
+from cloudant.design_document import DesignDocument
+from cloudant.index import Index, SpecialIndex
+
+from nose.plugins.attrib import attr
+
+from .unit_t_db_base import UnitTestDbBase
+
+
+@attr(db=['cloudant'])
+class DatabasePartitionTests(UnitTestDbBase):
+
+    def setUp(self):
+        super(DatabasePartitionTests, self).setUp()
+        self.db_set_up(partitioned=True)
+
+    def tearDown(self):
+        self.db_tear_down()
+        super(DatabasePartitionTests, self).tearDown()
+
+    def test_is_partitioned_database(self):
+        self.assertTrue(self.db.metadata()['props']['partitioned'])
+
+    def test_create_partitioned_design_document(self):
+        ddoc_id = 'empty_ddoc'
+
+        ddoc = DesignDocument(self.db, ddoc_id, partitioned=True)
+        ddoc.save()
+
+        r = self.db.r_session.get(ddoc.document_url)
+        r.raise_for_status()
+
+        self.assertTrue(r.json()['options']['partitioned'])
+
+    def test_partitioned_all_docs(self):
+        for partition_key in self.populate_db_with_partitioned_documents(5, 25):
+            docs = self.db.partitioned_all_docs(partition_key)
+            self.assertEquals(len(docs['rows']), 25)
+
+            for doc in docs['rows']:
+                self.assertTrue(doc['id'].startswith(partition_key + ':'))
+
+    def test_partition_metadata(self):
+        for partition_key in self.populate_db_with_partitioned_documents(5, 25):
+            meta = self.db.partition_metadata(partition_key)
+            self.assertEquals(meta['partition'], partition_key)
+            self.assertEquals(meta['doc_count'], 25)
+
+    def test_partitioned_search(self):
+        ddoc = DesignDocument(self.db, 'partitioned_search', partitioned=True)
+        ddoc.add_search_index(
+            'search1',
+            'function(doc) { index("id", doc._id, {"store": true}); }'
+        )
+        ddoc.save()
+
+        for partition_key in self.populate_db_with_partitioned_documents(2, 10):
+            results = self.db.get_partitioned_search_result(
+                partition_key, ddoc['_id'], 'search1', query='*:*')
+
+            i = 0
+            for result in results['rows']:
+                print(result)
+                self.assertTrue(result['id'].startswith(partition_key + ':'))
+                i += 1
+            self.assertEquals(i, 10)
+
+    def test_get_partitioned_index(self):
+        index_name = 'test_partitioned_index'
+
+        self.db.create_query_index(index_name=index_name, fields=['foo'])
+
+        results = self.db.get_query_indexes()
+        self.assertEquals(len(results), 2)
+
+        index_all_docs = results[0]
+        self.assertEquals(index_all_docs.name, '_all_docs')
+        self.assertEquals(type(index_all_docs), SpecialIndex)
+        self.assertFalse(index_all_docs.partitioned)
+
+        index_partitioned = results[1]
+        self.assertEquals(index_partitioned.name, index_name)
+        self.assertEquals(type(index_partitioned), Index)
+        self.assertTrue(index_partitioned.partitioned)
+
+    def test_partitioned_query(self):
+        self.db.create_query_index(fields=['foo'])
+
+        for partition_key in self.populate_db_with_partitioned_documents(2, 10):
+            results = self.db.get_partitioned_query_result(
+                partition_key, selector={'foo': {'$eq': 'bar'}})
+
+            i = 0
+            for result in results:
+                self.assertTrue(result['_id'].startswith(partition_key + ':'))
+                i += 1
+            self.assertEquals(i, 10)
+
+    def test_partitioned_view(self):
+        ddoc = DesignDocument(self.db, 'partitioned_view', partitioned=True)
+        ddoc.add_view('view1', 'function(doc) { emit(doc._id, 1); }')
+        ddoc.save()
+
+        for partition_key in self.populate_db_with_partitioned_documents(2, 10):
+            results = self.db.get_partitioned_view_result(
+                partition_key, ddoc['_id'], 'view1')
+
+            i = 0
+            for result in results:
+                self.assertTrue(
+                    result['id'].startswith(partition_key + ':'))
+                i += 1
+            self.assertEquals(i, 10)


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Add partitioned databases feature.

See [partitioned_databases.rst](https://github.com/cloudant/python-cloudant/blob/63f58a4b219da63cc945771db8d07725f95af1b8/docs/partitioned_databases.rst).
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->
<!--
## Approach


Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes
New API (non-breaking).
<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy
No change.
<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing
Includes additional testing.
<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
No change.
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->