### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/tests/unit/changes_tests.py
+++ b/tests/unit/changes_tests.py
@@ -474,9 +474,9 @@ class ChangesTests(UnitTestDbBase):
             include_docs=False
         )
         params = feed._translate(feed._options)
-        self.assertEquals(params['filter'], 'mailbox/new_mail')
-        self.assertEquals(params['foo'], 'bar')
-        self.assertEquals(params['include_docs'], 'false')
+        self.assertEqual(params['filter'], 'mailbox/new_mail')
+        self.assertEqual(params['foo'], 'bar')
+        self.assertEqual(params['include_docs'], 'false')
 
     def test_invalid_argument_type(self):
         """

--- a/tests/unit/client_tests.py
+++ b/tests/unit/client_tests.py
@@ -266,7 +266,7 @@ class ClientTests(UnitTestDbBase):
             timeout=None
         )
 
-        self.assertEquals(all_dbs, ['animaldb'])
+        self.assertEqual(all_dbs, ['animaldb'])
 
     @mock.patch('cloudant._client_session.Session.request')
     def test_session_basic_with_no_credentials(self, m_req):
@@ -333,7 +333,7 @@ class ClientTests(UnitTestDbBase):
             auth=('baz', 'qux'),  # uses HTTP Basic Auth
             timeout=None
         )
-        self.assertEquals(all_dbs, ['animaldb'])
+        self.assertEqual(all_dbs, ['animaldb'])
 
     @skip_if_not_cookie_auth
     def test_basic_auth_str(self):
@@ -442,7 +442,7 @@ class ClientTests(UnitTestDbBase):
 
         self.assertEqual(cm.exception.status_code, 500)
 
-        self.assertEquals(m_req.call_count, 3)
+        self.assertEqual(m_req.call_count, 3)
         m_req.assert_called_with(
             'PUT',
             '/'.join([self.url, dbname]),
@@ -730,7 +730,7 @@ class CloudantClientTests(UnitTestDbBase):
             with cloudant_bluemix(vcap_services, instance_name=instance_name) as c:
                 self.assertIsInstance(c, Cloudant)
                 self.assertIsInstance(c.r_session, requests.Session)
-                self.assertEquals(c.session()['userCtx']['name'], self.user)
+                self.assertEqual(c.session()['userCtx']['name'], self.user)
         except Exception as err:
             self.fail('Exception {0} was raised.'.format(str(err)))
 
@@ -809,7 +809,7 @@ class CloudantClientTests(UnitTestDbBase):
                                   service_name=service_name) as c:
                 self.assertIsInstance(c, Cloudant)
                 self.assertIsInstance(c.r_session, requests.Session)
-                self.assertEquals(c.session()['userCtx']['name'], self.user)
+                self.assertEqual(c.session()['userCtx']['name'], self.user)
         except Exception as err:
             self.fail('Exception {0} was raised.'.format(str(err)))
 
@@ -850,7 +850,7 @@ class CloudantClientTests(UnitTestDbBase):
             c.connect()
             self.assertIsInstance(c, Cloudant)
             self.assertIsInstance(c.r_session, requests.Session)
-            self.assertEquals(c.session()['userCtx']['name'], self.user)
+            self.assertEqual(c.session()['userCtx']['name'], self.user)
 
         except Exception as err:
             self.fail('Exception {0} was raised.'.format(str(err)))
@@ -916,7 +916,7 @@ class CloudantClientTests(UnitTestDbBase):
             c.connect()
             self.assertIsInstance(c, Cloudant)
             self.assertIsInstance(c.r_session, requests.Session)
-            self.assertEquals(c.session()['userCtx']['name'], self.user)
+            self.assertEqual(c.session()['userCtx']['name'], self.user)
 
         except Exception as err:
             self.fail('Exception {0} was raised.'.format(str(err)))
@@ -960,7 +960,7 @@ class CloudantClientTests(UnitTestDbBase):
             c.connect()
             self.assertIsInstance(c, Cloudant)
             self.assertIsInstance(c.r_session, requests.Session)
-            self.assertEquals(c.session()['userCtx']['name'], self.user)
+            self.assertEqual(c.session()['userCtx']['name'], self.user)
 
         except Exception as err:
             self.fail('Exception {0} was raised.'.format(str(err)))

--- a/tests/unit/database_partition_tests.py
+++ b/tests/unit/database_partition_tests.py
@@ -63,7 +63,7 @@ class DatabasePartitionTests(UnitTestDbBase):
     def test_partitioned_all_docs(self):
         for partition_key in self.populate_db_with_partitioned_documents(5, 25):
             docs = self.db.partitioned_all_docs(partition_key)
-            self.assertEquals(len(docs['rows']), 25)
+            self.assertEqual(len(docs['rows']), 25)
 
             for doc in docs['rows']:
                 self.assertTrue(doc['id'].startswith(partition_key + ':'))
@@ -71,8 +71,8 @@ class DatabasePartitionTests(UnitTestDbBase):
     def test_partition_metadata(self):
         for partition_key in self.populate_db_with_partitioned_documents(5, 25):
             meta = self.db.partition_metadata(partition_key)
-            self.assertEquals(meta['partition'], partition_key)
-            self.assertEquals(meta['doc_count'], 25)
+            self.assertEqual(meta['partition'], partition_key)
+            self.assertEqual(meta['doc_count'], 25)
 
     def test_partitioned_search(self):
         ddoc = DesignDocument(self.db, 'partitioned_search', partitioned=True)
@@ -91,7 +91,7 @@ class DatabasePartitionTests(UnitTestDbBase):
                 print(result)
                 self.assertTrue(result['id'].startswith(partition_key + ':'))
                 i += 1
-            self.assertEquals(i, 10)
+            self.assertEqual(i, 10)
 
     def test_get_partitioned_index(self):
         index_name = 'test_partitioned_index'
@@ -99,16 +99,16 @@ class DatabasePartitionTests(UnitTestDbBase):
         self.db.create_query_index(index_name=index_name, fields=['foo'])
 
         results = self.db.get_query_indexes()
-        self.assertEquals(len(results), 2)
+        self.assertEqual(len(results), 2)
 
         index_all_docs = results[0]
-        self.assertEquals(index_all_docs.name, '_all_docs')
-        self.assertEquals(type(index_all_docs), SpecialIndex)
+        self.assertEqual(index_all_docs.name, '_all_docs')
+        self.assertEqual(type(index_all_docs), SpecialIndex)
         self.assertFalse(index_all_docs.partitioned)
 
         index_partitioned = results[1]
-        self.assertEquals(index_partitioned.name, index_name)
-        self.assertEquals(type(index_partitioned), Index)
+        self.assertEqual(index_partitioned.name, index_name)
+        self.assertEqual(type(index_partitioned), Index)
         self.assertTrue(index_partitioned.partitioned)
 
     def test_partitioned_query(self):
@@ -122,7 +122,7 @@ class DatabasePartitionTests(UnitTestDbBase):
             for result in results:
                 self.assertTrue(result['_id'].startswith(partition_key + ':'))
                 i += 1
-            self.assertEquals(i, 10)
+            self.assertEqual(i, 10)
 
     def test_partitioned_view(self):
         ddoc = DesignDocument(self.db, 'partitioned_view', partitioned=True)
@@ -138,4 +138,4 @@ class DatabasePartitionTests(UnitTestDbBase):
                 self.assertTrue(
                     result['id'].startswith(partition_key + ':'))
                 i += 1
-            self.assertEquals(i, 10)
+            self.assertEqual(i, 10)

--- a/tests/unit/database_tests.py
+++ b/tests/unit/database_tests.py
@@ -885,7 +885,7 @@ class DatabaseTests(UnitTestDbBase):
         # Get new revisions limit.
         self.assertEqual(self.db.get_revision_limit(), 1234)
 
-        self.assertEquals(m_req.call_count, 3)
+        self.assertEqual(m_req.call_count, 3)
 
     @attr(db='couch')
     def test_view_clean_up(self):
@@ -1084,19 +1084,19 @@ class DatabaseTests(UnitTestDbBase):
 
         ddoc = self.db[index.design_document_id]
 
-        self.assertEquals(ddoc['_id'], index.design_document_id)
+        self.assertEqual(ddoc['_id'], index.design_document_id)
         self.assertTrue(ddoc['_rev'].startswith('1-'))
 
-        self.assertEquals(ddoc['indexes'], {})
-        self.assertEquals(ddoc['language'], 'query')
-        self.assertEquals(ddoc['lists'], {})
-        self.assertEquals(ddoc['shows'], {})
+        self.assertEqual(ddoc['indexes'], {})
+        self.assertEqual(ddoc['language'], 'query')
+        self.assertEqual(ddoc['lists'], {})
+        self.assertEqual(ddoc['shows'], {})
 
         index = ddoc['views'][index.name]
-        self.assertEquals(index['map']['fields']['age'], 'asc')
-        self.assertEquals(index['map']['fields']['name'], 'asc')
-        self.assertEquals(index['options']['def']['fields'], ['name', 'age'])
-        self.assertEquals(index['reduce'], '_count')
+        self.assertEqual(index['map']['fields']['age'], 'asc')
+        self.assertEqual(index['map']['fields']['name'], 'asc')
+        self.assertEqual(index['options']['def']['fields'], ['name', 'age'])
+        self.assertEqual(index['reduce'], '_count')
 
     @attr(couchapi=2)
     def test_delete_json_index(self):
@@ -1369,22 +1369,22 @@ class CloudantDatabaseTests(UnitTestDbBase):
 
         ddoc = self.db[index.design_document_id]
 
-        self.assertEquals(ddoc['_id'], index.design_document_id)
+        self.assertEqual(ddoc['_id'], index.design_document_id)
         self.assertTrue(ddoc['_rev'].startswith('1-'))
 
-        self.assertEquals(ddoc['language'], 'query')
-        self.assertEquals(ddoc['lists'], {})
-        self.assertEquals(ddoc['shows'], {})
-        self.assertEquals(ddoc['views'], {})
+        self.assertEqual(ddoc['language'], 'query')
+        self.assertEqual(ddoc['lists'], {})
+        self.assertEqual(ddoc['shows'], {})
+        self.assertEqual(ddoc['views'], {})
 
         text_index = ddoc['indexes'][index.name]
-        self.assertEquals(text_index['analyzer']['default'], 'keyword')
-        self.assertEquals(text_index['analyzer']['fields']['$default'], 'standard')
-        self.assertEquals(text_index['analyzer']['name'], 'perfield')
-        self.assertEquals(text_index['index']['default_analyzer'], 'keyword')
-        self.assertEquals(text_index['index']['default_field'], {})
-        self.assertEquals(text_index['index']['fields'], [{'name': 'name', 'type': 'string'}, {'name': 'age', 'type': 'number'}])
-        self.assertEquals(text_index['index']['selector'], {})
+        self.assertEqual(text_index['analyzer']['default'], 'keyword')
+        self.assertEqual(text_index['analyzer']['fields']['$default'], 'standard')
+        self.assertEqual(text_index['analyzer']['name'], 'perfield')
+        self.assertEqual(text_index['index']['default_analyzer'], 'keyword')
+        self.assertEqual(text_index['index']['default_field'], {})
+        self.assertEqual(text_index['index']['fields'], [{'name': 'name', 'type': 'string'}, {'name': 'age', 'type': 'number'}])
+        self.assertEqual(text_index['index']['selector'], {})
         self.assertTrue(text_index['index']['index_array_lengths'])
 
     def test_create_all_fields_text_index(self):
@@ -1396,22 +1396,22 @@ class CloudantDatabaseTests(UnitTestDbBase):
 
         ddoc = self.db[index.design_document_id]
 
-        self.assertEquals(ddoc['_id'], index.design_document_id)
+        self.assertEqual(ddoc['_id'], index.design_document_id)
         self.assertTrue(ddoc['_rev'].startswith('1-'))
 
-        self.assertEquals(ddoc['language'], 'query')
-        self.assertEquals(ddoc['lists'], {})
-        self.assertEquals(ddoc['shows'], {})
-        self.assertEquals(ddoc['views'], {})
+        self.assertEqual(ddoc['language'], 'query')
+        self.assertEqual(ddoc['lists'], {})
+        self.assertEqual(ddoc['shows'], {})
+        self.assertEqual(ddoc['views'], {})
 
         index = ddoc['indexes'][index.name]
-        self.assertEquals(index['analyzer']['default'], 'keyword')
-        self.assertEquals(index['analyzer']['fields'], {'$default': 'standard'})
-        self.assertEquals(index['analyzer']['name'], 'perfield')
-        self.assertEquals(index['index']['default_analyzer'], 'keyword')
-        self.assertEquals(index['index']['default_field'], {})
-        self.assertEquals(index['index']['fields'], 'all_fields')
-        self.assertEquals(index['index']['selector'], {})
+        self.assertEqual(index['analyzer']['default'], 'keyword')
+        self.assertEqual(index['analyzer']['fields'], {'$default': 'standard'})
+        self.assertEqual(index['analyzer']['name'], 'perfield')
+        self.assertEqual(index['index']['default_analyzer'], 'keyword')
+        self.assertEqual(index['index']['default_field'], {})
+        self.assertEqual(index['index']['fields'], 'all_fields')
+        self.assertEqual(index['index']['selector'], {})
         self.assertTrue(index['index']['index_array_lengths'])
 
     def test_create_multiple_indexes_one_ddoc(self):
@@ -1436,27 +1436,27 @@ class CloudantDatabaseTests(UnitTestDbBase):
 
         ddoc = self.db['_design/ddoc001']
 
-        self.assertEquals(ddoc['_id'], index.design_document_id)
+        self.assertEqual(ddoc['_id'], index.design_document_id)
         self.assertTrue(ddoc['_rev'].startswith('2-'))
 
-        self.assertEquals(ddoc['language'], 'query')
-        self.assertEquals(ddoc['lists'], {})
-        self.assertEquals(ddoc['shows'], {})
+        self.assertEqual(ddoc['language'], 'query')
+        self.assertEqual(ddoc['lists'], {})
+        self.assertEqual(ddoc['shows'], {})
 
         json_index = ddoc['views']['json-index-001']
-        self.assertEquals(json_index['map']['fields']['age'], 'asc')
-        self.assertEquals(json_index['map']['fields']['name'], 'asc')
-        self.assertEquals(json_index['options']['def']['fields'], ['name', 'age'])
-        self.assertEquals(json_index['reduce'], '_count')
+        self.assertEqual(json_index['map']['fields']['age'], 'asc')
+        self.assertEqual(json_index['map']['fields']['name'], 'asc')
+        self.assertEqual(json_index['options']['def']['fields'], ['name', 'age'])
+        self.assertEqual(json_index['reduce'], '_count')
 
         text_index = ddoc['indexes']['text-index-001']
-        self.assertEquals(text_index['analyzer']['default'], 'keyword')
-        self.assertEquals(text_index['analyzer']['fields']['$default'], 'standard')
-        self.assertEquals(text_index['analyzer']['name'], 'perfield')
-        self.assertEquals(text_index['index']['default_analyzer'], 'keyword')
-        self.assertEquals(text_index['index']['default_field'], {})
-        self.assertEquals(text_index['index']['fields'], [{'name': 'name', 'type': 'string'}, {'name': 'age', 'type': 'number'}])
-        self.assertEquals(text_index['index']['selector'], {})
+        self.assertEqual(text_index['analyzer']['default'], 'keyword')
+        self.assertEqual(text_index['analyzer']['fields']['$default'], 'standard')
+        self.assertEqual(text_index['analyzer']['name'], 'perfield')
+        self.assertEqual(text_index['index']['default_analyzer'], 'keyword')
+        self.assertEqual(text_index['index']['default_field'], {})
+        self.assertEqual(text_index['index']['fields'], [{'name': 'name', 'type': 'string'}, {'name': 'age', 'type': 'number'}])
+        self.assertEqual(text_index['index']['selector'], {})
         self.assertTrue(text_index['index']['index_array_lengths'])
 
     def test_create_query_index_failure(self):
@@ -1513,28 +1513,28 @@ class CloudantDatabaseTests(UnitTestDbBase):
 
         indexes = self.db.get_query_indexes(raw_result=True)
 
-        self.assertEquals(indexes['total_rows'], 3)
+        self.assertEqual(indexes['total_rows'], 3)
 
         all_docs_index = indexes['indexes'][0]
-        self.assertEquals(all_docs_index['ddoc'], None)
-        self.assertEquals(all_docs_index['def']['fields'], [{'_id': 'asc'}])
-        self.assertEquals(all_docs_index['name'], '_all_docs')
-        self.assertEquals(all_docs_index['type'], 'special')
+        self.assertEqual(all_docs_index['ddoc'], None)
+        self.assertEqual(all_docs_index['def']['fields'], [{'_id': 'asc'}])
+        self.assertEqual(all_docs_index['name'], '_all_docs')
+        self.assertEqual(all_docs_index['type'], 'special')
 
         json_index = indexes['indexes'][1]
-        self.assertEquals(json_index['ddoc'], '_design/ddoc001')
-        self.assertEquals(json_index['def']['fields'], [{'name': 'asc'}, {'age': 'asc'}])
-        self.assertEquals(json_index['name'], 'json-idx-001')
-        self.assertEquals(json_index['type'], 'json')
+        self.assertEqual(json_index['ddoc'], '_design/ddoc001')
+        self.assertEqual(json_index['def']['fields'], [{'name': 'asc'}, {'age': 'asc'}])
+        self.assertEqual(json_index['name'], 'json-idx-001')
+        self.assertEqual(json_index['type'], 'json')
 
         text_index = indexes['indexes'][2]
-        self.assertEquals(text_index['ddoc'], '_design/ddoc001')
-        self.assertEquals(text_index['def']['default_analyzer'], 'keyword')
-        self.assertEquals(text_index['def']['default_field'], {})
-        self.assertEquals(text_index['def']['fields'], [])
-        self.assertEquals(text_index['def']['selector'], {})
-        self.assertEquals(text_index['name'], 'text-idx-001')
-        self.assertEquals(text_index['type'], 'text')
+        self.assertEqual(text_index['ddoc'], '_design/ddoc001')
+        self.assertEqual(text_index['def']['default_analyzer'], 'keyword')
+        self.assertEqual(text_index['def']['default_field'], {})
+        self.assertEqual(text_index['def']['fields'], [])
+        self.assertEqual(text_index['def']['selector'], {})
+        self.assertEqual(text_index['name'], 'text-idx-001')
+        self.assertEqual(text_index['type'], 'text')
         self.assertTrue(text_index['def']['index_array_lengths'])
 
     def test_get_query_indexes(self):

--- a/tests/unit/design_document_tests.py
+++ b/tests/unit/design_document_tests.py
@@ -843,9 +843,9 @@ class DesignDocumentTests(UnitTestDbBase):
         # Validate the metadata
         search_index_metadata = search_info['search_index']
         self.assertIsNotNone(search_index_metadata)
-        self.assertEquals(search_index_metadata['doc_del_count'], 0, 'There should be no deleted docs.')
+        self.assertEqual(search_index_metadata['doc_del_count'], 0, 'There should be no deleted docs.')
         self.assertTrue(search_index_metadata['doc_count'] <= 100, 'There should be 100 or fewer docs.')
-        self.assertEquals(search_index_metadata['committed_seq'], 0, 'The committed_seq should be 0.')
+        self.assertEqual(search_index_metadata['committed_seq'], 0, 'The committed_seq should be 0.')
         self.assertTrue(search_index_metadata['pending_seq'] <= 101, 'The pending_seq should be 101 or fewer.')
         self.assertTrue(search_index_metadata['disk_size'] >0, 'The disk_size should be greater than 0.')
 
@@ -1275,7 +1275,7 @@ class DesignDocumentTests(UnitTestDbBase):
         doc = Document(self.db, 'rewrite_doc')
         doc.save()
         resp = self.client.r_session.get('/'.join([ddoc.document_url, '_rewrite']))
-        self.assertEquals(
+        self.assertEqual(
             response_to_json_dict(resp),
             {
                 '_id': 'rewrite_doc',

--- a/tests/unit/document_tests.py
+++ b/tests/unit/document_tests.py
@@ -944,14 +944,14 @@ class DocumentTests(UnitTestDbBase):
 
         raw_doc = self.db.all_docs(include_docs=True)['rows'][0]['doc']
 
-        self.assertEquals(raw_doc['name'], 'julia')
-        self.assertEquals(raw_doc['dt']['_type'], 'datetime')
-        self.assertEquals(raw_doc['dt']['value'], '2018-07-09T15:11:10')
+        self.assertEqual(raw_doc['name'], 'julia')
+        self.assertEqual(raw_doc['dt']['_type'], 'datetime')
+        self.assertEqual(raw_doc['dt']['value'], '2018-07-09T15:11:10')
 
         doc2 = Document(self.db, doc['_id'], decoder=DTDecoder)
         doc2.fetch()
 
-        self.assertEquals(doc2['dt'], doc['dt'])
+        self.assertEqual(doc2['dt'], doc['dt'])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/iam_auth_tests.py
+++ b/tests/unit/iam_auth_tests.py
@@ -88,12 +88,12 @@ class IAMAuthTests(unittest.TestCase):
 
     def test_iam_set_credentials(self):
         iam = IAMSession(MOCK_API_KEY, 'http://127.0.0.1:5984')
-        self.assertEquals(iam._api_key, MOCK_API_KEY)
+        self.assertEqual(iam._api_key, MOCK_API_KEY)
 
         new_api_key = 'some_new_api_key'
         iam.set_credentials(None, new_api_key)
 
-        self.assertEquals(iam._api_key, new_api_key)
+        self.assertEqual(iam._api_key, new_api_key)
 
     @mock.patch('cloudant._client_session.ClientSession.request')
     def test_iam_get_access_token(self, m_req):

--- a/tests/unit/index_tests.py
+++ b/tests/unit/index_tests.py
@@ -161,21 +161,21 @@ class IndexTests(UnitTestDbBase):
         with DesignDocument(self.db, index.design_document_id) as ddoc:
             self.assertIsInstance(ddoc.get_view(index.name), QueryIndexView)
 
-            self.assertEquals(ddoc['_id'], index.design_document_id)
+            self.assertEqual(ddoc['_id'], index.design_document_id)
             self.assertTrue(ddoc['_rev'].startswith('1-'))
 
-            self.assertEquals(ddoc['indexes'], {})
-            self.assertEquals(ddoc['language'], 'query')
-            self.assertEquals(ddoc['lists'], {})
-            self.assertEquals(ddoc['shows'], {})
+            self.assertEqual(ddoc['indexes'], {})
+            self.assertEqual(ddoc['language'], 'query')
+            self.assertEqual(ddoc['lists'], {})
+            self.assertEqual(ddoc['shows'], {})
 
             self.assertListEqual(list(ddoc['views'].keys()), ['index001'])
 
             view = ddoc['views'][index.name]
-            self.assertEquals(view['map']['fields']['age'], 'asc')
-            self.assertEquals(view['map']['fields']['name'], 'asc')
-            self.assertEquals(view['options']['def']['fields'], ['name', 'age'])
-            self.assertEquals(view['reduce'], '_count')
+            self.assertEqual(view['map']['fields']['age'], 'asc')
+            self.assertEqual(view['map']['fields']['name'], 'asc')
+            self.assertEqual(view['options']['def']['fields'], ['name', 'age'])
+            self.assertEqual(view['reduce'], '_count')
 
     def test_create_an_index_without_ddoc_index_name(self):
         """
