### PR TITLE
Use custom encoder (if provided) for all view `key` params not just `keys`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 - [FIXED] Fixed result paging for grouped view queries.
 - [FIXED] Incorrect use of username as account name in `Cloudant.bluemix()`.
 - [IMPROVED] Documented use of None account name and url override for `Cloudant.iam()`.
-- [FIXED] Use custom encoder on get_docs params.
+- [FIXED] Use custom encoder (if provided) for all view `key` params not just `keys`.
 
 # 2.14.0 (2020-08-17)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - [FIXED] Fixed result paging for grouped view queries.
 - [FIXED] Incorrect use of username as account name in `Cloudant.bluemix()`.
 - [IMPROVED] Documented use of None account name and url override for `Cloudant.iam()`.
+- [FIXED] Use custom encoder on get_docs params.
 
 # 2.14.0 (2020-08-17)
 

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -209,7 +209,9 @@ def _py_to_couch_translate(key, val, encoder=None):
     try:
         if key in ['keys', 'endkey_docid', 'startkey_docid', 'stale', 'update']:
             return {key: val}
-        elif key in ['endkey', 'key', 'startkey']:
+        elif key in ['endkey', 'key', 'startkey'] and type(val) is not (int or LONGTYPE or bool):
+            # if type(val) == list:
+            #     return {key: json.dumps(list(val), cls=encoder)}
             return {key: json.dumps(val, cls=encoder)}
         if val is None:
             return {key: None}

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -171,6 +171,7 @@ def python_to_couch(options, encoder=None):
     :func:`~cloudant.view.View.__call__` callable, both used to retrieve data.
 
     :param dict options: Python style parameters to be translated.
+    :param encoder: Custom encoder, defaults to None
 
     :returns: Dictionary of translated CouchDB/Cloudant query parameters
     """

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -209,9 +209,7 @@ def _py_to_couch_translate(key, val, encoder=None):
     try:
         if key in ['keys', 'endkey_docid', 'startkey_docid', 'stale', 'update']:
             return {key: val}
-        elif key in ['endkey', 'key', 'startkey'] and type(val) is not (int or LONGTYPE or bool):
-            # if type(val) == list:
-            #     return {key: json.dumps(list(val), cls=encoder)}
+        if key in ['endkey', 'key', 'startkey'] and type(val) is not (int or LONGTYPE or bool):
             return {key: json.dumps(val, cls=encoder)}
         if val is None:
             return {key: None}

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -29,8 +29,6 @@ try:
 except ImportError:
     from collections import Sequence
 
-ENCODER = None
-
 # Library Constants
 
 USER_AGENT = '/'.join([
@@ -78,12 +76,12 @@ RESULT_ARG_TYPES = {
 
 # pylint: disable=unnecessary-lambda
 TYPE_CONVERTERS = {
-    STRTYPE: lambda x: json.dumps(x, cls=ENCODER),
-    str: lambda x: json.dumps(x, cls=ENCODER),
-    UNITYPE: lambda x: json.dumps(x, cls=ENCODER),
-    Sequence: lambda x: json.dumps(list(x), cls=ENCODER),
-    list: lambda x: json.dumps(x, cls=ENCODER),
-    tuple: lambda x: json.dumps(list(x), cls=ENCODER),
+    STRTYPE: lambda x: json.dumps(x),
+    str: lambda x: json.dumps(x),
+    UNITYPE: lambda x: json.dumps(x),
+    Sequence: lambda x: json.dumps(list(x)),
+    list: lambda x: json.dumps(x),
+    tuple: lambda x: json.dumps(list(x)),
     int: lambda x: x,
     LONGTYPE: lambda x: x,
     bool: lambda x: 'true' if x else 'false',
@@ -211,9 +209,10 @@ def _py_to_couch_translate(key, val, encoder=None):
     try:
         if key in ['keys', 'endkey_docid', 'startkey_docid', 'stale', 'update']:
             return {key: val}
+        elif key in ['endkey', 'key', 'startkey']:
+            return {key: json.dumps(val, cls=encoder)}
         if val is None:
             return {key: None}
-        ENCODER = encoder
         arg_converter = TYPE_CONVERTERS.get(type(val))
         return {key: arg_converter(val)}
     except Exception as ex:

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -210,7 +210,7 @@ def _py_to_couch_translate(key, val, encoder=None):
     try:
         if key in ['keys', 'endkey_docid', 'startkey_docid', 'stale', 'update']:
             return {key: val}
-        if key in ['endkey', 'key', 'startkey'] and not isinstance(val, (int, LONGTYPE, bool)):
+        if key in ['endkey', 'key', 'startkey']:
             return {key: json.dumps(val, cls=encoder)}
         if val is None:
             return {key: None}

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -209,7 +209,7 @@ def _py_to_couch_translate(key, val, encoder=None):
     try:
         if key in ['keys', 'endkey_docid', 'startkey_docid', 'stale', 'update']:
             return {key: val}
-        if key in ['endkey', 'key', 'startkey'] and type(val) is not (int or LONGTYPE or bool):
+        if key in ['endkey', 'key', 'startkey'] and not isinstance(val, (int, LONGTYPE, bool)):
             return {key: json.dumps(val, cls=encoder)}
         if val is None:
             return {key: None}

--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -512,6 +512,15 @@ class DatabaseTests(UnitTestDbBase):
         data = self.db.all_docs(limit=1, skip=LONG_NUMBER)
         self.assertEqual(len(data.get('rows')), 1)
 
+    def test_all_docs_get_uses_custom_encoder(self):
+        """
+        Test that all_docs uses the custom encoder.
+        """
+        self.set_up_client(auto_connect=True, encoder="AEncoder")
+        database = self.client[self.test_dbname]
+        with self.assertRaises(CloudantArgumentError):
+            database.all_docs(endkey=['foo', 10])
+
     def test_custom_result_context_manager(self):
         """
         Test using the database custom result context manager

