### PR TITLE
Support boolean type for `key`, `endkey`, and `startkey` in view requests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 - [FIXED] Incorrect use of username as account name in `Cloudant.bluemix()`.
 - [IMPROVED] Documented use of None account name and url override for `Cloudant.iam()`.
 - [FIXED] Use custom encoder (if provided) for all view `key` params not just `keys`.
-- [FIXED] View with a boolean type key.
+- [FIXED] Support boolean type for key, endkey, and startkey in view requests.
 
 # 2.14.0 (2020-08-17)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 - [FIXED] Incorrect use of username as account name in `Cloudant.bluemix()`.
 - [IMPROVED] Documented use of None account name and url override for `Cloudant.iam()`.
 - [FIXED] Use custom encoder (if provided) for all view `key` params not just `keys`.
-- [FIXED] Support boolean type for key, endkey, and startkey in view requests.
+- [FIXED] Support boolean type for `key`, `endkey`, and `startkey` in view requests.
 
 # 2.14.0 (2020-08-17)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - [FIXED] Incorrect use of username as account name in `Cloudant.bluemix()`.
 - [IMPROVED] Documented use of None account name and url override for `Cloudant.iam()`.
 - [FIXED] Use custom encoder (if provided) for all view `key` params not just `keys`.
+- [FIXED] View with a boolean type key.
 
 # 2.14.0 (2020-08-17)
 

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -191,7 +191,7 @@ def py_to_couch_validate(key, val):
     # Validate argument values and ensure that a boolean is not passed in
     # if an integer is expected
     if (not isinstance(val, RESULT_ARG_TYPES[key]) or
-            (type(val) is bool and int in RESULT_ARG_TYPES[key])):
+            (type(val) is bool and bool not in RESULT_ARG_TYPES[key] and int in RESULT_ARG_TYPES[key])):
         raise CloudantArgumentError(117, key, RESULT_ARG_TYPES[key])
     if key == 'keys':
         for key_list_val in val:

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -192,7 +192,7 @@ def py_to_couch_validate(key, val):
     if key == 'keys':
         for key_list_val in val:
             if (not isinstance(key_list_val, RESULT_ARG_TYPES['key']) or
-                    type(key_list_val) is bool):
+                    isinstance(key_list_val, bool)):
                 raise CloudantArgumentError(134, RESULT_ARG_TYPES['key'])
     if key == 'stale':
         if val not in ('ok', 'update_after'):

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -191,7 +191,8 @@ def py_to_couch_validate(key, val):
     # Validate argument values and ensure that a boolean is not passed in
     # if an integer is expected
     if (not isinstance(val, RESULT_ARG_TYPES[key]) or
-            (type(val) is bool and bool not in RESULT_ARG_TYPES[key] and int in RESULT_ARG_TYPES[key])):
+            (type(val) is bool and bool not in RESULT_ARG_TYPES[key] and
+             int in RESULT_ARG_TYPES[key])):
         raise CloudantArgumentError(117, key, RESULT_ARG_TYPES[key])
     if key == 'keys':
         for key_list_val in val:

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -187,7 +187,11 @@ def py_to_couch_validate(key, val):
     """
     if key not in RESULT_ARG_TYPES:
         raise CloudantArgumentError(116, key)
-    if not isinstance(val, RESULT_ARG_TYPES[key]):
+    # pylint: disable=unidiomatic-typecheck
+    # Validate argument values and ensure that a boolean is not passed in
+    # if an integer is expected
+    if (not isinstance(val, RESULT_ARG_TYPES[key]) or
+            (type(val) is bool and int in RESULT_ARG_TYPES[key])):
         raise CloudantArgumentError(117, key, RESULT_ARG_TYPES[key])
     if key == 'keys':
         for key_list_val in val:

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -56,20 +56,20 @@ ANY_TYPE = object()
 
 RESULT_ARG_TYPES = {
     'descending': (bool,),
-    'endkey': (int, LONGTYPE, STRTYPE, Sequence,),
+    'endkey': (int, LONGTYPE, STRTYPE, Sequence, bool,),
     'endkey_docid': (STRTYPE,),
     'group': (bool,),
     'group_level': (int, LONGTYPE, NONETYPE,),
     'include_docs': (bool,),
     'inclusive_end': (bool,),
-    'key': (int, LONGTYPE, STRTYPE, Sequence,),
+    'key': (int, LONGTYPE, STRTYPE, Sequence, bool,),
     'keys': (list,),
     'limit': (int, LONGTYPE, NONETYPE,),
     'reduce': (bool,),
     'skip': (int, LONGTYPE, NONETYPE,),
     'stable': (bool,),
     'stale': (STRTYPE,),
-    'startkey': (int, LONGTYPE, STRTYPE, Sequence,),
+    'startkey': (int, LONGTYPE, STRTYPE, Sequence, bool,),
     'startkey_docid': (STRTYPE,),
     'update': (STRTYPE,),
 }

--- a/src/cloudant/_common_util.py
+++ b/src/cloudant/_common_util.py
@@ -187,11 +187,7 @@ def py_to_couch_validate(key, val):
     """
     if key not in RESULT_ARG_TYPES:
         raise CloudantArgumentError(116, key)
