### PR TITLE
DeprecationWarning fix for method_whitelist

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 - [FIXED] Fixed the documentation for `bookmarks`.
 - [FIXED] Also exit `follow_replication` for `failed` state.
 - [FIXED] Fixed result paging for grouped view queries.
+- [FIXED] Replaced a depricated method `method_whitelist` with `allowed_methods`
 
 # 2.14.0 (2020-08-17)
 

--- a/src/cloudant/adapters.py
+++ b/src/cloudant/adapters.py
@@ -41,7 +41,7 @@ class Replay429Adapter(HTTPAdapter):
             read=0,
             # Allow retries for all the CouchDB HTTP method types
             allowed_methods=frozenset(['GET', 'HEAD', 'PUT', 'POST',
-                                        'DELETE', 'COPY']),
+                                       'DELETE', 'COPY']),
             # Only retry for a 429 too many requests status code
             status_forcelist=[429],
             # Configure the start value of the doubling backoff

--- a/src/cloudant/adapters.py
+++ b/src/cloudant/adapters.py
@@ -40,7 +40,7 @@ class Replay429Adapter(HTTPAdapter):
             connect=0,
             read=0,
             # Allow retries for all the CouchDB HTTP method types
-            method_whitelist=frozenset(['GET', 'HEAD', 'PUT', 'POST',
+            allowed_methods=frozenset(['GET', 'HEAD', 'PUT', 'POST',
                                         'DELETE', 'COPY']),
             # Only retry for a 429 too many requests status code
             status_forcelist=[429],


### PR DESCRIPTION
FIX: DeprecationWarning: Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0. Use 'allowed_methods' instead

<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

DeprecationWarning: Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0. Use 'allowed_methods' instead

## Approach

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
--> 

## Schema & API Changes

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