@@ -189,21 +189,21 @@ class IndexTests(UnitTestDbBase):
         with DesignDocument(self.db, index.design_document_id) as ddoc:
             self.assertIsInstance(ddoc.get_view(index.name), QueryIndexView)
 
-            self.assertEquals(ddoc['_id'], index.design_document_id)
+            self.assertEqual(ddoc['_id'], index.design_document_id)
             self.assertTrue(ddoc['_rev'].startswith('1-'))
 
-            self.assertEquals(ddoc['indexes'], {})
-            self.assertEquals(ddoc['language'], 'query')
-            self.assertEquals(ddoc['lists'], {})
-            self.assertEquals(ddoc['shows'], {})
+            self.assertEqual(ddoc['indexes'], {})
+            self.assertEqual(ddoc['language'], 'query')
+            self.assertEqual(ddoc['lists'], {})
+            self.assertEqual(ddoc['shows'], {})
 
             self.assertListEqual(list(ddoc['views'].keys()), [index.name])
 
             view = ddoc['views'][index.name]
-            self.assertEquals(view['map']['fields']['age'], 'asc')
-            self.assertEquals(view['map']['fields']['name'], 'asc')
-            self.assertEquals(view['options']['def']['fields'], ['name', 'age'])
-            self.assertEquals(view['reduce'], '_count')
+            self.assertEqual(view['map']['fields']['age'], 'asc')
+            self.assertEqual(view['map']['fields']['name'], 'asc')
+            self.assertEqual(view['options']['def']['fields'], ['name', 'age'])
+            self.assertEqual(view['reduce'], '_count')
 
     def test_create_an_index_with_empty_ddoc_index_name(self):
         """
@@ -217,21 +217,21 @@ class IndexTests(UnitTestDbBase):
         with DesignDocument(self.db, index.design_document_id) as ddoc:
             self.assertIsInstance(ddoc.get_view(index.name), QueryIndexView)
 
-            self.assertEquals(ddoc['_id'], index.design_document_id)
+            self.assertEqual(ddoc['_id'], index.design_document_id)
             self.assertTrue(ddoc['_rev'].startswith('1-'))
 
-            self.assertEquals(ddoc['indexes'], {})
-            self.assertEquals(ddoc['language'], 'query')
-            self.assertEquals(ddoc['lists'], {})
-            self.assertEquals(ddoc['shows'], {})
+            self.assertEqual(ddoc['indexes'], {})
+            self.assertEqual(ddoc['language'], 'query')
+            self.assertEqual(ddoc['lists'], {})
+            self.assertEqual(ddoc['shows'], {})
 
             self.assertListEqual(list(ddoc['views'].keys()), [index.name])
 
             view = ddoc['views'][index.name]
-            self.assertEquals(view['map']['fields']['age'], 'asc')
-            self.assertEquals(view['map']['fields']['name'], 'asc')
-            self.assertEquals(view['options']['def']['fields'], ['name', 'age'])
-            self.assertEquals(view['reduce'], '_count')
+            self.assertEqual(view['map']['fields']['age'], 'asc')
+            self.assertEqual(view['map']['fields']['name'], 'asc')
+            self.assertEqual(view['options']['def']['fields'], ['name', 'age'])
+            self.assertEqual(view['reduce'], '_count')
 
     def test_create_an_index_using_design_prefix(self):
         """
