### PR TITLE
Removed data_size from view info assertion

### DIFF
--- a/tests/unit/design_document_tests.py
+++ b/tests/unit/design_document_tests.py
@@ -778,6 +778,8 @@ class DesignDocumentTests(UnitTestDbBase):
         info['view_index'].pop('signature')
         if 'disk_size' in info['view_index']:
             info['view_index'].pop('disk_size')
+        if 'data_size' in info['view_index']:
+            info['view_index'].pop('data_size')
         # Remove Cloudant/Couch 2 fields if present to allow test to pass on Couch 1.6
         if 'sizes' in info['view_index']:
             info['view_index'].pop('sizes')
@@ -790,8 +792,7 @@ class DesignDocumentTests(UnitTestDbBase):
             {'view_index': {'update_seq': 0, 'waiting_clients': 0,
                             'language': 'javascript',
                             'purge_seq': 0, 'compact_running': False,
-                            'waiting_commit': False, 'updater_running': False,
-                            'data_size': 0
+                            'waiting_commit': False, 'updater_running': False
                             },
              'name': name
             })


### PR DESCRIPTION
The data_size field is no longer present in CouchDB 3.x so remove it from the assertion for compatibility.

## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Removed data_size from view info assertion

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
* Run `tests.unit.design_document_tests.DesignDocumentTests.test_get_info` with CouchDB 3 rc1

### 2. What you expected to happen
Test to pass

### 3. What actually happened
Assertion failure:
```
{'vie[33 chars]se, 'waiting_clients': 0, 'waiting_commit': Fa[104 chars]001'} != {'vie[33 chars]se, 'update_seq': 0, 'waiting_clients': 0, 'wa[120 chars]001'}
  {'name': 'ddoc001',
   'view_index': {'compact_running': False,
+                 'data_size': 0,
                  'language': 'javascript',
                  'purge_seq': 0,
                  'update_seq': 0,
                  'updater_running': False,
                  'waiting_clients': 0,
                  'waiting_commit': False}}
```

## Approach

Remove the `data_size` element from the view info before asserting as it is no longer present in CouchDB 3.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Modified existing tests to reduce assertable members of view info to be compatible with both 2.x and 3.x

## Monitoring and Logging

- "No change"