--- a/tests/unit/param_translation_tests.py
+++ b/tests/unit/param_translation_tests.py
@@ -44,7 +44,8 @@ class PythonToCouchTests(unittest.TestCase):
         """
         Test endkey translation is successful.
         """
-        self.assertEqual(python_to_couch({'endkey': 10}), {'endkey': 10})
+        expected = python_to_couch({'endkey': 10})
+        self.assertEqual(expected, {'endkey': 10})
         # Test with long type
         self.assertEqual(python_to_couch({'endkey': LONG_NUMBER}), {'endkey': LONG_NUMBER})
         self.assertEqual(
@@ -57,10 +58,8 @@ class PythonToCouchTests(unittest.TestCase):
         )
 
         # Test with custom encoder
-        self.assertEqual(
-            python_to_couch({'endkey': ['foo', 10]}, "AEncoder"),
-            {'endkey': '["foo", 10]'}
-        )
+        with self.assertRaises(CloudantArgumentError):
+            python_to_couch({'endkey': ['foo', 10]}, "AEncoder")
 
     def test_valid_endkey_docid(self):
         """

--- a/tests/unit/param_translation_tests.py
+++ b/tests/unit/param_translation_tests.py
@@ -36,7 +36,7 @@ class PythonToCouchTests(unittest.TestCase):
             {'descending': 'true'}
         )
         self.assertEqual(
-            python_to_couch({'descending': False}),
+            python_to_couch({'descending': False}), 
             {'descending': 'false'}
         )
 
@@ -44,8 +44,7 @@ class PythonToCouchTests(unittest.TestCase):
         """
         Test endkey translation is successful.
         """
-        expected = python_to_couch({'endkey': 10})
-        self.assertEqual(expected, {'endkey': 10})
+        self.assertEqual(python_to_couch({'endkey': 10}), {'endkey': 10})
         # Test with long type
         self.assertEqual(python_to_couch({'endkey': LONG_NUMBER}), {'endkey': LONG_NUMBER})
         self.assertEqual(

--- a/tests/unit/param_translation_tests.py
+++ b/tests/unit/param_translation_tests.py
@@ -57,10 +57,6 @@ class PythonToCouchTests(unittest.TestCase):
             {'endkey': '["foo", 10]'}
         )
 
-        # Test with custom encoder
-        with self.assertRaises(CloudantArgumentError):
-            python_to_couch({'endkey': ['foo', 10]}, "AEncoder")
-
     def test_valid_endkey_docid(self):
         """
         Test endkey_docid translation is successful.

