### PR TITLE
Override dict's get method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 - [FIXED] Incorrect use of username as account name in `Cloudant.bluemix()`.
 - [IMPROVED] Documented use of None account name and url override for `Cloudant.iam()`.
 - [FIXED] Use custom encoder (if provided) for all view `key` params not just `keys`.
-- [NEW] Override the `get()` method for CouchDatabase, allowing it to retrive remote docuemnts if the `remote` parameter is specified.
+- [NEW] Override `dict.get` method for `CouchDatabase` to add `remote` parameter allowing it to retrieve a remote document if specified.
 
 # 2.14.0 (2020-08-17)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - [FIXED] Incorrect use of username as account name in `Cloudant.bluemix()`.
 - [IMPROVED] Documented use of None account name and url override for `Cloudant.iam()`.
 - [FIXED] Use custom encoder (if provided) for all view `key` params not just `keys`.
+- [NEW] Override the `get()` method for CouchDatabase, allowing it to retrive remote docuemnts if the `remote` parameter is specified.
 
 # 2.14.0 (2020-08-17)
 

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -705,6 +705,25 @@ class CouchDatabase(dict):
         else:
             raise KeyError(key)
         return doc
+		
+    def get(self, key, remote=False):
+        """
+        Overrides dict's get method. This gets an item from the databse  or cache 
+        like __getitem__, but instead of throwing an exception if the item is not
+        found, it simply returns None.
+        
+        :param bool remote: Dictates whether a request to the server is made to
+            retreive the doc, or if the doc will only be retrieved from the local
+            cache.
+            Defaults to False.
+        """
+        if remote:
+            try:
+                return self.__getitem__(key)
+            except KeyError:
+                return None
+        else:
+            return super(CouchDatabase, self).get(key)
 
     def __contains__(self, key):
         """

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -705,13 +705,13 @@ class CouchDatabase(dict):
         else:
             raise KeyError(key)
         return doc
-		
+
     def get(self, key, remote=False):
         """
-        Overrides dict's get method. This gets an item from the databse  or cache 
+        Overrides dict's get method. This gets an item from the databse  or cache
         like __getitem__, but instead of throwing an exception if the item is not
         found, it simply returns None.
-        
+
         :param bool remote: Dictates whether a request to the server is made to
             retreive the doc, or if the doc will only be retrieved from the local
             cache.

--- a/src/cloudant/database.py
+++ b/src/cloudant/database.py
@@ -708,13 +708,12 @@ class CouchDatabase(dict):
 
     def get(self, key, remote=False):
         """
-        Overrides dict's get method. This gets an item from the databse  or cache
+        Overrides dict's get method. This gets an item from the database or cache
         like __getitem__, but instead of throwing an exception if the item is not
         found, it simply returns None.
 
-        :param bool remote: Dictates whether a request to the server is made to
-            retreive the doc, or if the doc will only be retrieved from the local
-            cache.
+        :param bool remote: Dictates whether a remote request is made to
+            retrieve the doc, if it is not present in the local cache.
             Defaults to False.
         """
         if remote:

--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -256,6 +256,8 @@ class DatabaseTests(UnitTestDbBase):
         data = {'_id': 'julia06', 'name': 'julia', 'age': 6}
         doc = self.db.create_document(data)
         self.assertEqual(self.db['julia06'], doc)
+        self.assertEqual(self.db.get('julia06'), doc)
+        self.assertEqual(self.db.get('julia06', remote=True), doc)
         self.assertEqual(doc['_id'], data['_id'])
         self.assertTrue(doc['_rev'].startswith('1-'))
         self.assertEqual(doc['name'], data['name'])
@@ -271,6 +273,42 @@ class DatabaseTests(UnitTestDbBase):
                 'Document with id julia06 already exists.'
                 )
 
