### PR TITLE
Correct replicator states

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # UNRELEASED
 - [REMOVED] Removed Python 2 compatibility from the supported environments.
 - [FIXED] Fixed the documentation for `bookmarks`.
+- [FIXED] Also exit `follow_replication` for `failed` state.
 
 # 2.14.0 (2020-08-17)
 

--- a/src/cloudant/replicator.py
+++ b/src/cloudant/replicator.py
@@ -193,7 +193,12 @@ class Replicator(object):
             repl_doc, state = update_state()
             if repl_doc:
                 yield repl_doc
-            if state is not None and state in ['error', 'completed']:
+            # This is a little awkward, since 2.1 the terminal states are
+            # "failed" and "completed", so those should be the exit states, but
+            # for backwards compatibility with older versions "error" is also
+            # needed. The code has always exited for "error" state even long
+            # after 2.1 was available so that behaviour is retained.
+            if state is not None and state in ['error', 'failed', 'completed']:
                 return
 
             # Now listen on changes feed for the state
@@ -202,7 +207,8 @@ class Replicator(object):
                     repl_doc, state = update_state()
                     if repl_doc is not None:
                         yield repl_doc
-                    if state is not None and state in ['error', 'completed']:
+                    # See note about these states
+                    if state is not None and state in ['error', 'failed', 'completed']:
                         return
 
     def stop_replication(self, repl_id):

--- a/tests/unit/replicator_tests.py
+++ b/tests/unit/replicator_tests.py
@@ -322,12 +322,14 @@ class ReplicatorTests(UnitTestDbBase):
         )
         self.replication_ids.append(repl_id)
         repl_state = None
-        valid_states = ['completed', 'error', 'triggered', 'running', None]
+        # note triggered is for versions prior to 2.1
+        valid_states = ['completed', 'error', 'initializing', 'triggered', 'pending', 'running', 'failed', 'crashing', None]
         finished = False
+        # Wait for 5 minutes or a terminal replication state
         for _ in range(300):
             repl_state = self.replicator.replication_state(repl_id)
             self.assertTrue(repl_state in valid_states)
-            if repl_state in ('error', 'completed'):
+            if repl_state in ('error', 'failed', 'completed'):
                 finished = True
                 break
             time.sleep(1)
@@ -407,7 +409,8 @@ class ReplicatorTests(UnitTestDbBase):
             repl_id
         )
         self.replication_ids.append(repl_id)
-        valid_states = ('completed', 'error', 'triggered', 'running', None)
+        # note triggered is for versions prior to 2.1
+        valid_states = ['completed', 'error', 'initializing', 'triggered', 'pending', 'running', 'failed', 'crashing', None]
         repl_states = []
         if 'scheduler' in self.client.features():
             state_key = 'state'


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Correct the list of valid replicator states

Fixes #464 

## Approach

* Add the `failed` state to `follow_replication` since this is another condition under which it should exit in CouchDB 2.1+.

## Schema & API Changes

`follow_replication` exits for the `error` state even though that is a retryable state in CouchDB 2.1+ systems, it was existing behaviour for Couch < 2.1. Using the `error` state as an exit condition is retained so the code continues to operate in the same way as it has since launch when interacting with CouchDB >=2.1 based servers.

Behaviour change for the `failed` state which should have ended `follow_replication` but didn't, this is a fix.

## Security and Privacy

- "No change"

## Testing

The replicator tests were missing some other states introduced in CouchDB 2.1 scheduler.

- Modified existing tests because they did not have the complete list of replicator states for CouchDB 2.1+ and intermittently failed as a result.

## Monitoring and Logging

- "No change"
