### PR TITLE
[MIGRATION] Add note about authentication errors and server errors

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -22,7 +22,8 @@ content like using `raw_result=True` in `python-cloudant`.
 1. Error handling is not transferable from `python-cloudant` to `cloudant-python-sdk`. For more information go to the [Error handling section](https://cloud.ibm.com/apidocs/cloudant?code=python#error-handling) in our API docs.
 1. Custom HTTP client configurations in `python-cloudant` are not transferable to 
    `cloudant-python-sdk`. For more information go to the [Configuring the HTTP client section
-   (https://githubcom/IBM/ibm-cloud-sdk-common/#configuring-the-http-client) in the IBM Cloud SDK Common README.
+   (https://github.com/IBM/ibm-cloud-sdk-common/#configuring-the-http-client) in the IBM Cloud 
+   SDK Common README.
 1. Authentication errors turn out at the time of instantiation of a client, while errors
    with the server can be found during calling the first operation against it. We suggest to
    check server errors with [`getServerInformation`](https://cloud.ibm.com/apidocs/cloudant?

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -24,15 +24,17 @@ content like using `raw_result=True` in `python-cloudant`.
    `cloudant-python-sdk`. For more information go to the
    [Configuring the HTTP client section](https://github.com/IBM/ibm-cloud-sdk-common/#configuring-the-http-client)
    in the IBM Cloud SDK Common README.
-1. Authentication errors occur during service instantiation. For example, the code `service = 
-   CloudantV1.new_instance(service_name="EXAMPLE")` will fail with `ValueError: At least one of 
-   iam_profile_name or iam_profile_id must be specified.` if required environment variables 
+   
+### Troubleshooting
+1. Authentication errors occur during service instantiation. For example, the code `service =
+   CloudantV1.new_instance(service_name="EXAMPLE")` will fail with `ValueError: At least one of
+   iam_profile_name or iam_profile_id must be specified.` if required environment variables
    prefixed with `EXAMPLE` are not set.
 1. Server errors occur when running a request against the service. We suggest to
    check server errors with
    [`getServerInformation`](https://cloud.ibm.com/apidocs/cloudant?code=python#getserverinformation)
    which is the new alternative of `metadata()`.
-
+   
 ## Request mapping
 Here's a list of the top 5 most frequently used `python-cloudant` operations and the `cloudant-python-sdk` equivalent API operation documentation link:
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -21,6 +21,10 @@ content like using `raw_result=True` in `python-cloudant`.
    com/IBM/ibm-cloud-sdk-common/#automatic-retries) feature for failed requests.
 1. Error handling is not transferable from `python-cloudant` to `cloudant-python-sdk`. For more information go to the [Error handling section](https://cloud.ibm.com/apidocs/cloudant?code=python#error-handling) in our API docs.
 1. Custom HTTP client configurations in `python-cloudant` are not transferable to `python-java-sdk`. For more information go to the [Configuring the HTTP client section(https://githubcom/IBM/ibm-cloud-sdk-common/#configuring-the-http-client) in the IBM Cloud SDK Common README.
+1. Authentication errors turn out at the time of instantiation of a client, while errors
+   with the server can be found during calling the first operation against it. We suggest to
+   check server errors with [`getServerInformation`](https://cloud.ibm.com/apidocs/cloudant?
+   code=python#getserverinformation) which is the new alternative of `metadata()`.
 
 ## Request mapping
 Here's a list of the top 5 most frequently used `python-cloudant` operations and the `cloudant-python-sdk` equivalent API operation documentation link:

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -20,7 +20,9 @@ content like using `raw_result=True` in `python-cloudant`.
 1. Replay adapters are replaced by the [automatic retries](https://github.
    com/IBM/ibm-cloud-sdk-common/#automatic-retries) feature for failed requests.
 1. Error handling is not transferable from `python-cloudant` to `cloudant-python-sdk`. For more information go to the [Error handling section](https://cloud.ibm.com/apidocs/cloudant?code=python#error-handling) in our API docs.
-1. Custom HTTP client configurations in `python-cloudant` are not transferable to `python-java-sdk`. For more information go to the [Configuring the HTTP client section(https://githubcom/IBM/ibm-cloud-sdk-common/#configuring-the-http-client) in the IBM Cloud SDK Common README.
+1. Custom HTTP client configurations in `python-cloudant` are not transferable to 
+   `cloudant-python-sdk`. For more information go to the [Configuring the HTTP client section
+   (https://githubcom/IBM/ibm-cloud-sdk-common/#configuring-the-http-client) in the IBM Cloud SDK Common README.
 1. Authentication errors turn out at the time of instantiation of a client, while errors
    with the server can be found during calling the first operation against it. We suggest to
    check server errors with [`getServerInformation`](https://cloud.ibm.com/apidocs/cloudant?

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -21,13 +21,17 @@ content like using `raw_result=True` in `python-cloudant`.
    com/IBM/ibm-cloud-sdk-common/#automatic-retries) feature for failed requests.
 1. Error handling is not transferable from `python-cloudant` to `cloudant-python-sdk`. For more information go to the [Error handling section](https://cloud.ibm.com/apidocs/cloudant?code=python#error-handling) in our API docs.
 1. Custom HTTP client configurations in `python-cloudant` are not transferable to 
-   `cloudant-python-sdk`. For more information go to the [Configuring the HTTP client section
-   (https://github.com/IBM/ibm-cloud-sdk-common/#configuring-the-http-client) in the IBM Cloud 
-   SDK Common README.
-1. Authentication errors turn out at the time of instantiation of a client, while errors
-   with the server can be found during calling the first operation against it. We suggest to
-   check server errors with [`getServerInformation`](https://cloud.ibm.com/apidocs/cloudant?
-   code=python#getserverinformation) which is the new alternative of `metadata()`.
+   `cloudant-python-sdk`. For more information go to the
+   [Configuring the HTTP client section](https://github.com/IBM/ibm-cloud-sdk-common/#configuring-the-http-client)
+   in the IBM Cloud SDK Common README.
+1. Authentication errors occur during service instantiation. For example, the code `service = 
+   CloudantV1.new_instance(service_name="EXAMPLE")` will fail with `ValueError: At least one of 
+   iam_profile_name or iam_profile_id must be specified.` if required environment variables 
+   prefixed with `EXAMPLE` are not set.
+1. Server errors occur when running a request against the service. We suggest to
+   check server errors with
+   [`getServerInformation`](https://cloud.ibm.com/apidocs/cloudant?code=python#getserverinformation)
+   which is the new alternative of `metadata()`.
 
 ## Request mapping
 Here's a list of the top 5 most frequently used `python-cloudant` operations and the `cloudant-python-sdk` equivalent API operation documentation link:

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -20,7 +20,7 @@ content like using `raw_result=True` in `python-cloudant`.
 1. Replay adapters are replaced by the [automatic retries](https://github.
    com/IBM/ibm-cloud-sdk-common/#automatic-retries) feature for failed requests.
 1. Error handling is not transferable from `python-cloudant` to `cloudant-python-sdk`. For more information go to the [Error handling section](https://cloud.ibm.com/apidocs/cloudant?code=python#error-handling) in our API docs.
-1. Custom HTTP client configurations in `python-cloudant` are not transferable to 
+1. Custom HTTP client configurations in `python-cloudant` can be set differently in
    `cloudant-python-sdk`. For more information go to the
    [Configuring the HTTP client section](https://github.com/IBM/ibm-cloud-sdk-common/#configuring-the-http-client)
    in the IBM Cloud SDK Common README.


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [ ] Added tests for code changes _or_ test/build only changes
- [ ] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
There have been some questions regarding migration lately. This PR tries to address them.

## Approach

I clarified some of the questionable topics in this change:
* where users should check the server errors and the authentication errors

I also fixed a typo from python-java-sdk to cloudant-python-sdk

My IDE lately breaks the lines automatically, I have not figured out how I can turn it off yet, but I think this is a great feature, and it helps the reviewers to read the long lines more effectively, so I kept these modifications.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"


## Testing

- N/A

## Monitoring and Logging

- "No change"
