### PR TITLE
Fix "DeprecationWarning" from "collections"

### DIFF
--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -19,7 +19,7 @@ throughout the library.
 
 import sys
 import platform
-from collections import Sequence
+from collections.abc import Sequence
 import json
 
 from ._2to3 import LONGTYPE, STRTYPE, NONETYPE, UNITYPE, iteritems_


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [ ] Added tests for code changes _or_ test/build only changes
- [ ] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Using or importing the ABCs from 'collections'
instead of from 'collections.abc' is deprecated, and in 3.8 it will stop
working.

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
1) start your python3 interpreter with -Wd so it shows deprecation warnings
2) `import cloudant._common_util`
### 2. What you expected to happen
The import should work wihout warnings
### 3. What actually happened
```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  from collections import Sequence
```

## Approach

Use the error message suggested change

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

I don't know how (and if it's necessary for this change, actually) to test an import change like this. But if you have any ideas, let me know!