### PR TITLE
Add new keep_alive param to couchdb class

### DIFF
--- a/src/cloudant/client.py
+++ b/src/cloudant/client.py
@@ -63,6 +63,9 @@ class CouchDB(dict):
     :param bool auto_renew: Keyword argument, if set to True performs
         automatic renewal of expired session authentication settings.
         Default is False.
+    :param bool keep_alive: Keyword argument, if set to False add
+        header Connection: Close to session header.
+        Default is True.
     :param float timeout: Timeout in seconds (use float for milliseconds, for
         example 0.1 for 100 ms) for connecting to and reading bytes from the
         server.  If a single value is provided it will be applied to both the
@@ -97,6 +100,7 @@ class CouchDB(dict):
         self._timeout = kwargs.get('timeout', None)
         self.r_session = None
         self._auto_renew = kwargs.get('auto_renew', False)
+        self._keep_alive = kwargs.get('keep_alive', True)
         self._use_basic_auth = kwargs.get('use_basic_auth', False)
         self._use_iam = kwargs.get('use_iam', False)
         self._iam_client_id = kwargs.get('iam_client_id', None)
@@ -180,6 +184,9 @@ class CouchDB(dict):
                 auto_renew=self._auto_renew,
                 timeout=self._timeout
             )
+        # If a keep alive is false, we add a new custom header
+        if not self._keep_alive:
+            self.r_session.headers.update({'Connection': 'close'})
 
         # If a Transport Adapter was supplied add it to the session
         if self.adapter is not None:


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [ ] Added tests for code changes _or_ test/build only changes
- [ ] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [ ] Completed the PR template below:

## Description

It is common to prepare and open a session to connect to iterate with couchdb. However, when you open a session, not necessarly you iterating with the database, you could be executing some transformation job. If you leave the session idle, the server could kill you connection and if you try to use the connection, the client raise an protocol error. See [issue 461](https://github.com/cloudant/python-cloudant/issues/491)
Fixes #461 

## Approach


To avoid the ECONNRESET error you should open the connection with Connection: close header. This pr add a param that allow the user handle if he wants the default behavior, ie, keep alive true or not.

## Schema & API Changes

Add param keep_alive to couchdb keep_alive

## Security and Privacy

"No change"

## Testing

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
"No change"