### PR TITLE
Fixed the bug where design doc was created in CouchDB 3.0 with partition enabled even when the partition flag was false

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2.14.0 (2020-05-07)
+
+- [FIXED] Creating design documents with appropriate partition flag
+
 # 2.13.0 (2020-04-16)
 
 - [FIXED] Correctly raise exceptions from `create_database` calls.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
-# 2.14.0 (2020-05-07)
+# UNRELEASED
 
-- [FIXED] Creating design documents with appropriate partition flag
+- [FIXED] Set default value for `partitioned` parameter to false when creating a design document.
 
 # 2.13.0 (2020-04-16)
 

--- a/src/cloudant/design_document.py
+++ b/src/cloudant/design_document.py
@@ -50,6 +50,8 @@ class DesignDocument(Document):
 
         if partitioned:
             self.setdefault('options', {'partitioned': True})
+        else:
+            self.setdefault('options', {'partitioned': False})
 
         self._nested_object_names = frozenset(['views', 'indexes', 'lists', 'shows'])
         for prop in self._nested_object_names:

--- a/tests/unit/database_partition_tests.py
+++ b/tests/unit/database_partition_tests.py
@@ -48,6 +48,17 @@ class DatabasePartitionTests(UnitTestDbBase):
         r.raise_for_status()
 
         self.assertTrue(r.json()['options']['partitioned'])
+        
+    def test_create_non_partitioned_design_document(self):
+        ddoc_id = 'empty_ddoc'
+
+        ddoc = DesignDocument(self.db, ddoc_id, partitioned=False)
+        ddoc.save()
+
+        r = self.db.r_session.get(ddoc.document_url)
+        r.raise_for_status()
+
+        self.assertFalse(r.json()['options']['partitioned'])
 
     def test_partitioned_all_docs(self):
         for partition_key in self.populate_db_with_partitioned_documents(5, 25):

--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -364,7 +364,7 @@ class DatabaseTests(UnitTestDbBase):
         """
         # Get an empty design document object that does not exist remotely
         local_ddoc = self.db.get_design_document('_design/ddoc01')
-        self.assertEqual(local_ddoc, {'_id': '_design/ddoc01', 'indexes': {},
+        self.assertEqual(local_ddoc, {'_id': '_design/ddoc01', 'indexes': {}, 'options': {'partitioned': False},
                                       'views': {}, 'lists': {}, 'shows': {}})
         # Add the design document to the database
         map_func = 'function(doc) {\n emit(doc._id, 1); \n}'

--- a/tests/unit/design_document_tests.py
+++ b/tests/unit/design_document_tests.py
@@ -161,6 +161,32 @@ class DesignDocumentTests(UnitTestDbBase):
         remote_ddoc.fetch()
         self.assertEqual(remote_ddoc, ddoc)
 
+    def test_correct_view_partitioning(self):
+        """
+        Test that adding a design doc with particular partition flag
+        is created properly.
+        """
+        ddoc = DesignDocument(self.db, '_design/ddoc001',partitioned=True)
+        ddoc.create()
+        ddoc.fetch()
+        
+        try:
+            partition_val = ddoc.get('options')["partitioned"]
+        except:
+            partition_val = None
+        ddoc.delete()
+        self.assertEqual(partition_val, True)
+        
+        ddoc = DesignDocument(self.db, '_design/ddoc002',partitioned=False)
+        ddoc.create()
+        ddoc.fetch()
+        try:
+            partition_val = ddoc.get('options')["partitioned"]
+        except:
+            partition_val = None
+        ddoc.delete()
+        self.assertEqual(partition_val, False)
+    
     def test_delete_design_document_success_with_encoded_url(self):
         """
         Test that we can remove a design document from the remote

--- a/tests/unit/design_document_tests.py
+++ b/tests/unit/design_document_tests.py
@@ -161,7 +161,7 @@ class DesignDocumentTests(UnitTestDbBase):
         remote_ddoc.fetch()
         self.assertEqual(remote_ddoc, ddoc)
 