--- a/tests/unit/param_translation_tests.py
+++ b/tests/unit/param_translation_tests.py
@@ -36,7 +36,7 @@ class PythonToCouchTests(unittest.TestCase):
             {'descending': 'true'}
         )
         self.assertEqual(
-            python_to_couch({'descending': False}), 
+            python_to_couch({'descending': False}),
             {'descending': 'false'}
         )
 
@@ -44,9 +44,9 @@ class PythonToCouchTests(unittest.TestCase):
         """
         Test endkey translation is successful.
         """
-        self.assertEqual(python_to_couch({'endkey': 10}), {'endkey': 10})
+        self.assertEqual(python_to_couch({'endkey': 10}), {'endkey': '10'})
         # Test with long type
-        self.assertEqual(python_to_couch({'endkey': LONG_NUMBER}), {'endkey': LONG_NUMBER})
+        self.assertEqual(python_to_couch({'endkey': LONG_NUMBER}), {'endkey': str(LONG_NUMBER)})
         self.assertEqual(
             python_to_couch({'endkey': 'foo'}),
             {'endkey': '"foo"'}
@@ -120,9 +120,9 @@ class PythonToCouchTests(unittest.TestCase):
         """
         Test key translation is successful.
         """
-        self.assertEqual(python_to_couch({'key': 10}), {'key': 10})
+        self.assertEqual(python_to_couch({'key': 10}), {'key': '10'})
         # Test with long type
-        self.assertEqual(python_to_couch({'key': LONG_NUMBER}), {'key': LONG_NUMBER})
+        self.assertEqual(python_to_couch({'key': LONG_NUMBER}), {'key': str(LONG_NUMBER)})
         self.assertEqual(python_to_couch({'key': 'foo'}), {'key': '"foo"'})
         self.assertEqual(
             python_to_couch({'key': ['foo', 10]}),
@@ -194,9 +194,9 @@ class PythonToCouchTests(unittest.TestCase):
         """
         Test startkey translation is successful.
         """
-        self.assertEqual(python_to_couch({'startkey': 10}), {'startkey': 10})
+        self.assertEqual(python_to_couch({'startkey': 10}), {'startkey': '10'})
         # Test with long type
-        self.assertEqual(python_to_couch({'startkey': LONG_NUMBER}), {'startkey': LONG_NUMBER})
+        self.assertEqual(python_to_couch({'startkey': LONG_NUMBER}), {'startkey': str(LONG_NUMBER)})
         self.assertEqual(
             python_to_couch({'startkey': 'foo'}),
             {'startkey': '"foo"'}

--- a/tests/unit/param_translation_tests.py
+++ b/tests/unit/param_translation_tests.py
@@ -36,7 +36,7 @@ class PythonToCouchTests(unittest.TestCase):
             {'descending': 'true'}
         )
         self.assertEqual(
-            python_to_couch({'descending': False}), 
+            python_to_couch({'descending': False}),
             {'descending': 'false'}
         )
 
@@ -53,6 +53,12 @@ class PythonToCouchTests(unittest.TestCase):
         )
         self.assertEqual(
             python_to_couch({'endkey': ['foo', 10]}),
+            {'endkey': '["foo", 10]'}
+        )
+
+        # Test with custom encoder
+        self.assertEqual(
+            python_to_couch({'endkey': ['foo', 10]}, "AEncoder"),
             {'endkey': '["foo", 10]'}
         )
 


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Fixes https://github.com/cloudant/python-cloudant/issues/221#issuecomment-752424499

## Approach

Used custom encoder at `_py_to_couch_translate` for `endkey`, `key`, and `startkey` parameters.

## Schema & API Changes

`endkey`, `key` and `startkey` parameters will be encoded with the custom encoder.

## Security and Privacy

- No change

## Testing

Test that all_docs uses the custom encoder. Fixed `test_valid_endkey`, `test_valid_key` and `test_valid_startkey ` with long type.

## Monitoring and Logging

- No change