-    # pylint: disable=unidiomatic-typecheck
-    # Validate argument values and ensure that a boolean is not passed in
-    # if an integer is expected
-    if (not isinstance(val, RESULT_ARG_TYPES[key]) or
-            (type(val) is bool and int in RESULT_ARG_TYPES[key])):
+    if not isinstance(val, RESULT_ARG_TYPES[key]):
         raise CloudantArgumentError(117, key, RESULT_ARG_TYPES[key])
     if key == 'keys':
         for key_list_val in val:

--- a/tests/unit/param_translation_tests.py
+++ b/tests/unit/param_translation_tests.py
@@ -240,16 +240,6 @@ class PythonToCouchTests(unittest.TestCase):
             python_to_couch({'descending': 10})
         self.assertTrue(str(cm.exception).startswith(msg))
 
-    def test_invalid_endkey(self):
-        """
-        Test endkey translation fails when a non-string or a non-list value is
-        used.
-        """
-        msg = 'Argument endkey not instance of expected type:'
-        with self.assertRaises(CloudantArgumentError) as cm:
-            python_to_couch({'endkey': True})
-        self.assertTrue(str(cm.exception).startswith(msg))
-
     def test_invalid_endkey_docid(self):
         """
         Test endkey_docid translation fails when a non-string value is used.
@@ -293,16 +283,6 @@ class PythonToCouchTests(unittest.TestCase):
         msg = 'Argument inclusive_end not instance of expected type:'
         with self.assertRaises(CloudantArgumentError) as cm:
             python_to_couch({'inclusive_end': 10})
-        self.assertTrue(str(cm.exception).startswith(msg))
-
-    def test_invalid_key(self):
-        """
-        Test key translation fails when a non-string or a non-list value is
-        used.
-        """
-        msg = 'Argument key not instance of expected type:'
-        with self.assertRaises(CloudantArgumentError) as cm:
-            python_to_couch({'key': True})
         self.assertTrue(str(cm.exception).startswith(msg))
 
     def test_invalid_keys_not_list(self):
@@ -363,16 +343,6 @@ class PythonToCouchTests(unittest.TestCase):
         msg = 'Invalid value for stale option foo'
         with self.assertRaises(CloudantArgumentError) as cm:
             python_to_couch({'stale': 'foo'})
-        self.assertTrue(str(cm.exception).startswith(msg))
-
-    def test_invalid_startkey(self):
-        """
-        Test startkey translation fails when a non-string or a non-list value
-        is used.
-        """
-        msg = 'Argument startkey not instance of expected type:'
-        with self.assertRaises(CloudantArgumentError) as cm:
-            python_to_couch({'startkey': True})
         self.assertTrue(str(cm.exception).startswith(msg))
 
     def test_invalid_startkey_docid(self):

--- a/tests/unit/param_translation_tests.py
+++ b/tests/unit/param_translation_tests.py
@@ -36,7 +36,7 @@ class PythonToCouchTests(unittest.TestCase):
             {'descending': 'true'}
         )
         self.assertEqual(
-            python_to_couch({'descending': False}), 
+            python_to_couch({'descending': False}),
             {'descending': 'false'}
         )
 
@@ -54,6 +54,11 @@ class PythonToCouchTests(unittest.TestCase):
         self.assertEqual(
             python_to_couch({'endkey': ['foo', 10]}),
             {'endkey': '["foo", 10]'}
+        )
+
+        self.assertEqual(
+            python_to_couch({'endkey': True}),
+            {'endkey': 'true'}
         )
 
     def test_valid_endkey_docid(self):
@@ -127,6 +132,10 @@ class PythonToCouchTests(unittest.TestCase):
         self.assertEqual(
             python_to_couch({'key': ['foo', 10]}),
             {'key': '["foo", 10]'}
+        )
+        self.assertEqual(
+            python_to_couch({'key': True}),
+            {'key': 'true'}
         )
 
     def test_valid_keys(self):
@@ -206,6 +215,11 @@ class PythonToCouchTests(unittest.TestCase):
             {'startkey': '["foo", 10]'}
         )
 
+        self.assertEqual(
+            python_to_couch({'startkey': True}),
+            {'startkey': 'true'}
+        )
+
     def test_valid_startkey_docid(self):
         """
         Test startkey_docid translation is successful.
