### PR TITLE
Update test server config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 - [FIXED] Fixed the documentation for `bookmarks`.
 - [FIXED] Also exit `follow_replication` for `failed` state.
 - [FIXED] Fixed result paging for grouped view queries.
+- [FIXED] Incorrect use of username as account name in `Cloudant.bluemix()`.
+- [IMPROVED] Documented use of None account name and url override for `Cloudant.iam()`.
 
 # 2.14.0 (2020-08-17)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 def getEnvForSuite(suiteName) {
   // Base environment variables
   def envVars = [
-    "CLOUDANT_ACCOUNT=$DB_USER",
+    "DB_URL=${SDKS_TEST_SERVER_URL}",
     "RUN_CLOUDANT_TESTS=1",
     "SKIP_DB_UPDATES=1" // Disable pending resolution of case 71610
   ]
@@ -29,8 +29,8 @@ def setupPythonAndTest(pythonVersion, testSuite) {
     // Unstash the source on this node
     unstash name: 'source'
     // Set up the environment and test
-    withCredentials([usernamePassword(credentialsId: 'clientlibs-test', usernameVariable: 'DB_USER', passwordVariable: 'DB_PASSWORD'),
-                     string(credentialsId: 'clientlibs-test-iam', variable: 'DB_IAM_API_KEY')]) {
+    withCredentials([usernamePassword(credentialsId: 'testServerLegacy', usernameVariable: 'DB_USER', passwordVariable: 'DB_PASSWORD'),
+                     string(credentialsId: 'testServerIamApiKey', variable: 'DB_IAM_API_KEY')]) {
       withEnv(getEnvForSuite("${testSuite}")) {
         try {
           sh """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,7 @@ def getEnvForSuite(suiteName) {
     case 'iam':
       // Setting IAM_API_KEY forces tests to run using an IAM enabled client.
       envVars.add("IAM_API_KEY=$DB_IAM_API_KEY")
+      envVars.add("IAM_TOKEN_URL=$SDKS_TEST_IAM_URL")
       break
     case 'cookie':
     case 'simplejson':

--- a/src/cloudant/client.py
+++ b/src/cloudant/client.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2015, 2019 IBM Corp. All rights reserved.
+# Copyright (c) 2015, 2021 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -853,7 +853,7 @@ class Cloudant(CouchDB):
             raise CloudantClientException(103)
 
         if hasattr(service, 'iam_api_key'):
-            return Cloudant.iam(service.username,
+            return Cloudant.iam(None,
                                 service.iam_api_key,
                                 url=service.url,
                                 **kwargs)
@@ -867,7 +867,7 @@ class Cloudant(CouchDB):
         """
         Create a Cloudant client that uses IAM authentication.
 
-        :param account_name: Cloudant account name.
+        :param account_name: Cloudant account name; or use None and a url kwarg.
         :param api_key: IAM authentication API key.
         """
         return cls(None,


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Change the test server configuration and allow for overriding the token server used by tests.
Fix `Cloudant.bluemix()` handling of username/account.

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue

Run Jenkins with a custom IAM token server.

### 2. What you expected to happen

Tests to pass.

### 3. What actually happened

Test failures.

## Approach

* Add `IAM_TOKEN_URL` environment variable to IAM test runs
* Add new env vars and cred IDs to `Jenkinsfile` - use `DB_URL` instead of `CLOUDANT_ACCOUNT`
* Fix tests to work with above (see "Testing" below)

The `Cloudant.bluemix()` function was assuming that the username was the account name. This does not work with the new style account credentials where username does not match account name. The URL was already being correctly provided, so just use `None` as the account name instead.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Modified existing tests because many made the assumption they would be run with `CLOUDANT_ACCOUNT` instead of a service URL.

Test run is on the whole pretty stable except:
1. replication tests which appear to have exposed a regression in Cloudant. I've temporarily disabled checking on replication progress via scheduler docs on this branch to demonstrate that these changes are good pending resolution of that server side problem.
2. periodically exceeding the rate limit on the account

## Monitoring and Logging

- "No change"
