### PR TITLE
Fix result paging for grouped view queries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 - [REMOVED] Removed Python 2 compatibility from the supported environments.
 - [FIXED] Fixed the documentation for `bookmarks`.
 - [FIXED] Also exit `follow_replication` for `failed` state.
+- [FIXED] Fixed result paging for grouped view queries.
 
 # 2.14.0 (2020-08-17)
 

--- a/src/cloudant/result.py
+++ b/src/cloudant/result.py
@@ -397,9 +397,10 @@ class Result(object):
 
                 # if we are in a view, keys could be duplicate so we
                 # need to start from the right docid
-                if last['id']:
+                last_doc_id = last.get('id')
+                if last_doc_id is not None:
                     response = self._call(startkey=last['key'],
-                                          startkey_docid=last['id'])
+                                          startkey_docid=last_doc_id)
                 # reduce result keys are unique by definition
                 else:
                     response = self._call(startkey=last['key'])


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
When querying a grouped view where either a) there's more documents than the default page size or b) there's more documents that the user-defined page size option, a `KeyError` occurs.  This happens when the view data iteration logic tries to retrieve the next set of results.

When querying a grouped view where pagination is needed, a `KeyError` occurs when trying to grab the next page.  This error is happening because the iteration logic is expecting an `id` field which does not exist for grouped view results.

fixes #456 
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

## Approach
Update [line 400 in `cloudant/result.py`](https://github.com/cloudant/python-cloudant/blob/master/src/cloudant/result.py#L400) to check that the `id` field exists.
<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing
Added new test `DatabaseTests.test_retrieve_grouped_view_result_with_page_size`.
<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