@@ -238,16 +252,6 @@ class PythonToCouchTests(unittest.TestCase):
         msg = 'Argument descending not instance of expected type:'
         with self.assertRaises(CloudantArgumentError) as cm:
             python_to_couch({'descending': 10})
-        self.assertTrue(str(cm.exception).startswith(msg))
-
-    def test_invalid_endkey(self):
-        """
-        Test endkey translation fails when a non-string or a non-list value is
-        used.
-        """
-        msg = 'Argument endkey not instance of expected type:'
-        with self.assertRaises(CloudantArgumentError) as cm:
-            python_to_couch({'endkey': True})
         self.assertTrue(str(cm.exception).startswith(msg))
 
     def test_invalid_endkey_docid(self):
@@ -293,16 +297,6 @@ class PythonToCouchTests(unittest.TestCase):
         msg = 'Argument inclusive_end not instance of expected type:'
         with self.assertRaises(CloudantArgumentError) as cm:
             python_to_couch({'inclusive_end': 10})
-        self.assertTrue(str(cm.exception).startswith(msg))
-
-    def test_invalid_key(self):
-        """
-        Test key translation fails when a non-string or a non-list value is
-        used.
-        """
-        msg = 'Argument key not instance of expected type:'
-        with self.assertRaises(CloudantArgumentError) as cm:
-            python_to_couch({'key': True})
         self.assertTrue(str(cm.exception).startswith(msg))
 
     def test_invalid_keys_not_list(self):
@@ -363,16 +357,6 @@ class PythonToCouchTests(unittest.TestCase):
         msg = 'Invalid value for stale option foo'
         with self.assertRaises(CloudantArgumentError) as cm:
             python_to_couch({'stale': 'foo'})
-        self.assertTrue(str(cm.exception).startswith(msg))
-
-    def test_invalid_startkey(self):
-        """
-        Test startkey translation fails when a non-string or a non-list value
-        is used.
-        """
-        msg = 'Argument startkey not instance of expected type:'
-        with self.assertRaises(CloudantArgumentError) as cm:
-            python_to_couch({'startkey': True})
         self.assertTrue(str(cm.exception).startswith(msg))
 
     def test_invalid_startkey_docid(self):

--- a/tests/unit/param_translation_tests.py
+++ b/tests/unit/param_translation_tests.py
@@ -36,7 +36,7 @@ class PythonToCouchTests(unittest.TestCase):
             {'descending': 'true'}
         )
         self.assertEqual(
-            python_to_couch({'descending': False}),
+            python_to_couch({'descending': False}), 
             {'descending': 'false'}
         )
 
@@ -240,6 +240,16 @@ class PythonToCouchTests(unittest.TestCase):
             python_to_couch({'descending': 10})
         self.assertTrue(str(cm.exception).startswith(msg))
 
