### PR TITLE
Remove incorrect restriction from docs for bookmarks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # UNRELEASED
 - [REMOVED] Removed Python 2 compatibility from the supported environments.
+- [FIXED] Fixed the documentation for `bookmarks`.
 
 # 2.14.0 (2020-08-17)
 

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -1242,8 +1242,7 @@ class CouchDatabase(dict):
             wrapped in a QueryResult or if the response JSON is returned.
             Defaults to False.
         :param str bookmark: A string that enables you to specify which page of
-            results you require. Only valid for queries using indexes of type
-            *text*.
+            results you require.
         :param int limit: Maximum number of results returned.  Only valid if
             used with ``raw_result=True``.
         :param int page_size: Sets the page size for result iteration.  Default

--- a/src/cloudant/query.py
+++ b/src/cloudant/query.py
@@ -69,8 +69,7 @@ class Query(dict):
     :param CloudantDatabase database: A Cloudant database instance used by the
         Query.
     :param str bookmark: A string that enables you to specify which page of
-        results you require. Only valid for queries using indexes of type
-        *text*.
+        results you require.
     :param list fields: A list of fields to be returned by the query.
     :param int limit: Maximum number of results returned.
     :param int r: Read quorum needed for the result.  Each document is read from
@@ -141,8 +140,7 @@ class Query(dict):
         and set ``raw_result=True`` instead.
 
         :param str bookmark: A string that enables you to specify which page of
-            results you require. Only valid for queries using indexes of type
-            *text*.
+            results you require.
         :param list fields: A list of fields to be returned by the query.
         :param int limit: Maximum number of results returned.
         :param int r: Read quorum needed for the result.  Each document is read
@@ -204,8 +202,7 @@ class Query(dict):
                 data = rslt[100:200]
 
         :param str bookmark: A string that enables you to specify which page of
-            results you require. Only valid for queries using indexes of type
-            *text*.
+            results you require.
         :param list fields: A list of fields to be returned by the query.
         :param int page_size: Sets the page size for result iteration.  Default
             is 100.

--- a/src/cloudant/result.py
+++ b/src/cloudant/result.py
@@ -488,8 +488,7 @@ class QueryResult(Result):
     :param query: A reference to the query callable that returns
         the JSON content result to be wrapped.
     :param str bookmark: A string that enables you to specify which page of
-        results you require. Only valid for queries using indexes of type
-        *text*.
+        results you require.
     :param list fields: A list of fields to be returned by the query.
     :param int page_size: Sets the page size for result iteration.  Default
         is 100.


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
The docs for `bookmarks` was incorrect. This PR fixes that.

## Approach


## Schema & API Changes

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->
- "No change"

## Security and Privacy

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->
- "No change"


## Testing

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->
- Docs only change

## Monitoring and Logging
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
- "No change"