-    def test_correct_view_partitioning(self):
+    def test_correct_design_document_partitioning(self):
         """
         Test that adding a design doc with particular partition flag
         is created properly.

--- a/tests/unit/design_document_tests.py
+++ b/tests/unit/design_document_tests.py
@@ -161,37 +161,6 @@ class DesignDocumentTests(UnitTestDbBase):
         remote_ddoc.fetch()
         self.assertEqual(remote_ddoc, ddoc)
 
-    def test_design_document_with_partitioned_true(self):
-        """
-        Test that adding a design doc with particular partition flag
-        is created properly.
-        """
-        ddoc = DesignDocument(self.db, '_design/ddoc001',partitioned=True)
-        ddoc.create()
-        ddoc.fetch()
-        try:
-            partition_val = ddoc.get('options')["partitioned"]
-        except:
-            partition_val = None
-        ddoc.delete()
-        self.assertEqual(partition_val, True)
-        
-    def test_design_document_with_partitioned_false(self):
-        """
-        Test that adding a design doc with particular partition flag
-        is created properly.
-        """
-        
-        ddoc = DesignDocument(self.db, '_design/ddoc002',partitioned=False)
-        ddoc.create()
-        ddoc.fetch()
-        try:
-            partition_val = ddoc.get('options')["partitioned"]
-        except:
-            partition_val = None
-        ddoc.delete()
-        self.assertEqual(partition_val, False)
-    
     def test_delete_design_document_success_with_encoded_url(self):
         """
         Test that we can remove a design document from the remote