+    def test_invalid_endkey(self):
+        """
+        Test endkey translation fails when a non-string or a non-list value is
+        used.
+        """
+        msg = 'Argument endkey not instance of expected type:'
+        with self.assertRaises(CloudantArgumentError) as cm:
+            python_to_couch({'endkey': True})
+        self.assertTrue(str(cm.exception).startswith(msg))
+
     def test_invalid_endkey_docid(self):
         """
         Test endkey_docid translation fails when a non-string value is used.
@@ -283,6 +293,16 @@ class PythonToCouchTests(unittest.TestCase):
         msg = 'Argument inclusive_end not instance of expected type:'
         with self.assertRaises(CloudantArgumentError) as cm:
             python_to_couch({'inclusive_end': 10})
+        self.assertTrue(str(cm.exception).startswith(msg))
+
+    def test_invalid_key(self):
+        """
+        Test key translation fails when a non-string or a non-list value is
+        used.
+        """
+        msg = 'Argument key not instance of expected type:'
+        with self.assertRaises(CloudantArgumentError) as cm:
+            python_to_couch({'key': True})
         self.assertTrue(str(cm.exception).startswith(msg))
 
     def test_invalid_keys_not_list(self):
@@ -343,6 +363,16 @@ class PythonToCouchTests(unittest.TestCase):
         msg = 'Invalid value for stale option foo'
         with self.assertRaises(CloudantArgumentError) as cm:
             python_to_couch({'stale': 'foo'})
+        self.assertTrue(str(cm.exception).startswith(msg))
+
+    def test_invalid_startkey(self):
+        """
+        Test startkey translation fails when a non-string or a non-list value
+        is used.
+        """
+        msg = 'Argument startkey not instance of expected type:'
+        with self.assertRaises(CloudantArgumentError) as cm:
+            python_to_couch({'startkey': True})
         self.assertTrue(str(cm.exception).startswith(msg))
 
     def test_invalid_startkey_docid(self):

--- a/tests/unit/param_translation_tests.py
+++ b/tests/unit/param_translation_tests.py
@@ -55,7 +55,6 @@ class PythonToCouchTests(unittest.TestCase):
             python_to_couch({'endkey': ['foo', 10]}),
             {'endkey': '["foo", 10]'}
         )
-
         self.assertEqual(
             python_to_couch({'endkey': True}),
             {'endkey': 'true'}
@@ -214,7 +213,6 @@ class PythonToCouchTests(unittest.TestCase):
             python_to_couch({'startkey': ['foo', 10]}),
             {'startkey': '["foo", 10]'}
         )
-
         self.assertEqual(
             python_to_couch({'startkey': True}),
             {'startkey': 'true'}

--- a/tests/unit/param_translation_tests.py
+++ b/tests/unit/param_translation_tests.py
@@ -254,6 +254,16 @@ class PythonToCouchTests(unittest.TestCase):
             python_to_couch({'descending': 10})
         self.assertTrue(str(cm.exception).startswith(msg))
 
+    def test_invalid_endkey(self):
+        """
+        Test endkey translation fails when a non-string or a non-list value is
+        used.
+        """
+        msg = 'Argument endkey not instance of expected type:'
+        with self.assertRaises(CloudantArgumentError) as cm:
+            python_to_couch({'endkey': {'foo': 'bar'}})
+        self.assertTrue(str(cm.exception).startswith(msg))
+
     def test_invalid_endkey_docid(self):
         """
         Test endkey_docid translation fails when a non-string value is used.
@@ -297,6 +307,16 @@ class PythonToCouchTests(unittest.TestCase):
         msg = 'Argument inclusive_end not instance of expected type:'
         with self.assertRaises(CloudantArgumentError) as cm:
             python_to_couch({'inclusive_end': 10})
+        self.assertTrue(str(cm.exception).startswith(msg))
+
+    def test_invalid_key(self):
+        """
+        Test key translation fails when a non-string or a non-list value is
+        used.
+        """
+        msg = 'Argument key not instance of expected type:'
+        with self.assertRaises(CloudantArgumentError) as cm:
+            python_to_couch({'key': {'foo': 'bar'}})
         self.assertTrue(str(cm.exception).startswith(msg))
 
     def test_invalid_keys_not_list(self):
@@ -357,6 +377,16 @@ class PythonToCouchTests(unittest.TestCase):
         msg = 'Invalid value for stale option foo'
         with self.assertRaises(CloudantArgumentError) as cm:
             python_to_couch({'stale': 'foo'})
+        self.assertTrue(str(cm.exception).startswith(msg))
+
+    def test_invalid_startkey(self):
+        """
+        Test startkey translation fails when a non-string or a non-list value
+        is used.
+        """
+        msg = 'Argument startkey not instance of expected type:'
+        with self.assertRaises(CloudantArgumentError) as cm:
+            python_to_couch({'startkey': {'foo': 'bar'}})
         self.assertTrue(str(cm.exception).startswith(msg))
 
     def test_invalid_startkey_docid(self):


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Fixes #494 

## Approach

Allow bool type for `endkey`, `key`, and `startkey`. 

## Schema & API Changes

- No change

## Security and Privacy

- No change


## Testing

Edited the `invalid` tests to use `{'foo': 'bar'}` invalid values instead of booleans, and extended the existing tests to validate boolean types.

## Monitoring and Logging

- No change