+    def test_get_non_existing_document_from_remote(self):
+        """
+        Test dict's get on non existing document from remote.
+        """
+        doc = self.db.get('non-existing', remote=True)
+        self.assertIsNone(doc)
+
+    def test_get_non_existing_document_from_cache(self):
+        """
+        Test dict's get on non existing document from cache.
+        """
+        doc = self.db.get('non-existing')
+        self.assertIsNone(doc)
+
+    def test_get_document_from_cache(self):
+        """
+        Test dict's get on a document from cache.
+        """
+        doc = Document(self.db, document_id='julia06')
+        self.db['julia06'] = doc
+        self.assertEqual(self.db.get('julia06'), doc)
+        # fetch the local doc independently from the value of the remote param
+        self.assertEqual(self.db.get('julia06', remote=True), doc)
+        self.assertEqual(self.db['julia06'], doc)
+
+    def test_get_document_from_remote(self):
+        """
+        Test dict's get on a document from remote.
+        """
+        data = {'_id': 'julia06','name': 'julia06', 'age': 6}
+        doc = self.db.create_document(data)
+        self.db.clear()
+        self.assertIsNone(self.db.get('julia06'))
+        self.assertEqual(self.db.get('julia06', remote=True), doc)
+        self.assertEqual(self.db['julia06'], doc)
+
     def test_create_document_that_already_exists(self):
         """
         Test creating a document that already exists
@@ -278,6 +316,8 @@ class DatabaseTests(UnitTestDbBase):
         data = {'_id': 'julia'}
         doc = self.db.create_document(data)
         self.assertEqual(self.db['julia'], doc)
+        self.assertEqual(self.db.get('julia', doc))
+        self.assertEqual(self.db.get('julia', remote=True), doc)
         self.assertTrue(doc['_rev'].startswith('1-'))
         # attempt to recreate document
         self.db.create_document(data, throw_on_exists=False)
@@ -289,6 +329,8 @@ class DatabaseTests(UnitTestDbBase):
         data = {'name': 'julia', 'age': 6}
         doc = self.db.create_document(data)
         self.assertEqual(self.db[doc['_id']], doc)
+        self.assertEqual(self.db.get(doc['_id']), doc)
+        self.assertEqual(self.db.get(doc['_id'], remote=True), doc)
         self.assertTrue(doc['_rev'].startswith('1-'))
         self.assertEqual(doc['name'], data['name'])
         self.assertEqual(doc['age'], data['age'])
@@ -302,6 +344,8 @@ class DatabaseTests(UnitTestDbBase):
         data = {'_id': '_design/julia06', 'name': 'julia', 'age': 6}
         doc = self.db.create_document(data)
         self.assertEqual(self.db['_design/julia06'], doc)
+        self.assertEqual(self.db.get('_design/julia06'), doc)
+        self.assertEqual(self.db.get('_design/julia06', remote=True), doc)
         self.assertEqual(doc['_id'], data['_id'])
         self.assertTrue(doc['_rev'].startswith('1-'))
         self.assertEqual(doc['name'], data['name'])
@@ -316,6 +360,8 @@ class DatabaseTests(UnitTestDbBase):
         """
         empty_doc = self.db.new_document()
         self.assertEqual(self.db[empty_doc['_id']], empty_doc)
+        self.assertEqual(self.db.get(empty_doc['_id']), empty_doc)
+        self.assertEqual(self.db.get(empty_doc['_id'], remote=True), empty_doc)
         self.assertTrue(all(x in ['_id', '_rev'] for x in empty_doc.keys()))
         self.assertTrue(empty_doc['_rev'].startswith('1-'))
 

--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -294,7 +294,7 @@ class DatabaseTests(UnitTestDbBase):
         doc = Document(self.db, document_id='julia06')
         self.db['julia06'] = doc
         self.assertEqual(self.db.get('julia06'), doc)
-        # fetch the local doc independently from the value of the remote param
+        # doc is fetched from the local dict preferentially to remote even with remote=True
         self.assertEqual(self.db.get('julia06', remote=True), doc)
         self.assertEqual(self.db['julia06'], doc)
 

--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -316,7 +316,7 @@ class DatabaseTests(UnitTestDbBase):
         data = {'_id': 'julia'}
         doc = self.db.create_document(data)
         self.assertEqual(self.db['julia'], doc)
-        self.assertEqual(self.db.get('julia', doc))
+        self.assertEqual(self.db.get('julia'), doc)
         self.assertEqual(self.db.get('julia', remote=True), doc)
         self.assertTrue(doc['_rev'].startswith('1-'))
         # attempt to recreate document


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Merges #474 and tests.

## Approach

One sentence in the pydoc was a little bit misleading, so I changed it to:
> Dictates whether a remote request is made to retrieve the doc, if it is not present in the local cache.

Extended the tests to cover the new behaviour based on the proposed behaviour table.

### Proposed behaviour


| Call | Doc is local | Doc is remote | Result | Covered with tests |
| --- | --- | --- | --- | --- |
| `db['foo']` | `True` | `True` | returns local doc | test_create_document_that_already_exists<br>test_create_document_without_id<br>test_create_design_document<br>test_create_empty_document
| `db['foo']` | `False` | `True` | returns remote doc | test_get_document_from_remote |
| `db['foo']` | `False` | `False` | returns `KeyError` | test_get_non_existing_doc_via_getitem
| `db['foo']` | `True` | `False` | returns local doc | test_get_document_from_cache |
| `db.get('foo')` | `True` | `True` | returns local doc | test_create_document_that_already_exists<br>test_create_document_without_id<br>test_create_design_document<br>
| `db.get('foo')` | `False` | `True` | returns `None` | test_get_document_from_remote |
| `db.get('foo')` | `False` | `False` | returns `None` | test_get_non_existing_document_from_cache |
| `db.get('foo')` | `True` | `False` | returns local doc | test_get_document_from_cache |
| `db.get('foo', remote=True)` | `True` | `True` | returns local doc | test_create_document_that_already_exists<br>test_create_document_without_id<br>test_create_design_document<br>test_create_empty_document
| `db.get('foo', remote=True)` | `False` | `True` | fetches remote doc | test_get_document_from_remote |
| `db.get('foo', remote=True)` | `False` | `False` | returns `None` | test_get_non_existing_document_from_remote |
| `db.get('foo', remote=True)` | `True` | `False` | returns local doc | test_get_document_from_cache |

## Testing

New assertions to cover the new feature to:
* `test_create_document_with_id`
* `test_create_document_that_already_exists`
* `test_create_document_without_id`
* `test_create_design_document`
* `test_create_empty_document`

New test cases:
* `test_get_non_existing_document_from_remote`
* `test_get_non_existing_document_from_cache`
* `test_get_document_from_cache`
* `test_get_document_from_remote`

## Monitoring and Logging

- No change