### PR TITLE
Fixup unit tests Broken by Couch3 

### DIFF
--- a/tests/unit/design_document_tests.py
+++ b/tests/unit/design_document_tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2015, 2018 IBM Corp. All rights reserved.
+# Copyright (C) 2015, 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -776,7 +776,8 @@ class DesignDocumentTests(UnitTestDbBase):
         info = ddoc_remote.info()
         # Remove variable fields to make equality easier to check
         info['view_index'].pop('signature')
-        info['view_index'].pop('disk_size')
+        if 'disk_size' in info['view_index']:
+            info['view_index'].pop('disk_size')
         # Remove Cloudant/Couch 2 fields if present to allow test to pass on Couch 1.6
         if 'sizes' in info['view_index']:
             info['view_index'].pop('sizes')

--- a/tests/unit/index_tests.py
+++ b/tests/unit/index_tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2015, 2018 IBM Corp. All rights reserved.
+# Copyright (C) 2015, 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -390,7 +390,7 @@ class IndexTests(UnitTestDbBase):
         self.populate_db_with_documents(100)
         result = self.db.get_query_result(fields=['name', 'age'],
                 selector={'age': {'$eq': 6}}, raw_result=True)
-        self.assertTrue(str(result['warning']).startswith("no matching index found"))
+        self.assertTrue(str(result['warning']).lower().startswith("no matching index found"))
 
 @attr(db='cloudant')
 class TextIndexTests(UnitTestDbBase):


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->
The most recent RC builds include metadata changes that mean disk_size has been removed. The test will now pop disk_size if it exists. There is also changes to the format of warnings.   


## Approach

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->
Fixed up the test DesignDocumentTests::test_get_info - the most recent RC builds include meta data changes that mean disk_size has been removed. The test will now pop disk_size if it exists. 

Fixed up the test CloudantIndexExceptionTests::test_index_usage_via_query - the most recent RC builds include warning message format changes - instead of responding with `no matching index found` the database responds with `No matching index found`. The test will now `.lower()` the warning message.

## Schema & API Changes
No change

## Security and Privacy
No change


## Testing

Run the tests against the latest RC build and assert they pass.

## Monitoring and Logging

No change