@@ -384,6 +353,7 @@ class DesignDocumentTests(UnitTestDbBase):
         self.assertEqual(ddoc_remote, {
             '_id': '_design/ddoc001',
             '_rev': ddoc['_rev'],
+            'options': {'partitioned': False},
             'lists': {},
             'shows': {},
             'indexes': {},
@@ -446,7 +416,7 @@ class DesignDocumentTests(UnitTestDbBase):
         ddoc_remote = DesignDocument(self.db, '_design/ddoc001')
         ddoc_remote.fetch()
         self.assertEqual(set(ddoc_remote.keys()),
-                         {'_id', '_rev', 'indexes', 'views', 'lists', 'shows'})
+                         {'_id', '_rev', 'indexes', 'views', 'options', 'lists', 'shows'})
         self.assertEqual(ddoc_remote['_id'], '_design/ddoc001')
         self.assertTrue(ddoc_remote['_rev'].startswith('1-'))
         self.assertEqual(ddoc_remote['_rev'], ddoc['_rev'])
@@ -463,6 +433,7 @@ class DesignDocumentTests(UnitTestDbBase):
         data = {
             '_id': '_design/ddoc001',
             'indexes': {},
+            'options': {'partitioned': False},
             'lists': {},
             'shows': {},
             'language': 'query',
@@ -494,6 +465,7 @@ class DesignDocumentTests(UnitTestDbBase):
         data = {
             '_id': '_design/ddoc001',
             'language': 'query',
+            'options': {'partitioned': False},
             'lists': {},
             'shows': {},
             'indexes': {'index001':
@@ -530,6 +502,7 @@ class DesignDocumentTests(UnitTestDbBase):
             'language': 'query',
             'lists': {},
             'shows': {},
+            'options': {'partitioned': False},
             'views': {
                 'view001': {'map': {'fields': {'name': 'asc', 'age': 'asc'}},
                             'reduce': '_count',
@@ -718,7 +691,7 @@ class DesignDocumentTests(UnitTestDbBase):
         ddoc.save()
         # Ensure that locally cached DesignDocument contains an
         # empty views dict.
-        self.assertEqual(set(ddoc.keys()), {'_id', '_rev', 'indexes', 'views', 'lists', 'shows'})
+        self.assertEqual(set(ddoc.keys()), {'_id', '_rev', 'indexes', 'options', 'views', 'lists', 'shows'})
         self.assertEqual(ddoc['_id'], '_design/ddoc001')
         self.assertTrue(ddoc['_rev'].startswith('1-'))
         self.assertEqual(ddoc.views, {})
@@ -726,7 +699,7 @@ class DesignDocumentTests(UnitTestDbBase):
         # include a views sub-document.
         resp = self.client.r_session.get(ddoc.document_url)
         raw_ddoc = response_to_json_dict(resp)
-        self.assertEqual(set(raw_ddoc.keys()), {'_id', '_rev'})
+        self.assertEqual(set(raw_ddoc.keys()), {'_id', '_rev','options'})
         self.assertEqual(raw_ddoc['_id'], ddoc['_id'])
         self.assertEqual(raw_ddoc['_rev'], ddoc['_rev'])
 
@@ -1107,6 +1080,7 @@ class DesignDocumentTests(UnitTestDbBase):
         self.assertEqual(ddoc_remote, {
             '_id': '_design/ddoc001',
             '_rev': ddoc['_rev'],
+            'options': {'partitioned': False},
             'indexes': {
                 'search001': {'index': search_index},
                 'search002': {'index': search_index, 'analyzer': 'simple'},
@@ -1131,7 +1105,7 @@ class DesignDocumentTests(UnitTestDbBase):
         ddoc_remote = DesignDocument(self.db, '_design/ddoc001')
         ddoc_remote.fetch()
         self.assertEqual(set(ddoc_remote.keys()),
-                         {'_id', '_rev', 'indexes', 'views', 'lists', 'shows'})
+                         {'_id', '_rev', 'indexes', 'options', 'views', 'lists', 'shows'})
         self.assertEqual(ddoc_remote['_id'], '_design/ddoc001')
         self.assertTrue(ddoc_remote['_rev'].startswith('1-'))
         self.assertEqual(ddoc_remote['_rev'], ddoc['_rev'])
@@ -1214,14 +1188,14 @@ class DesignDocumentTests(UnitTestDbBase):
         ddoc.save()
         # Ensure that locally cached DesignDocument contains an
         # empty search indexes and views dict.
-        self.assertEqual(set(ddoc.keys()), {'_id', '_rev', 'indexes', 'views', 'lists', 'shows'})
+        self.assertEqual(set(ddoc.keys()), {'_id', '_rev', 'indexes','options', 'views', 'lists', 'shows'})
         self.assertEqual(ddoc['_id'], '_design/ddoc001')
         self.assertTrue(ddoc['_rev'].startswith('1-'))
         # Ensure that remotely saved design document does not
         # include a search indexes sub-document.
         resp = self.client.r_session.get(ddoc.document_url)
         raw_ddoc = response_to_json_dict(resp)
-        self.assertEqual(set(raw_ddoc.keys()), {'_id', '_rev'})
+        self.assertEqual(set(raw_ddoc.keys()), {'_id', '_rev','options'})
         self.assertEqual(raw_ddoc['_id'], ddoc['_id'])
         self.assertEqual(raw_ddoc['_rev'], ddoc['_rev'])
 
@@ -1444,6 +1418,7 @@ class DesignDocumentTests(UnitTestDbBase):
         self.assertEqual(ddoc_remote, {
             '_id': '_design/ddoc001',
             '_rev': ddoc['_rev'],
+            'options': {'partitioned': False},
             'lists': {
                 'list001': list_func,
                 'list002': list_func,
@@ -1468,7 +1443,7 @@ class DesignDocumentTests(UnitTestDbBase):
         ddoc_remote = DesignDocument(self.db, '_design/ddoc001')
         ddoc_remote.fetch()
         self.assertEqual(set(ddoc_remote.keys()),
-                         {'_id', '_rev', 'indexes', 'views', 'lists', 'shows'})
+                         {'_id', '_rev', 'options', 'indexes', 'views', 'lists', 'shows'})
         self.assertEqual(ddoc_remote['_id'], '_design/ddoc001')
         self.assertTrue(ddoc_remote['_rev'].startswith('1-'))
         self.assertEqual(ddoc_remote['_rev'], ddoc['_rev'])
@@ -1483,14 +1458,14 @@ class DesignDocumentTests(UnitTestDbBase):
         ddoc = DesignDocument(self.db, '_design/ddoc001')
         ddoc.save()
         # Ensure that locally cached DesignDocument contains lists dict
-        self.assertEqual(set(ddoc.keys()), {'_id', '_rev', 'lists', 'shows', 'indexes', 'views'})
+        self.assertEqual(set(ddoc.keys()), {'_id', '_rev', 'lists', 'options', 'shows', 'indexes', 'views'})
         self.assertEqual(ddoc['_id'], '_design/ddoc001')
         self.assertTrue(ddoc['_rev'].startswith('1-'))
         # Ensure that remotely saved design document does not
         # include a lists sub-document.
         resp = self.client.r_session.get(ddoc.document_url)
         raw_ddoc = response_to_json_dict(resp)
-        self.assertEqual(set(raw_ddoc.keys()), {'_id', '_rev'})
+        self.assertEqual(set(raw_ddoc.keys()), {'_id', '_rev','options'})
         self.assertEqual(raw_ddoc['_id'], ddoc['_id'])
         self.assertEqual(raw_ddoc['_rev'], ddoc['_rev'])
 
@@ -1745,6 +1720,7 @@ class DesignDocumentTests(UnitTestDbBase):
         self.assertEqual(ddoc_remote, {
             '_id': '_design/ddoc001',
             '_rev': ddoc['_rev'],
+            'options': {'partitioned': False},
             'lists': {},
             'shows': {
                 'show001': show_func,
@@ -1769,7 +1745,7 @@ class DesignDocumentTests(UnitTestDbBase):
         ddoc_remote = DesignDocument(self.db, '_design/ddoc001')
         ddoc_remote.fetch()
         self.assertEqual(set(ddoc_remote.keys()),
-                         {'_id', '_rev', 'indexes', 'views', 'lists', 'shows'})
+                         {'_id', '_rev', 'indexes', 'options', 'views', 'lists', 'shows'})
         self.assertEqual(ddoc_remote['_id'], '_design/ddoc001')
         self.assertTrue(ddoc_remote['_rev'].startswith('1-'))
         self.assertEqual(ddoc_remote['_rev'], ddoc['_rev'])
@@ -1784,14 +1760,14 @@ class DesignDocumentTests(UnitTestDbBase):
         ddoc = DesignDocument(self.db, '_design/ddoc001')
         ddoc.save()
         # Ensure that locally cached DesignDocument contains shows dict
-        self.assertEqual(set(ddoc.keys()), {'_id', '_rev', 'lists', 'shows', 'indexes', 'views'})
+        self.assertEqual(set(ddoc.keys()), {'_id', '_rev', 'lists','options', 'shows', 'indexes', 'views'})
         self.assertEqual(ddoc['_id'], '_design/ddoc001')
         self.assertTrue(ddoc['_rev'].startswith('1-'))
         # Ensure that remotely saved design document does not
         # include a shows sub-document.
         resp = self.client.r_session.get(ddoc.document_url)
         raw_ddoc = response_to_json_dict(resp)
-        self.assertEqual(set(raw_ddoc.keys()), {'_id', '_rev'})
+        self.assertEqual(set(raw_ddoc.keys()), {'_id', '_rev','options'})
         self.assertEqual(raw_ddoc['_id'], ddoc['_id'])
         self.assertEqual(raw_ddoc['_rev'], ddoc['_rev'])
 

--- a/tests/unit/design_document_tests.py
+++ b/tests/unit/design_document_tests.py
@@ -161,7 +161,7 @@ class DesignDocumentTests(UnitTestDbBase):
         remote_ddoc.fetch()
         self.assertEqual(remote_ddoc, ddoc)
 
-    def test_correct_design_document_partitioning(self):
+    def test_design_document_with_partitioned_true(self):
         """
         Test that adding a design doc with particular partition flag
         is created properly.
@@ -169,13 +169,18 @@ class DesignDocumentTests(UnitTestDbBase):
         ddoc = DesignDocument(self.db, '_design/ddoc001',partitioned=True)
         ddoc.create()
         ddoc.fetch()
-        
         try:
             partition_val = ddoc.get('options')["partitioned"]
         except:
             partition_val = None
         ddoc.delete()
         self.assertEqual(partition_val, True)
+        
+    def test_design_document_with_partitioned_false(self):
+        """
+        Test that adding a design doc with particular partition flag
+        is created properly.
+        """
         
         ddoc = DesignDocument(self.db, '_design/ddoc002',partitioned=False)
         ddoc.create()


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->
In CouchDB 3.0.0, when attempting to create a design document with `partitioned=false`, the cloudant still creates the design doc with `partitioned=true`
Fixes #466 

## Approach

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->
In the **src/cloudant/design_document.py**, in the `__init__` function, the partition options were being set only when` partition=true`.
I added an else clause to set partition option when partition flag is `false`.

## Schema & API Changes

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->
No change
## Security and Privacy

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->
No change
## Testing

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->
#### Old commit
Modified existing test **design_document_tests.py** because it already contains relevant tests for unit testing. Added the new test function `test_correct_design_document_partitioned_true` and `test_correct_design_document_partitioned_false`
#### Latest commit
Modified existing test **database_partition_tests.py** because it already contains the test for _partitioned design doc_ (`test_create_partitioned_design_document`). Added the new test function for non-partitioned design doc `test_create_non_partitioned_design_document` . Reversed the changes in **design_document_tests.py** made in _old commit_.
Also updated **design_document_tests.py** and **database_tests.py** for checking partition value while validation

## Monitoring and Logging
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
No change