### PR TITLE
Added skip_if_iam to some tests that rely on a legacy password

### DIFF
--- a/tests/unit/client_tests.py
+++ b/tests/unit/client_tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2015, 2018 IBM Corp. All rights reserved.
+# Copyright (C) 2015, 2019 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ from cloudant.feed import Feed, InfiniteFeed
 from nose.plugins.attrib import attr
 from requests import ConnectTimeout, HTTPError
 
-from .unit_t_db_base import skip_if_not_cookie_auth, UnitTestDbBase
+from .unit_t_db_base import skip_if_iam, skip_if_not_cookie_auth, UnitTestDbBase
 from .. import bytes_, str_
 
 
@@ -782,6 +782,7 @@ class CloudantClientTests(UnitTestDbBase):
                 str(err)
             )
 
+    @skip_if_iam
     def test_cloudant_bluemix_dedicated_context_helper(self):
         """
         Test that the cloudant_bluemix context helper works as expected when
@@ -888,6 +889,7 @@ class CloudantClientTests(UnitTestDbBase):
         finally:
             c.disconnect()
 
+    @skip_if_iam
     def test_bluemix_constructor_specify_instance_name(self):
         """
         Test instantiating a client object using a VCAP_SERVICES environment


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue

Run tests with only `IAM_API_KEY` and `CLOUDANT_ACCOUNT`, but no `DB_USER` or `DB_PASSWORD`.

### 2. What you expected to happen

Tests to use IAM credentials and pass.

### 3. What actually happened

Two tests failed:
* `test_bluemix_constructor_specify_instance_name`
* `test_cloudant_bluemix_dedicated_context_helper`

Note these tests pass during the current `master` build because _both_ legacy credentials _and_ IAM credentials are supplied - meaning that these two tests pass with the supplied legacy creds instead of the IAM creds.

## Approach

Skip running these tests when using IAM credentials.

These bluemix initialization tests make a connection to the service to test the init worked correctly. They use a username and password combination so can't work with an IAM API key without additional switching. While they pass in cases where both legacy creds and IAM creds are supplied, if only IAM creds are supplied they fail.

We could either add the switching to run them with IAM creds, but that's not really the point of the tests (note `test_bluemix_constructor_with_iam` exists for this). So instead we should disable them for IAM testing; noting that they run during legacy creds testing.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Modified existing tests with `@skip_if_iam` to skip tests requiring legacy credentials.

## Monitoring and Logging

- "No change"
