### PR TITLE
Fix broken Python 2 build

### DIFF
--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -19,16 +19,15 @@ throughout the library.
 
 import sys
 import platform
-import collections
 import json
 
 from ._2to3 import LONGTYPE, STRTYPE, NONETYPE, UNITYPE, iteritems_
 from .error import CloudantArgumentError, CloudantException, CloudantClientException
 
 try:
-    Sequence = collections.abc.Sequence  # noqa
+    from collections.abc import Sequence
 except AttributeError:
-    Sequence = collections.Sequence  # noqa
+    from collections import Sequence
 
 # Library Constants
 

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -26,9 +26,9 @@ from ._2to3 import LONGTYPE, STRTYPE, NONETYPE, UNITYPE, iteritems_
 from .error import CloudantArgumentError, CloudantException, CloudantClientException
 
 try:
-    sequence = collections.abc.Sequence
+    Sequence = collections.abc.Sequence  # noqa
 except AttributeError:
-    sequence = collections.Sequence
+    Sequence = collections.Sequence  # noqa
 
 # Library Constants
 
@@ -57,20 +57,20 @@ ANY_TYPE = object()
 
 RESULT_ARG_TYPES = {
     'descending': (bool,),
-    'endkey': (int, LONGTYPE, STRTYPE, sequence,),
+    'endkey': (int, LONGTYPE, STRTYPE, Sequence,),
     'endkey_docid': (STRTYPE,),
     'group': (bool,),
     'group_level': (int, LONGTYPE, NONETYPE,),
     'include_docs': (bool,),
     'inclusive_end': (bool,),
-    'key': (int, LONGTYPE, STRTYPE, sequence,),
+    'key': (int, LONGTYPE, STRTYPE, Sequence,),
     'keys': (list,),
     'limit': (int, LONGTYPE, NONETYPE,),
     'reduce': (bool,),
     'skip': (int, LONGTYPE, NONETYPE,),
     'stable': (bool,),
     'stale': (STRTYPE,),
-    'startkey': (int, LONGTYPE, STRTYPE, sequence,),
+    'startkey': (int, LONGTYPE, STRTYPE, Sequence,),
     'startkey_docid': (STRTYPE,),
     'update': (STRTYPE,),
 }
@@ -80,7 +80,7 @@ TYPE_CONVERTERS = {
     STRTYPE: lambda x: json.dumps(x),
     str: lambda x: json.dumps(x),
     UNITYPE: lambda x: json.dumps(x),
-    sequence: lambda x: json.dumps(list(x)),
+    Sequence: lambda x: json.dumps(list(x)),
     list: lambda x: json.dumps(x),
     tuple: lambda x: json.dumps(list(x)),
     int: lambda x: x,

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -26,7 +26,7 @@ from .error import CloudantArgumentError, CloudantException, CloudantClientExcep
 
 try:
     from collections.abc import Sequence
-except AttributeError:
+except ImportError:
     from collections import Sequence
 
 # Library Constants

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -26,9 +26,9 @@ from ._2to3 import LONGTYPE, STRTYPE, NONETYPE, UNITYPE, iteritems_
 from .error import CloudantArgumentError, CloudantException, CloudantClientException
 
 try:
-    Sequence = collections.abc.Sequence
+    Sequence = collections.abc.Sequence  # noqa
 except AttributeError:
-    Sequence = collections.Sequence
+    Sequence = collections.Sequence  # noqa
 
 # Library Constants
 

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -19,11 +19,16 @@ throughout the library.
 
 import sys
 import platform
-from collections.abc import Sequence
+import collections
 import json
 
 from ._2to3 import LONGTYPE, STRTYPE, NONETYPE, UNITYPE, iteritems_
 from .error import CloudantArgumentError, CloudantException, CloudantClientException
+
+try:
+    Sequence = collections.abc.Sequence
+except AttributeError:
+    Sequence = collections.Sequence
 
 # Library Constants
 

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -26,9 +26,9 @@ from ._2to3 import LONGTYPE, STRTYPE, NONETYPE, UNITYPE, iteritems_
 from .error import CloudantArgumentError, CloudantException, CloudantClientException
 
 try:
-    Sequence = collections.abc.Sequence  # noqa
+    sequence = collections.abc.Sequence
 except AttributeError:
-    Sequence = collections.Sequence  # noqa
+    sequence = collections.Sequence
 
 # Library Constants
 
@@ -57,20 +57,20 @@ ANY_TYPE = object()
 
 RESULT_ARG_TYPES = {
     'descending': (bool,),
-    'endkey': (int, LONGTYPE, STRTYPE, Sequence,),
+    'endkey': (int, LONGTYPE, STRTYPE, sequence,),
     'endkey_docid': (STRTYPE,),
     'group': (bool,),
     'group_level': (int, LONGTYPE, NONETYPE,),
     'include_docs': (bool,),
     'inclusive_end': (bool,),
-    'key': (int, LONGTYPE, STRTYPE, Sequence,),
+    'key': (int, LONGTYPE, STRTYPE, sequence,),
     'keys': (list,),
     'limit': (int, LONGTYPE, NONETYPE,),
     'reduce': (bool,),
     'skip': (int, LONGTYPE, NONETYPE,),
     'stable': (bool,),
     'stale': (STRTYPE,),
-    'startkey': (int, LONGTYPE, STRTYPE, Sequence,),
+    'startkey': (int, LONGTYPE, STRTYPE, sequence,),
     'startkey_docid': (STRTYPE,),
     'update': (STRTYPE,),
 }
@@ -80,7 +80,7 @@ TYPE_CONVERTERS = {
     STRTYPE: lambda x: json.dumps(x),
     str: lambda x: json.dumps(x),
     UNITYPE: lambda x: json.dumps(x),
-    Sequence: lambda x: json.dumps(list(x)),
+    sequence: lambda x: json.dumps(list(x)),
     list: lambda x: json.dumps(x),
     tuple: lambda x: json.dumps(list(x)),
     int: lambda x: x,


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [ ] Added tests for code changes _or_ test/build only changes
- [X] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [X] Completed the PR template below:

## Description
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->
f2c1298 accidentally broke the build as collections.abc is only available in Python 3.x.

This commit adds a workaround that enables the import that works both on 2 and 3.

## Approach

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes
"No change"
<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing
No new tests because the change is not semantic.

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
"No change"
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
