### PR TITLE
Make `create_query_index` always supply `partitioned`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # UNRELEASED
 
 - [FIXED] Set default value for `partitioned` parameter to false when creating a design document.
+- [FIXED] Always set `partitioned` for `create_query_index` requests
 
 # 2.13.0 (2020-04-16)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # UNRELEASED
 
 - [FIXED] Set default value for `partitioned` parameter to false when creating a design document.
-- [FIXED] Always set `partitioned` for `create_query_index` requests
+- [FIXED] Corrected setting of `partitioned` flag for `create_query_index` requests.
 
 # 2.13.0 (2020-04-16)
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -284,8 +284,12 @@ when constructing the new ``DesignDocument`` class.
     ddoc.add_view('myview','function(doc) { emit(doc.foo, doc.bar); }')
     ddoc.save()
 
-Similarly, to define a partitioned Cloudant Query index you must set the
-``partitioned=True`` optional.
+
+To define a partitioned Cloudant Query index you may set the
+``partitioned=True`` optional, but it is not required as the index will be
+partitioned by default in a partitioned database. Conversely, you must
+set the ``partitioned=False`` optional if you wish to create a global
+(non-partitioned) index in a partitioned database.
 
 .. code-block:: python
 

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -1100,7 +1100,7 @@ class CouchDatabase(dict):
             design_document_id=None,
             index_name=None,
             index_type='json',
-            partitioned=False,
+            partitioned=None,
             **kwargs
     ):
         """

--- a/src/cloudant/index.py
+++ b/src/cloudant/index.py
@@ -154,8 +154,7 @@ class Index(object):
         self._def_check()
         payload['index'] = self._def
 
-        if self._partitioned:
-            payload['partitioned'] = True
+        payload['partitioned'] = bool(self._partitioned)
 
         headers = {'Content-Type': 'application/json'}
         resp = self._r_session.post(

--- a/src/cloudant/index.py
+++ b/src/cloudant/index.py
@@ -47,7 +47,7 @@ class Index(object):
         :func:`~cloudant.database.CloudantDatabase.create_query_index`.
     """
 
-    def __init__(self, database, design_document_id=None, name=None, partitioned=False, **kwargs):
+    def __init__(self, database, design_document_id=None, name=None, partitioned=None, **kwargs):
         self._database = database
         self._r_session = self._database.r_session
         self._ddoc_id = design_document_id
@@ -154,7 +154,8 @@ class Index(object):
         self._def_check()
         payload['index'] = self._def
 
-        payload['partitioned'] = bool(self._partitioned)
+        if self._partitioned is not None:
+            payload['partitioned'] = bool(self._partitioned)
 
         headers = {'Content-Type': 'application/json'}
         resp = self._r_session.post(

--- a/tests/unit/index_tests.py
+++ b/tests/unit/index_tests.py
@@ -561,7 +561,11 @@ class TextIndexTests(UnitTestDbBase):
         ddoc = DesignDocument(self.db, document_id="unpartitioned_query_index_ddoc")
         ddoc["language"] = "query"
         ddoc.save()
-        index = self.db.create_query_index(design_document_id="_design/unpartitioned_query_index_ddoc", fields=["key"])
+        index = self.db.create_query_index(
+            design_document_id="_design/unpartitioned_query_index_ddoc",
+            fields=["key"],
+            partitioned=False
+        )
         index.create()
         self.assertGreater(len(self.db.get_query_indexes()), 0)
 

--- a/tests/unit/index_tests.py
+++ b/tests/unit/index_tests.py
@@ -554,6 +554,17 @@ class TextIndexTests(UnitTestDbBase):
             '<{} \'dict\'>'.format('type' if PY2 else 'class')
         )
 
+    def test_create_unpartitioned_query_index(self):
+        """
+        Test that create_query_index works on an unpartitioned database
+        """
+        ddoc = DesignDocument(self.db, document_id="unpartitioned_query_index_ddoc")
+        ddoc["language"] = "query"
+        ddoc.save()
+        index = self.db.create_query_index(design_document_id="_design/unpartitioned_query_index_ddoc", fields=["key"])
+        index.create()
+        self.assertGreater(len(self.db.get_query_indexes()), 0)
+
     def test_search_index_via_query(self):
         """
         Test that a created TEXT index will produce expected query results.


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
The issue is described in #468 .
`create_query_index` does not always supply `partitioned` which is
always required by the service.



<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

## Approach
This PR changes the behavior that so that `partitioned` is now always
present in the `create_query_index` requests.

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes
~~- "No change"~~

EDIT: Two default `False` parameters have been changed to `None`. The users should not notice any difference.

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy
- "No change"
<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->
- Added new test case

## Monitoring and Logging
- "No change"



This fixes #468