### PR TITLE
Override dict's get method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 - [FIXED] Set default value for `partitioned` parameter to false when creating a design document.
 - [FIXED] Corrected setting of `partitioned` flag for `create_query_index` requests.
+- [NEW] Override the `get()` method for CouchDatabase, allowing it to retrive remote docuemnts if the `remote` parameter is specified.
 
 # 2.13.0 (2020-04-16)
 

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -705,6 +705,25 @@ class CouchDatabase(dict):
         else:
             raise KeyError(key)
         return doc
+		
+    def get(self, key, remote=False):
+        """
+        Overrides dict's get method. This gets an item from the databse  or cache 
+        like __getitem__, but instead of throwing an exception if the item is not
+        found, it simply returns None.
+        
+        :param bool remote: Dictates whether a request to the server is made to
+            retreive the doc, or if the doc will only be retrieved from the local
+            cache.
+            Defaults to False.
+        """
+        if remote:
+            try:
+                return self.__getitem__(key)
+            except KeyError:
+                return None
+        else:
+            return super(CouchDatabase, self).get(key)
 
     def __contains__(self, key):
         """

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -705,13 +705,13 @@ class CouchDatabase(dict):
         else:
             raise KeyError(key)
         return doc
-		
+
     def get(self, key, remote=False):
         """
-        Overrides dict's get method. This gets an item from the databse  or cache 
+        Overrides dict's get method. This gets an item from the databse  or cache
         like __getitem__, but instead of throwing an exception if the item is not
         found, it simply returns None.
-        
+
         :param bool remote: Dictates whether a request to the server is made to
             retreive the doc, or if the doc will only be retrieved from the local
             cache.


### PR DESCRIPTION
This allows the get method to be able to work with remote databases. Currently calling get only returns a doc if it is in the cache. The original behavior is preserved by use of the `remote` parameter, consistent with other overridden methods such as `keys()`, therefore this should be a non-breaking change.

## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [ ] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Currently, calling the `get()` method on a database object returns None, even for documents I know exist in the database. This was because the method had not been overridden, therefore was only returning documents from the cache. With this change, it should now be possible to use the `get()` method on databases, rather than try/except blocks.

## Approach

The code simply wraps a try/except block over the `__getitem__ ()` when the `remote` paramaeter is True, and falls back to the original behavior by calling super if it is False.

## Schema & API Changes

Updated the `CouchDatabase.get()` method, adding a `remote` parameter for that method

## Security and Privacy

No Change

## Testing

Existing tests should suffice for this change, because it makes no large changes, it is only a shorthand for calling an existing method.

## Monitoring and Logging

No Change
