### PR TITLE
Intermittent read timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
 # command to run tests
 script:
     - pylint ./src/cloudant
-    - nosetests -A 'not db or ((db is "couch" or "couch" in db) and (not couchapi or couchapi <='${COUCHDB_VERSION:0:1}'))' -w ./tests/unit
+    - nosetests -A 'not db or ((db == "couch" or "couch" in db) and (not couchapi or couchapi <='${COUCHDB_VERSION:0:1}'))' -w ./tests/unit
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,13 @@ sudo: required
 language: python
 
 python:
-  - "2.7"
-  - "3.6"
+  - "3.8"
 
 env:
-  - ADMIN_PARTY=true COUCHDB_VERSION=2.1.1
-  - ADMIN_PARTY=false COUCHDB_VERSION=2.1.1
-  - ADMIN_PARTY=true COUCHDB_VERSION=1.7.1
-  - ADMIN_PARTY=false COUCHDB_VERSION=1.7.1
+  - ADMIN_PARTY=true COUCHDB_VERSION=2.3.1
+  - ADMIN_PARTY=false COUCHDB_VERSION=2.3.1
+  - ADMIN_PARTY=true COUCHDB_VERSION=1.7.2
+  - ADMIN_PARTY=false COUCHDB_VERSION=1.7.2
 
 services:
   - docker

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,10 +61,9 @@ stage('Checkout'){
 }
 
 stage('Test'){
-  def py2 = '2'
   def py3 = '3'
   def axes = [:]
-  [py2, py3].each { version ->
+  [py3].each { version ->
     ['basic','cookie','iam'].each { auth ->
        axes.put("Python${version}-${auth}", {setupPythonAndTest(version, auth)})
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ def setupPythonAndTest(pythonVersion, testSuite) {
             pip install -r test-requirements.txt
             ${'simplejson'.equals(testSuite) ? 'pip install simplejson' : ''}
             pylint ./src/cloudant
-            nosetests -A 'not db or (db is "cloudant" or "cloudant" in db)' -w ./tests/unit --with-xunit
+            nosetests -A 'not db or (db == "cloudant" or "cloudant" in db)' -w ./tests/unit --with-xunit
           """
         } finally {
           // Load the test results

--- a/tests/unit/client_tests.py
+++ b/tests/unit/client_tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2015, 2019 IBM Corp. All rights reserved.
+# Copyright (C) 2015, 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -405,9 +405,10 @@ class ClientTests(UnitTestDbBase):
         """
         dbname = 'invalidDbName_'
         self.client.connect()
-        with self.assertRaises(CloudantDatabaseException) as cm:
+        with self.assertRaises((CloudantDatabaseException, HTTPError)) as cm:
             self.client.create_database(dbname)
-        self.assertEqual(cm.exception.status_code, 400)
+        code = cm.exception.status_code if hasattr(cm.exception, 'status_code') else cm.exception.response.status_code
+        self.assertEqual(code, 400)
         self.client.disconnect()
 
     @skip_if_not_cookie_auth

--- a/tests/unit/replicator_tests.py
+++ b/tests/unit/replicator_tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2015, 2018 IBM Corp. All rights reserved.
+# Copyright (C) 2015, 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -220,10 +220,13 @@ class ReplicatorTests(UnitTestDbBase):
     def test_timeout_in_create_replication(self):
         """
         Test that a read timeout exception is thrown when creating a
-        replicator with a timeout value of 500 ms.
+        replicator with a read timeout value of 5 s.
         """
-        # Setup client with a timeout
-        self.set_up_client(auto_connect=True, timeout=.5)
+        # Setup client with a read timeout (but the standard connect timeout)
+        # Note that this timeout applies to all connections from this client
+        # setting it too short can cause intermittent failures when responses
+        # are not quick enough. Setting it too long makes the test take longer.
+        self.set_up_client(auto_connect=True, timeout=(30,5))
         self.db = self.client[self.test_target_dbname]
         self.target_db = self.client[self.test_dbname]
         # Construct a replicator with the updated client

--- a/tests/unit/unit_t_db_base.py
+++ b/tests/unit/unit_t_db_base.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2015, 2019 IBM Corp. All rights reserved.
+# Copyright (C) 2015, 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -109,7 +109,7 @@ class UnitTestDbBase(unittest.TestCase):
 
             if os.environ.get('DB_USER') is None:
                 # Get couchdb docker node name
-                if os.environ.get('COUCHDB_VERSION') == '2.1.1':
+                if os.environ.get('COUCHDB_VERSION') == '2.3.1':
                     os.environ['NODENAME'] = requests.get(
                         '{0}/_membership'.format(os.environ['DB_URL'])).json()['all_nodes'][0]
                 os.environ['DB_USER_CREATED'] = '1'
@@ -117,7 +117,7 @@ class UnitTestDbBase(unittest.TestCase):
                     unicode_(uuid.uuid4())
                     )
                 os.environ['DB_PASSWORD'] = 'password'
-                if os.environ.get('COUCHDB_VERSION') == '2.1.1':
+                if os.environ.get('COUCHDB_VERSION') == '2.3.1':
                     resp = requests.put(
                         '{0}/_node/{1}/_config/admins/{2}'.format(
                             os.environ['DB_URL'],
@@ -143,7 +143,7 @@ class UnitTestDbBase(unittest.TestCase):
         """
         if (os.environ.get('RUN_CLOUDANT_TESTS') is None and
             os.environ.get('DB_USER_CREATED') is not None):
-            if os.environ.get('COUCHDB_VERSION') == '2.1.1':
+            if os.environ.get('COUCHDB_VERSION') == '2.3.1':
                 resp = requests.delete(
                     '{0}://{1}:{2}@{3}/_node/{4}/_config/admins/{5}'.format(
                         os.environ['DB_URL'].split('://', 1)[0],


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Adjust read timeout in intermittently failing test and update test matrices.

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue

Run `tests.unit.replicator_tests.ReplicatorTests.test_timeout_in_create_replication`

### 2. What you expected to happen

Test to pass.

### 3. What actually happened

It intermittently fails.

## Approach

Change the timeout from `.5` to `(30,5)` - this means the connect timeout stays at the default 30s instead of also being reduced to .5s and the read timeout is increased from .5 seconds to 5 s. Whilst this means the test takes longer to run, it is much more reliable.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Modified existing tests because to change timeout to resolve intermittent failure.
- Modified test matrix to remove Python 2 as it is EOL.
- Modified test matrix for CouchDB version
    *  `1.7.1` -> `1.7.2` (although Couch 1.x is EOL, we'll still run these tests until the next major I think)
        * Had to fix `tests.unit.client_tests.ClientTests.test_create_invalid_database_name` as a result of this change
    * `2.1.1` -> `2.3.1`
        * Had to fix test set up special casing version as a result of this change.

## Monitoring and Logging

- "No change"