@@ -245,21 +245,21 @@ class IndexTests(UnitTestDbBase):
         with DesignDocument(self.db, index.design_document_id) as ddoc:
             self.assertIsInstance(ddoc.get_view(index.name), QueryIndexView)
 
-            self.assertEquals(ddoc['_id'], index.design_document_id)
+            self.assertEqual(ddoc['_id'], index.design_document_id)
             self.assertTrue(ddoc['_rev'].startswith('1-'))
 
-            self.assertEquals(ddoc['indexes'], {})
-            self.assertEquals(ddoc['language'], 'query')
-            self.assertEquals(ddoc['lists'], {})
-            self.assertEquals(ddoc['shows'], {})
+            self.assertEqual(ddoc['indexes'], {})
+            self.assertEqual(ddoc['language'], 'query')
+            self.assertEqual(ddoc['lists'], {})
+            self.assertEqual(ddoc['shows'], {})
 
             self.assertListEqual(list(ddoc['views'].keys()), [index.name])
 
             view = ddoc['views'][index.name]
-            self.assertEquals(view['map']['fields']['age'], 'asc')
-            self.assertEquals(view['map']['fields']['name'], 'asc')
-            self.assertEquals(view['options']['def']['fields'], ['name', 'age'])
-            self.assertEquals(view['reduce'], '_count')
+            self.assertEqual(view['map']['fields']['age'], 'asc')
+            self.assertEqual(view['map']['fields']['name'], 'asc')
+            self.assertEqual(view['options']['def']['fields'], ['name', 'age'])
+            self.assertEqual(view['reduce'], '_count')
 
     def test_create_uses_custom_encoder(self):
         """
@@ -446,22 +446,22 @@ class TextIndexTests(UnitTestDbBase):
         self.assertEqual(index.design_document_id, '_design/ddoc001')
         self.assertEqual(index.name, 'index001')
         with DesignDocument(self.db, index.design_document_id) as ddoc:
-            self.assertEquals(ddoc['_id'], index.design_document_id)
+            self.assertEqual(ddoc['_id'], index.design_document_id)
             self.assertTrue(ddoc['_rev'].startswith('1-'))
 
-            self.assertEquals(ddoc['language'], 'query')
-            self.assertEquals(ddoc['lists'], {})
-            self.assertEquals(ddoc['shows'], {})
-            self.assertEquals(ddoc['views'], {})
+            self.assertEqual(ddoc['language'], 'query')
+            self.assertEqual(ddoc['lists'], {})
+            self.assertEqual(ddoc['shows'], {})
+            self.assertEqual(ddoc['views'], {})
 
             index = ddoc['indexes']['index001']
-            self.assertEquals(index['analyzer']['default'], 'keyword')
-            self.assertEquals(index['analyzer']['fields']['$default'], 'standard')
-            self.assertEquals(index['analyzer']['name'], 'perfield')
-            self.assertEquals(index['index']['default_analyzer'], 'keyword')
-            self.assertEquals(index['index']['default_field'], {})
-            self.assertEquals(index['index']['fields'], 'all_fields')
-            self.assertEquals(index['index']['selector'], {})
+            self.assertEqual(index['analyzer']['default'], 'keyword')
+            self.assertEqual(index['analyzer']['fields']['$default'], 'standard')
+            self.assertEqual(index['analyzer']['name'], 'perfield')
+            self.assertEqual(index['index']['default_analyzer'], 'keyword')
+            self.assertEqual(index['index']['default_field'], {})
+            self.assertEqual(index['index']['fields'], 'all_fields')
+            self.assertEqual(index['index']['selector'], {})
             self.assertTrue(index['index']['index_array_lengths'])
 
     def test_create_a_search_index_with_kwargs(self):
@@ -480,22 +480,22 @@ class TextIndexTests(UnitTestDbBase):
         self.assertEqual(index.design_document_id, '_design/ddoc001')
         self.assertEqual(index.name, 'index001')
         with DesignDocument(self.db, index.design_document_id) as ddoc:
-            self.assertEquals(ddoc['_id'], index.design_document_id)
+            self.assertEqual(ddoc['_id'], index.design_document_id)
             self.assertTrue(ddoc['_rev'].startswith('1-'))
 
-            self.assertEquals(ddoc['language'], 'query')
-            self.assertEquals(ddoc['lists'], {})
-            self.assertEquals(ddoc['shows'], {})
-            self.assertEquals(ddoc['views'], {})
+            self.assertEqual(ddoc['language'], 'query')
+            self.assertEqual(ddoc['lists'], {})
+            self.assertEqual(ddoc['shows'], {})
+            self.assertEqual(ddoc['views'], {})
 
             index = ddoc['indexes']['index001']
-            self.assertEquals(index['analyzer']['default'], 'keyword')
-            self.assertEquals(index['analyzer']['fields']['$default'], 'german')
-            self.assertEquals(index['analyzer']['name'], 'perfield')
-            self.assertEquals(index['index']['default_analyzer'], 'keyword')
-            self.assertEquals(index['index']['default_field']['analyzer'], 'german')
-            self.assertEquals(index['index']['fields'], [{'name': 'name', 'type': 'string'}, {'name': 'age', 'type': 'number'}])
-            self.assertEquals(index['index']['selector'], {})
+            self.assertEqual(index['analyzer']['default'], 'keyword')
+            self.assertEqual(index['analyzer']['fields']['$default'], 'german')
+            self.assertEqual(index['analyzer']['name'], 'perfield')
+            self.assertEqual(index['index']['default_analyzer'], 'keyword')
+            self.assertEqual(index['index']['default_field']['analyzer'], 'german')
+            self.assertEqual(index['index']['fields'], [{'name': 'name', 'type': 'string'}, {'name': 'age', 'type': 'number'}])
+            self.assertEqual(index['index']['selector'], {})
             self.assertTrue(index['index']['default_field']['enabled'])
             self.assertTrue(index['index']['index_array_lengths'])
 

--- a/tests/unit/replicator_mock_tests.py
+++ b/tests/unit/replicator_mock_tests.py
@@ -86,9 +86,9 @@ class ReplicatorDocumentValidationMockTests(unittest.TestCase):
         rep.create_replication(src, tgt, repl_id=self.repl_id)
 
         kcall = m_replicator.create_document.call_args_list
-        self.assertEquals(len(kcall), 1)
+        self.assertEqual(len(kcall), 1)
         args, kwargs = kcall[0]
-        self.assertEquals(len(args), 1)
+        self.assertEqual(len(args), 1)
 
         expected_doc = {
             '_id': self.repl_id,
@@ -118,9 +118,9 @@ class ReplicatorDocumentValidationMockTests(unittest.TestCase):
             src, tgt, repl_id=self.repl_id, user_ctx=self.user_ctx)
 
         kcall = m_replicator.create_document.call_args_list
-        self.assertEquals(len(kcall), 1)
+        self.assertEqual(len(kcall), 1)
         args, kwargs = kcall[0]
-        self.assertEquals(len(args), 1)
+        self.assertEqual(len(args), 1)
 
         expected_doc = {
             '_id': self.repl_id,
@@ -154,9 +154,9 @@ class ReplicatorDocumentValidationMockTests(unittest.TestCase):
             src, tgt, repl_id=self.repl_id, user_ctx=self.user_ctx)
 
         kcall = m_replicator.create_document.call_args_list
-        self.assertEquals(len(kcall), 1)
+        self.assertEqual(len(kcall), 1)
         args, kwargs = kcall[0]
-        self.assertEquals(len(args), 1)
+        self.assertEqual(len(args), 1)
 
         expected_doc = {
             '_id': self.repl_id,


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [ ] Added tests for code changes _or_ test/build only changes
- [ ] Updated the change log file (`CHANGES.md`) _or_ test/build only changes
- [ ] Completed the PR template below:

## Description

The deprecated aliases have been removed in Python 3.11 in https://github.com/python/cpython/pull/28268

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing


## Monitoring and Logging
- "No change"