### PR TITLE
Disable false-positive linter error

### DIFF
--- a/src/cloudant/feed.py
+++ b/src/cloudant/feed.py
@@ -144,7 +144,7 @@ class Feed(object):
         """
         Provides Python3 compatibility.
         """
-        return self.next()
+        return self.next()  # pylint: disable=not-callable
 
     def next(self):
         """

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,5 +2,5 @@ mock==1.3.0
 nose
 sphinx
 sphinx_rtd_theme
-pylint
+pylint==2.5.2
 flaky

--- a/tests/unit/design_document_tests.py
+++ b/tests/unit/design_document_tests.py
@@ -391,6 +391,7 @@ class DesignDocumentTests(UnitTestDbBase):
         # the expected content in each case.
         self.assertEqual(db_copy, ddoc['views']['view002'].pop('dbcopy'))
         self.assertEqual({'epi': {'dbcopy': {'view002': db_copy}}, 'partitioned': False}, ddoc_remote.pop('options'))
+        self.assertEqual({'partitioned': False}, ddoc.pop('options'))
         self.assertEqual(ddoc_remote, ddoc)
         self.assertTrue(ddoc_remote['_rev'].startswith('1-'))
         self.assertEqual(ddoc_remote, {
@@ -1553,7 +1554,8 @@ class DesignDocumentTests(UnitTestDbBase):
             'indexes': {},
             'views': {},
             'lists': {},
-            'shows': {}
+            'shows': {},
+            'options': {'partitioned': False}
         })
         # Document with geospatial point
         geodoc = Document(self.db, 'doc001')

--- a/tests/unit/design_document_tests.py
+++ b/tests/unit/design_document_tests.py
@@ -390,7 +390,7 @@ class DesignDocumentTests(UnitTestDbBase):
         # before comparison also. Compare the removed values with
         # the expected content in each case.
         self.assertEqual(db_copy, ddoc['views']['view002'].pop('dbcopy'))
-        self.assertEqual({'epi': {'dbcopy': {'view002': db_copy}}}, ddoc_remote.pop('options'))
+        self.assertEqual({'epi': {'dbcopy': {'view002': db_copy}}, 'partitioned': False}, ddoc_remote.pop('options'))
         self.assertEqual(ddoc_remote, ddoc)
         self.assertTrue(ddoc_remote['_rev'].startswith('1-'))
         self.assertEqual(ddoc_remote, {


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

The build has been failing recently with a false positive linter error.
Pylint was complaining that a method is not callable, even though
the method is defined right on the following line.

As I could not find either the reason pylint was failing or a
solution that resolves this issue, this commit disables the check for
that specific line pylint was failing on.


Links to failed runs: https://cloudant-sdks-jenkins.swg-devops.com/job/Main/job/python-cloudant/job/master/28/display/redirect and https://cloudant-sdks-jenkins.swg-devops.com/job/Main/job/python-cloudant/job/master/29/display/redirect

## Approach

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

I was able to reproduce both the issue and the fix locally.

## Schema & API Changes

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

- "No change"

## Security and Privacy

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

- "No change"

## Testing

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

- Build only changes

## Monitoring and Logging
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->

- "No change"



Note to reviewers: the file prior to this commit was last changed in c74b7d8e0e37ba6b64fd4f9657157b220c550455 (more than a year ago), whereas the build has started failing only recently (less than a month ago) - link to verify: https://github.com/cloudant/python-cloudant/commits/master/src/cloudant/feed.py