### PR TITLE
Trigger search index builds before asserting metadata

### DIFF
--- a/tests/unit/design_document_tests.py
+++ b/tests/unit/design_document_tests.py
@@ -827,6 +827,9 @@ class DesignDocumentTests(UnitTestDbBase):
         ddoc_remote = DesignDocument(self.db, '_design/ddoc001')
         ddoc_remote.fetch()
 
+        # Make a request to the search index to ensure it is built
+        self.db.get_search_result('_design/ddoc001', 'search001', query='name:julia*')
+
         search_info = ddoc_remote.search_info('search001')
         # Check the search index name
         self.assertEqual(search_info['name'], '_design/ddoc001/search001', 'The search index name should be correct.')
@@ -856,7 +859,8 @@ class DesignDocumentTests(UnitTestDbBase):
         ddoc_remote = DesignDocument(self.db, '_design/ddoc001')
         ddoc_remote.fetch()
 
-        ddoc_remote.search_info('search001')  # trigger index build
+        # Make a request to the search index to ensure it is built
+        self.db.get_search_result('_design/ddoc001', 'search001', query='name:julia*')
 
         search_disk_size = ddoc_remote.search_disk_size('search001')
 


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Updated `_search_info` tests to trigger index build

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
Run tests:
* `tests.unit.design_document_tests.DesignDocumentTests.test_get_search_disk_size`
* `tests.unit.design_document_tests.DesignDocumentTests.test_get_search_info`

### 2. What you expected to happen
Tests to pass

### 3. What actually happened
Assertions fail with:
* `False is not true : The disk_size should be greater than 0.`

## Approach

Update tests to ensure a search index build is triggered before asserting metadata.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Modified existing tests to trigger search index build.

## Monitoring and Logging

- "No change"
