### PR TITLE
Raise exception when database name is invalid

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- [FIXED] Correctly raise exceptions from `create_database` calls.
+
 # 2.12.0 (2019-03-28)
 
 - [NEW] Added partitioned database support.

--- a/src/cloudant/client.py
+++ b/src/cloudant/client.py
@@ -290,6 +290,7 @@ class CouchDB(dict):
         except CloudantDatabaseException as ex:
             if ex.status_code == 412:
                 raise CloudantClientException(412, dbname)
+            raise ex
         super(CouchDB, self).__setitem__(dbname, new_db)
         return new_db
 

--- a/src/cloudant/error.py
+++ b/src/cloudant/error.py
@@ -107,7 +107,13 @@ class CloudantDatabaseException(CloudantException):
     """
     def __init__(self, code=100, *args):
         try:
-            msg = DATABASE[code].format(*args)
+            if code in DATABASE:
+                msg = DATABASE[code].format(*args)
+            elif isinstance(code, int):
+                msg = ' '.join(args)
+            else:
+                code = 100
+                msg = DATABASE[code]
         except (KeyError, IndexError):
             code = 100
             msg = DATABASE[code]


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Update `create_database` to raise exception when database name is invalid.
Fixes #446 
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

## Approach
Added additional `if` to raise `CloudantDatabaseException` when status code is `400`.
<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes
 "No change"
<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy
 "No change"
<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing
Added new test `test_create_invalid_database_name`
<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
"No change"
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->